### PR TITLE
Expose TableName in AST for analysis

### DIFF
--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -209,15 +209,15 @@ loadModule m bod1 mi = do
 
 resolveRef :: Name -> Eval e (Maybe Ref)
 resolveRef qn@(QName q n _) = do
-          dsm <- firstOf (eeRefStore.rsModules.ix q._2.ix n) <$> ask
-          case dsm of
-            d@Just {} -> return d
-            Nothing -> firstOf (evalRefs.rsLoaded.ix qn) <$> get
+  dsm <- asks $ firstOf $ eeRefStore.rsModules.ix q._2.ix n
+  case dsm of
+    d@Just {} -> return d
+    Nothing -> firstOf (evalRefs.rsLoaded.ix qn) <$> get
 resolveRef nn@(Name _ _) = do
-          nm <- firstOf (eeRefStore.rsNatives.ix nn) <$> ask
-          case nm of
-            d@Just {} -> return d
-            Nothing -> firstOf (evalRefs.rsLoaded.ix nn) <$> get
+  nm <- asks $ firstOf $ eeRefStore.rsNatives.ix nn
+  case nm of
+    d@Just {} -> return d
+    Nothing -> firstOf (evalRefs.rsLoaded.ix nn) <$> get
 
 
 unify :: HM.HashMap Text Ref -> Either Text Ref -> Ref

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -25,7 +25,7 @@ module Pact.Native
 import Control.Concurrent hiding (yield)
 import Control.Lens hiding (parts,Fold,contains)
 import Control.Monad
-import Control.Monad.Reader (ask)
+import Control.Monad.Reader (asks)
 import Control.Monad.Catch
 import Data.Default
 import qualified Data.Attoparsec.Text as AP
@@ -435,7 +435,7 @@ yield i as = argsError i as
 
 resume :: NativeFun e
 resume i [TBinding ps bd (BindSchema _) bi] = do
-  rm <- firstOf (eePactStep . _Just . psResume . _Just) <$> ask
+  rm <- asks $ firstOf $ eePactStep . _Just . psResume . _Just
   case rm of
     Nothing -> evalError' i "Resume: no yielded value in context"
     Just rval -> bindObjectLookup rval >>= bindReduce ps bd bi

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -697,7 +697,9 @@ toAST TLiteral {..} = trackPrim _tInfo (litToPrim _tLiteral) (PrimLit _tLiteral)
 toAST TTable {..} = do
   debug $ "TTable: " ++ show _tTableType
   ty <- TySchema TyTable <$> traverse toUserType _tTableType
-  Table <$> (trackNode ty =<< freshId _tInfo (asString _tModule <> "." <> asString _tTableName))
+  Table
+    <$> (trackNode ty =<< freshId _tInfo (asString _tModule <> "." <> asString _tTableName))
+    <*> pure _tTableName
 toAST TModule {..} = die _tInfo "Modules not supported"
 toAST TUse {..} = die _tInfo "Use not supported"
 toAST TStep {..} = do

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -34,7 +34,7 @@ module Pact.Types.Typecheck
     Fun (..),fInfo,fName,fTypes,fSpecial,fType,fArgs,fBody,fDocs,
     Node (..),aId,aTy,
     Named (..),
-    AST (..),aNode,aAppFun,aAppArgs,aBindings,aBody,aBindType,aList,aObject,aPrimValue,aEntity,aExec,aRollback,
+    AST (..),aNode,aAppFun,aAppArgs,aBindings,aBody,aBindType,aList,aObject,aPrimValue,aEntity,aExec,aRollback,aTableName,
     Visit(..),Visitor
   ) where
 
@@ -283,7 +283,8 @@ data AST n =
   _aNode :: n
   } |
   Table {
-  _aNode :: n
+  _aNode :: n,
+  _aTableName :: TableName
   } |
   Step {
   _aNode :: n,


### PR DESCRIPTION
This exposes the `TableName` in the `Table` `AST` constructor so pact-analyze can track DB access.