### PR TITLE
Some cleanup from Weeder run and weeder config file

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -1,0 +1,20 @@
+- package:
+  - name: pact
+  - section:
+    - name: exe:pact
+    - message:
+      - name: Module not compiled
+      - module: Repl.hs 
+    - message:
+      - name: Redundant build-depends entry
+      - depends:
+        - base
+        - ghcjs-base
+        - pact
+  - section:
+    - name: library
+    - message:
+      - name: Redundant build-depends entry
+      - depends:
+        - hspec
+        - stm

--- a/pact.cabal
+++ b/pact.cabal
@@ -190,3 +190,12 @@ test-suite hspec
               , unordered-containers
               , ansi-wl-pprint
               , bytestring
+  other-modules:
+                Blake2Spec
+              , DocgenSpec
+              , KeysetSpec
+              , PactTestsSpec
+              , ParserSpec
+              , PersistSpec
+              , TypecheckSpec
+              , TypesSpec

--- a/tests/Blake2Spec.hs
+++ b/tests/Blake2Spec.hs
@@ -1,4 +1,4 @@
-module Blake2Spec where
+module Blake2Spec (spec) where
 
 import Test.Hspec
 import Crypto.Hash.Blake2Native

--- a/tests/KeysetSpec.hs
+++ b/tests/KeysetSpec.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module KeysetSpec where
+module KeysetSpec (spec) where
 
 import Test.Hspec
 

--- a/tests/ParserSpec.hs
+++ b/tests/ParserSpec.hs
@@ -1,4 +1,4 @@
-module ParserSpec where
+module ParserSpec (spec) where
 
 import Test.Hspec
 import Pact.Repl

--- a/tests/TypecheckSpec.hs
+++ b/tests/TypecheckSpec.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module TypecheckSpec where
+module TypecheckSpec (spec) where
 
 import Test.Hspec
 import Pact.Typechecker hiding (debug)

--- a/tests/TypesSpec.hs
+++ b/tests/TypesSpec.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module TypesSpec where
+module TypesSpec (spec) where
 
 
 import Test.Hspec


### PR DESCRIPTION
Some cleanup suggest by Weeder.  The Weeder config file suppresses some false positive warnings. Weeder can be run by hand until we add it to the Travis build:
one time: stack install weeder
then: weeder --build .

