### PR TITLE
Switch to token parsing.

### DIFF
--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -329,7 +329,7 @@ readMsg i as = argsError i as
 newtype ParsedDecimal = ParsedDecimal Decimal
 instance FromJSON ParsedDecimal where
   parseJSON (String s) =
-    ParsedDecimal <$> case AP.parseOnly number s of
+    ParsedDecimal <$> case AP.parseOnly (unPactParser number) s of
                         Right (LDecimal d) -> return d
                         Right (LInteger i) -> return (fromIntegral i)
                         _ -> fail $ "Failure parsing decimal string: " ++ show s
@@ -347,7 +347,7 @@ readDecimal i as = argsError i as
 newtype ParsedInteger = ParsedInteger Integer
 instance FromJSON ParsedInteger where
   parseJSON (String s) =
-    ParsedInteger <$> case AP.parseOnly number s of
+    ParsedInteger <$> case AP.parseOnly (unPactParser number) s of
                         Right (LInteger i) -> return i
                         _ -> fail $ "Failure parsing integer string: " ++ show s
   parseJSON (Number n) = return $ ParsedInteger (round n)

--- a/tests/ParserSpec.hs
+++ b/tests/ParserSpec.hs
@@ -11,3 +11,6 @@ loadBadParens :: Spec
 loadBadParens = do
   (r,_s) <- runIO $ execScript' Quiet "tests/pact/bad/bad-parens.repl"
   it "should fail due to extra close-parens" $ r `shouldSatisfy` isLeft
+
+  (r,_s) <- runIO $ execScript' Quiet "tests/pact/comments.repl"
+  it "should parse correctly" $ r `shouldSatisfy` isRight

--- a/tests/pact/comments.repl
+++ b/tests/pact/comments.repl
@@ -1,0 +1,20 @@
+(+ 1 2
+  ;
+  )
+
+(define-keyset 'k (sig-keyset))
+
+(module foo-mod 'k
+  "this defines foo"
+  (defun foo ()
+    "parses with semicolon"
+    1
+    ;
+    ;;
+    )
+  )
+
+(+ 1
+  ; This is fine
+  2
+  )


### PR DESCRIPTION
This change was motivated by issue #22. We were parsing on a
character-by-character level, but `parsers`'s `TokenParsing` can handle
comments automatically. So it should make our code not just more
correct, but also simpler (since we can remove `space` everywhere).

Performance was essentially unchanged. See https://gist.github.com/joelburget/7e5eb01415265572a21f7fd55d084579.

Fixes #22