### PR TITLE
Name vars instead of fields in AST for bindings

### DIFF
--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -263,7 +263,7 @@ applySchemas Pre ast = case ast of
   (Binding _ bs _ (BindSchema n)) -> findSchema n $ \sch -> do
     debug $ "applySchemas: " ++ show (n,sch)
     pmap <- M.fromList <$> forM bs
-      (\(Named bn _ ni,v) -> (bn,) <$> ((v,ni,) <$> lookupTy (_aNode v)))
+      (\(Named _ node ni, Prim _ (PrimLit (LString bn))) -> (bn,) <$> ((Var node,ni,) <$> lookupTy node))
     validateSchema sch pmap
     return ast
   _ -> return ast
@@ -655,8 +655,6 @@ toAST TApp {..} = do
             WithDefaultRead -> specialBind
             _ -> mkApp fun' args'
 
-
-
 toAST TBinding {..} = do
   bi <- freshId _tInfo (pack $ show _tBindType)
   bn <- trackIdNode bi
@@ -670,11 +668,13 @@ toAST TBinding {..} = do
         assocAST aid v'
         return (Named n an aid,v')
       BindSchema _ -> do
-        fieldName <- asPrimString v'
-        return (Named fieldName an aid,Var an)
+        _fieldName <- asPrimString v'
+        return (Named n an aid,v')
   bb <- scopeToBody _tInfo (map ((\ai -> Var (_nnNamed ai)).fst) bs) _tBindBody
   bt <- case _tBindType of
-    BindLet -> assocAST bi (last bb) >> return BindLet
+    BindLet -> do
+      assocAST bi (last bb)
+      return BindLet
     BindSchema sty -> do
       assocAST bi (last bb)
       sty' <- mangleType bi <$> traverse toUserType sty


### PR DESCRIPTION
This is more consistent with `Named Node` usage generally, and translation for `let` forms.

For a form like `(with-read accounts to { "balance" := to-bal } to-bal)` in the `AST`, the `Named Node` for the binding is now something like `"bind*5_to-bal"` instead of `"balance"`, as it was previously.

This fixes #44.