### PR TITLE
Play with using TVar instead of MVar

### DIFF
--- a/src/Pact/Server/PactService.hs
+++ b/src/Pact/Server/PactService.hs
@@ -11,7 +11,21 @@
 -- Service to provide Pact interpreter and backend.
 --
 
-module Pact.Server.PactService where
+module Pact.Server.PactService
+  (
+    -- * Initialization
+    initPactService
+    -- * Commands 
+    , applyCmd
+    , applyExec
+    , applyContinuation    
+    -- * Serialization of result.
+    , jsonResult
+    -- * 'ExecutionMode' to 'Transactional'
+    , exToTx
+    , runPayload
+  )
+where
 
 import Prelude
 
@@ -20,7 +34,7 @@ import Control.Exception.Safe
 import Control.Monad.Except
 import Control.Monad.Reader
 import qualified Data.Set as S
-import Control.Lens (view)
+import Control.Lens
 
 import Data.Aeson as A
 
@@ -29,22 +43,25 @@ import Pact.Types.RPC
 import Pact.Types.Runtime hiding (PublicKey)
 import Pact.Types.Server
 import Pact.Types.Logger
-
 import Pact.Interpreter
 
-
+-- | Init pact service based on 'CommandConfig'.
 initPactService :: CommandConfig -> Loggers -> IO (CommandExecInterface (PactRPC ParsedCode))
-initPactService CommandConfig {..} loggers = do
+initPactService config loggers = do
   let logger = newLogger loggers "PactService"
       klog s = logLog logger "INIT" s
-      mkCEI p@PactDbEnv {..} = do
+      mkCEI p = do
         cmdVar <- newMVar (CommandState initRefStore)
         klog "Creating Pact Schema"
         initSchema p
         return CommandExecInterface
-          { _ceiApplyCmd = \eMode cmd -> applyCmd logger _ccEntity p cmdVar eMode cmd (verifyCommand cmd)
-          , _ceiApplyPPCmd = applyCmd logger _ccEntity p cmdVar }
-  case _ccSqlite of
+          { _ceiApplyCmd = \eMode cmd -> 
+                              applyCmd 
+                                logger 
+                                (config^.ccEntity) 
+                                p cmdVar eMode cmd (verifyCommand cmd)
+          , _ceiApplyPPCmd = applyCmd logger (config^.ccEntity) p cmdVar }
+  case (config^.ccSqlite) of
     Nothing -> do
       klog "Initializing pure pact"
       mkPureEnv loggers >>= mkCEI
@@ -52,9 +69,11 @@ initPactService CommandConfig {..} loggers = do
       klog "Initializing pact SQLLite"
       mkSQLiteEnv logger True sqlc loggers >>= mkCEI
 
-
-
-
+-- | Apply a command for an 'EntityName' using a DB. 
+-- | Synchronization alert. Clients will need to 
+-- | handle asynchronous exceptions to cleanup resources. 
+-- | For example, see here, for an example of canonical form
+-- | of calling this method.
 applyCmd :: Logger -> Maybe EntityName -> PactDbEnv p -> MVar CommandState -> ExecutionMode -> Command a ->
             ProcessedCommand (PactRPC ParsedCode) -> IO CommandResult
 applyCmd _ _ _ _ ex cmd (ProcFail s) = return $ jsonResult ex (cmdToRequestKey cmd) s
@@ -69,17 +88,21 @@ applyCmd logger conf dbv cv exMode _ (ProcSucc cmd) = do
       return $ jsonResult exMode (cmdToRequestKey cmd) $
                CommandError "Command execution failed" (Just $ show e)
 
+-- | Converts an 'ExecutionMode' to a 'RequestKey'
 jsonResult :: ToJSON a => ExecutionMode -> RequestKey -> a -> CommandResult
 jsonResult ex cmd a = CommandResult cmd (exToTx ex) (toJSON a)
 
+-- | Execution Mode to Tranasaction
 exToTx :: ExecutionMode -> Maybe TxId
 exToTx (Transactional t) = Just t
 exToTx Local = Nothing
 
+{-| Run the payload command 'Command'. 
+-}
 runPayload :: Command (Payload (PactRPC ParsedCode)) -> CommandM p CommandResult
 runPayload c@Command{..} = do
   let runRpc (Exec pm) = applyExec (cmdToRequestKey c) pm c
-      runRpc (Continuation ym) = applyContinuation ym _cmdSigs
+      runRpc (Continuation ym) = applyContinuation ym $ _cmdSigs
       Payload{..} = _cmdPayload
   case _pAddress of
     Just Address{..} -> do
@@ -87,22 +110,30 @@ runPayload c@Command{..} = do
       ent <- view ceEntity
       mode <- view ceMode
       case ent of
-        Just entName | entName == _aFrom || (entName `S.member` _aTo) -> runRpc _pPayload
-        _ -> return $ jsonResult mode (cmdToRequestKey c) $ CommandError "Private" Nothing
+        Just entName | entName == (_aFrom) || (entName `S.member` (_aTo)) -> 
+          runRpc _pPayload
+        _ -> 
+          return $ jsonResult mode (cmdToRequestKey c) $ CommandError "Private" Nothing
     Nothing -> runRpc _pPayload
 
 
-
+-- | Synchronize the read of the CommandState and evaluate the 
+-- | expression setting up the current environment and return, 
+-- | with some additional book-keeping.
 applyExec :: RequestKey -> ExecMsg ParsedCode -> Command a -> CommandM p CommandResult
 applyExec rk (ExecMsg parsedCode edata) Command{..} = do
-  CommandEnv {..} <- ask
+  env <- ask
   when (null (_pcExps parsedCode)) $ throwCmdEx "No expressions found"
-  (CommandState refStore) <- liftIO $ readMVar _ceState
-  let evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode
-                (MsgData (userSigsToPactKeySet _cmdSigs) edata Nothing _cmdHash) refStore
+  (CommandState refStore) <- liftIO $ readMVar $ env^.ceState
+  let evalEnv = setupEvalEnv (env^.ceDbEnv) (env^.ceEntity) (env^.ceMode)
+                (MsgData 
+                    (userSigsToPactKeySet (_cmdSigs)) 
+                    edata Nothing 
+                    (_cmdHash)) refStore
   pr <- liftIO $ evalExec evalEnv parsedCode
-  void $ liftIO $ swapMVar _ceState $ CommandState (erRefStore pr)
-  return $ jsonResult _ceMode rk $ CommandSuccess (last (erOutput pr))
+  void $ liftIO $ swapMVar (env^.ceState) $ CommandState (erRefStore pr)
+  return $ jsonResult (env^.ceMode) rk $ CommandSuccess (last (erOutput pr))
 
+-- | Unsupported function, raises an error. 
 applyContinuation :: ContMsg -> [UserSig] -> CommandM p CommandResult
 applyContinuation _ _ = throwCmdEx "Continuation not supported"

--- a/src/Pact/Server/PactService.hs
+++ b/src/Pact/Server/PactService.hs
@@ -101,7 +101,7 @@ exToTx Local = Nothing
 runPayload :: Command (Payload (PactRPC ParsedCode)) -> CommandM p CommandResult
 runPayload c@Command{..} = do
   let runRpc (Exec pm) = applyExec (cmdToRequestKey c) pm c
-      runRpc (Continuation ym) = applyContinuation ym $ _cmdSigs
+      runRpc (Continuation ym) = applyContinuation ym _cmdSigs
       Payload{..} = _cmdPayload
   case _pAddress of
     Just Address{..} -> do

--- a/src/Pact/Server/Server.hs
+++ b/src/Pact/Server/Server.hs
@@ -65,6 +65,7 @@ usage =
   \entity     - Entity name for simulating privacy, defaults to \"entity\" \n\
   \\n"
 
+-- | Serve the a file given a configuration.
 serve :: FilePath -> IO ()
 serve configFile = do
   Config {..} <- Y.decodeFileEither configFile >>= \case

--- a/src/Pact/Types/Server.hs
+++ b/src/Pact/Types/Server.hs
@@ -40,6 +40,7 @@ module Pact.Types.Server
 
 import Control.Applicative
 import Control.Concurrent.MVar
+import Control.Concurrent.STM
 import Control.Exception.Safe
 import Control.Lens
 import Control.Monad.Reader
@@ -84,7 +85,7 @@ data CommandEnv p = CommandEnv {
       _ceEntity :: Maybe EntityName
     , _ceMode :: ExecutionMode
     , _ceDbEnv :: PactDbEnv p
-    , _ceState :: MVar CommandState
+    , _ceState :: TVar CommandState
     }
 $(makeLenses ''CommandEnv)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -23,3 +23,4 @@ extra-deps:
 flags: {}
 
 extra-package-dbs: []
+system-ghc : false


### PR DESCRIPTION
@slpopejoy I was trying to play with changing an MVar to TVar,  and hopefully this pr does not create new issues. Is there a test suite that I should run to test for any bugs that this pr introduces. My goal was to try replacing ``` writeChan ``` with ``` writeTChan ``` and perhaps consider using ``` TBQueue ``` where applicable.
I also used the ``` ^. ``` while I was at it, though I am on the fence about this, because ``` view ``` is as expressive.
I was also trying to run ``` stack haddock ```: 
``` .stack/setup-exe-cache/x86_64-linux-nopie/Cabal-simple_mPHDZzAJ_1.24.2.0_ghc-8.0.2 --builddir=.stack-work/dist/x86_64-linux-nopie/Cabal-1.24.2.0 haddock --html --hoogle --html-location=../$pkg-$version/ --haddock-option=--hyperlinked-source
    Process exited with code: ExitFailure 1
```
Is there an option where missing documentation is not an error so I can browse documentation locally? 