### PR TITLE
fix weeder warning

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -195,6 +195,7 @@ test-suite hspec
                 Blake2Spec
               , DocgenSpec
               , KeysetSpec
+              , HlintSpec
               , PactTestsSpec
               , ParserSpec
               , PersistSpec


### PR DESCRIPTION
The weeder CI integration, like the hlint before it, is creaky, as it requires devs to remember to run weeder, with the official recommendation being equally unsatisfying as it expects developers to install frequently from nightly stack to match CI downloading the latest and greatest. Far better to have it run in tests, like we have for hlint, but -- weeder doesn't export a library. I've opened an issue for this on weeder (https://github.com/ndmitchell/weeder/issues/37) but for now we have to keep up with this manually. Thus this small fix.