### PR TITLE
Fix appveyor build.

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -55,10 +55,10 @@ library
 
   -- other-extensions:
   build-depends:       Decimal >= 0.4.2 && < 0.5
-                     , aeson >= 0.11.3.0 && < 1.1
+                     , aeson >= 0.11.3.0 && < 1.3
                      , ansi-wl-pprint >= 0.6.7.3 && < 0.7
                      , attoparsec >= 0.13.0.2 && < 0.14
-                     , base >=4.9.0.0 && < 4.10
+                     , base >=4.9.0.0 && < 4.11
                      , base16-bytestring >=0.1.1.6 && < 0.2
                      , bound >= 2 && < 2.1
                      , bytestring >=0.10.8.1 && < 0.11
@@ -75,7 +75,7 @@ library
                      , lens-aeson >= 1.0.0.5 && < 1.1
                      , mtl >= 2.2.1 && < 2.3
                      , old-locale >= 1.0.0.7 && < 1.1
-                     , optparse-applicative >= 0.12.1.0 && < 0.14
+                     , optparse-applicative >= 0.12.1.0 && < 0.15
                      , parsers >= 0.12.4 && < 0.13
                      , safe >= 0.3.11 && < 0.4
                      , scientific >= 0.3.4.9 && < 0.4
@@ -85,11 +85,11 @@ library
                      -- kadena ghcjs compat fork
                      , thyme == 0.3.6.0
                      , transformers >= 0.5.2.0 && < 0.6
-                     , trifecta >= 1.6 && < 1.7
+                     , trifecta >= 1.6 && < 1.8
                      , unordered-containers >= 0.2.7.2 && < 0.3
                      , utf8-string >= 1.0.1.1 && < 1.1
-                     , vector >= 0.11.0.0 && < 0.12
-                     , vector-space >= 0.10.4 && < 0.11
+                     , vector >= 0.11.0.0 && < 0.13
+                     , vector-space >= 0.10.4 && < 0.14
                      , haskeline >= 0.7.4
   if !impl(ghcjs) && !os(windows)
     build-depends:   unix
@@ -97,10 +97,10 @@ library
   if !impl(ghcjs)
     build-depends:
                   async
-                , criterion >= 1.1.4.0 && < 1.2
+                , criterion >= 1.1.4.0 && < 1.4
                 , direct-sqlite
                 , safe-exceptions >= 0.1.5.0 && < 0.2
-                , statistics >= 0.13.3.0 && < 0.14
+                , statistics >= 0.13.3.0 && < 0.15
                 , snap-core
                 , snap-server
                 , ed25519-donna

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -37,7 +37,7 @@ import Data.Maybe
 #if !defined(ghcjs_HOST_OS)
 import Criterion
 import Criterion.Types
-import Statistics.Resampling.Bootstrap
+import Statistics.Types
 #endif
 import Pact.Typechecker
 import Pact.Types.Typecheck

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # stack yaml for ghc builds
 
-resolver: lts-8.15
+resolver: lts-10.6
 
 packages:
 - '.'


### PR DESCRIPTION
Our latest appveyor build failed with:

```
ghc-pkg.EXE: C:\sr\snapshots\141c7015\pkgdb\package.cache: you don't have
permission to modify this file
```

According to https://github.com/commercialhaskell/stack/issues/3492,
"The likely workaround is to switch to GHC 8.2.1", so this moves to
lts-10.6 (ghc 8.2.2).