### PR TITLE
Add time compatibility layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,12 +50,26 @@ matrix:
   # - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
   #   compiler: ": #GHC 7.8.4"
   #   addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  # - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #   compiler: ": #GHC 7.10.3"
-  #   addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  # - env: BUILD=cabal GHCVER=8.0.1 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #   compiler: ": #GHC 8.0.1"
-  #   addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.0.1 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7 FLAGS=-fthyme
+    compiler: ": #GHC 8.0.1"
+    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.0.1 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7 FLAGS=-f-thyme
+    compiler: ": #GHC 8.0.1"
+    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+
+  - env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.17 FLAGS=-fthyme
+    compiler: ": #GHC 8.2.2"
+    addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.17 FLAGS=-f-thyme
+    compiler: ": #GHC 8.2.2"
+    addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+
+  - env: BUILD=cabal GHCVER=8.4.2 CABALVER=2.2 HAPPYVER=1.19.5 ALEXVER=3.1.7 FLAGS=-fthyme
+    compiler: ": #GHC 8.4.2"
+    addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.4.2 CABALVER=2.2 HAPPYVER=1.19.5 ALEXVER=3.1.7 FLAGS=-f-thyme
+    compiler: ": #GHC 8.4.2"
+    addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
   # Build with the newest GHC and cabal-install. This is an accepted failure,
   # see below.
@@ -190,9 +204,9 @@ install:
       travis_retry cabal update
 
       # Get the list of packages from the stack.yaml file
-      PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
+      # PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
 
-      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $FLAGS
       ;;
   esac
   set +ex
@@ -207,7 +221,7 @@ script:
       stack exec -- bench +RTS -K1k
       ;;
     cabal)
-      cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $FLAGS
 
       ORIGDIR=$(pwd)
       for dir in $PACKAGES

--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -18,3 +18,6 @@
       - depends:
         - hspec
         - stm
+    - message:
+      - name: Module not compiled
+      - module: Pact.Types.TimeCompat.Time

--- a/pact.cabal
+++ b/pact.cabal
@@ -23,6 +23,16 @@ Flag server
   Description: Build pact dev server (only works in non-ghcjs builds)
   Default: True
 
+Flag thyme
+  Description: Use the thyme library
+  Default: True
+
+Flag thyme-master
+  Description:
+    Assume that the master branch of the thyme library is installed as version
+    0.3.5.5 in package database.
+  Default: False
+
 library
 
   exposed-modules:     Pact.Compile
@@ -83,7 +93,6 @@ library
                      , stm >= 2.4.4.1 && < 2.5
                      , text >= 1.2.2.1 && < 1.3
                      -- kadena ghcjs compat fork
-                     , thyme == 0.3.6.0
                      , transformers >= 0.5.2.0 && < 0.6
                      , trifecta >= 1.6 && < 1.8
                      , unordered-containers >= 0.2.7.2 && < 0.3
@@ -123,6 +132,7 @@ library
                   , Pact.Types.Crypto
                   , Pact.Types.RPC
                   , Pact.Types.SQLite
+                  , Pact.Types.Time
 
 
 
@@ -137,6 +147,27 @@ library
                   , Pact.Server.Server
                   , Pact.Types.Server
 
+  if impl(ghcjs) && os(darwin) && flag(thyme)
+    build-depends:
+        thyme >= 0.3.6.0
+
+  if flag(thyme-master)
+    cpp-options: -DTHYME_MASTER
+
+  if flag(thyme)
+    build-depends:
+          thyme >= 0.3.5.0
+        , time >= 1.5
+            -- Note that thyme already depends on time. So this
+            -- doesn't introduce a new dependency
+    other-modules:
+        Pact.Types.TimeCompat.Thyme
+    cpp-options: -DUSE_THYME
+  else
+    build-depends:
+        time >= 1.5
+    other-modules:
+        Pact.Types.TimeCompat.Time
 
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Pact/ApiReq.hs
+++ b/src/Pact/ApiReq.hs
@@ -36,7 +36,6 @@ import qualified Data.Yaml as Y
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.Text (Text,pack)
 import Data.Text.Encoding
-import Data.Thyme.Clock
 import qualified Data.Set as S
 
 import Crypto.Ed25519.Pure
@@ -47,6 +46,7 @@ import Pact.Types.Command
 import Pact.Types.RPC
 import Pact.Types.Runtime hiding (PublicKey)
 import Pact.Types.API
+import Pact.Types.Time
 
 
 data KeyPair = KeyPair {

--- a/src/Pact/Native/Time.hs
+++ b/src/Pact/Native/Time.hs
@@ -18,14 +18,13 @@ module Pact.Native.Time
 
 import Control.Monad
 import Prelude
-import Data.Thyme
 import Data.Decimal
-import System.Locale
 import Data.AffineSpace
 import Data.Semigroup
 
 import Pact.Types.Runtime
 import Pact.Native.Internal
+import Pact.Types.Time
 
 
 timedoc :: Text

--- a/src/Pact/Types/Lang.hs
+++ b/src/Pact/Types/Lang.hs
@@ -1,22 +1,22 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Module      :  Pact.Types.Lang
@@ -99,9 +99,7 @@ import qualified Data.ByteString.Lazy.UTF8 as BSL
 import Data.String
 import Data.Default
 import Data.Char
-import Data.Thyme
-import Data.Thyme.Format.Aeson ()
-import System.Locale
+import Pact.Types.Time
 import Data.Scientific
 import GHC.Generics
 import Data.Decimal

--- a/src/Pact/Types/Orphans.hs
+++ b/src/Pact/Types/Orphans.hs
@@ -13,8 +13,6 @@
 module Pact.Types.Orphans where
 
 import Data.Serialize
-import Data.Thyme
-import Data.Thyme.Internal.Micro
 import Data.Decimal
 import qualified Data.Aeson as A
 import Text.Trifecta.Combinators (DeltaParsing(..))
@@ -27,10 +25,6 @@ import qualified Data.Text as T
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import Data.Default
 import Control.DeepSeq
-
-instance Serialize Micro
-instance Serialize NominalDiffTime
-instance Serialize UTCTime
 
 instance (Serialize i) => Serialize (DecimalRaw i) where
     put (Decimal p i) = put p >> put i

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -80,9 +80,6 @@ import qualified Data.ByteString.Lazy.UTF8 as BSL
 import qualified Data.Set as S
 import Data.String
 import Data.Default
-import Data.Thyme
-import Data.Thyme.Format.Aeson ()
-import Data.Thyme.Time.Core
 import Data.Typeable
 import Data.Word
 import Control.Monad.Catch
@@ -97,6 +94,7 @@ import Data.Hashable
 import Pact.Types.Orphans ()
 import Pact.Types.Lang
 import Pact.Types.Util
+import Pact.Types.Time
 
 
 data StackFrame = StackFrame {
@@ -189,10 +187,12 @@ timeCodec = Codec enc dec
   where
     enc t = object [ day .= d,
                      micros .= encoder integerCodec (fromIntegral (toMicroseconds s)) ]
-      where (UTCTime (ModifiedJulianDay d) s) = unUTCTime t
+      where
+        (ModifiedJulianDay d) = t ^. _utctDay
+        s = t ^. _utctDayTime
     {-# INLINE enc #-}
     dec = withObject "UTCTime" $ \o ->
-      mkUTCTime <$> (ModifiedJulianDay <$> o .: day) <*>
+      utcTimeFromDaysAndDayTime <$> (ModifiedJulianDay <$> o .: day) <*>
       (fromMicroseconds . fromIntegral <$> (o .: micros >>= decoder integerCodec))
     {-# INLINE dec #-}
     day = "_P_timed"

--- a/src/Pact/Types/Time.hs
+++ b/src/Pact/Types/Time.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module: Pact.Types.Time
+-- Copyright: Copyright © 2018 Kadena LLC
+-- License:  BSD-style (see the file LICENSE)
+-- Maintainer:  Stuart Popejoy <stuart@kadena.io>
+--
+-- Time functions for use with pact
+--
+-- This module is a compatibility layer between the time
+-- functions used in the pact code base and supported
+-- third-party time libraries.
+--
+-- The main reason for the existence of this module is
+-- the lack of maintenance for the thyme library, the
+-- uncertainty of its future, and the lack of good
+-- alternatives. When this situation is resolved this
+-- module and the associated modules under
+-- @Pact.Types.TimeCompat@ should be removed.
+--
+-- For the time being the module shields the Pact code base
+-- from the ongoing (unversioned) churn of the different
+-- versions of thyme and guarantees stable behavior.
+--
+-- Currently the following libraries are supported:
+--
+-- [thyme ≥ 0.3.6.0]
+--     A fork from the thyme master branch that is available
+--     at https://github.com/kadena-io/thyme.
+--
+--     Directory supports all pact time functionality with an
+--     efficient implementation.
+--
+--     No third party or community support.
+--
+-- [thyme master]
+--    The master branch of the thyme library as of 2018-04-19.
+--
+--     Directoy supports all pact time functionality with an
+--     efficient implementation.
+--
+--     Doesn't support compilation with GHCJS on MacOSX.
+--
+--     There isn't an official package on Hackage for this version
+--     of the library. Therefore no stability is guaranteed.
+--
+--     It appears that the thyme library isn't actively supported
+--     or developed any more. So there may never be a new
+--     official version that would include the new features of this
+--     branch.
+--
+-- [thyme ≥ 0.3.5]
+--    The most recent released version of the thyme package on
+--    hackage as of 2018-04-19.
+--
+--    Requires some lifting to achieve compatibility.
+--
+--    More efficient implementation than the time library.
+--
+--     It appears that the thyme library isn't actively supported
+--     or developed any more. So this version may not receive
+--     any updates or bug fixes.
+--
+-- [time ≥ 1.5]
+--    The de facto standard time library for haskell.
+--
+--    Requires more heavy lifting to achieve compatibility than
+--    more recent versions (≥ 1.9) of the time library.
+--
+-- [time ≥ 1.9]
+--    The most recent version (as of 2018-04-19) of the defacto
+--    standard time librar for haskell.
+--
+--    Requires some straight forward lifting to achieve
+--    compatibility.
+--
+--    Less efficient implementation than the thyme library.
+--
+--    Most stable and best supported and maintained time library.
+--
+module Pact.Types.Time
+( module Implementation
+) where
+
+#ifdef USE_THYME
+import Pact.Types.TimeCompat.Thyme as Implementation
+#else
+import Pact.Types.TimeCompat.Time as Implementation
+#endif
+

--- a/src/Pact/Types/TimeCompat/Thyme.hs
+++ b/src/Pact/Types/TimeCompat/Thyme.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- |
+-- Module: Pact.Types.Time
+-- Copyright: Copyright © 2018 Kadena LLC
+-- License:  BSD-style (see the file LICENSE)
+-- Maintainer:  Stuart Popejoy <stuart@kadena.io>
+--
+-- The latest released version of the thyme library is 0.3.5.5 which was
+-- released 2014-11-27. Since then the master branch as diverged considerably
+-- and includes some breaking changes that are difficult to work around.
+-- Development and support of thyme has seems to have stalled since May 2016.
+--
+-- We support three different version of the thyme library:
+--
+-- [0.3.5.5]
+--     Latest official release on Hackage. Probably not supported with
+--     GHCJS.
+--
+-- [0.3.6]
+--     Unofficial fork of the thyme library at
+--     https://github.com/kadena-io/thyme. The fork is based of the
+--     source code of version 0.3.5.5 and adds support for compilation
+--     with GHCJS and add the format modifiers '%N' and '%v% from the
+--     master branch.
+--     Not available on Hackage.
+--
+-- [master as of 2018-04-19]
+--     Not supported with GHCJS. Not available on Hackage. Requires that
+--     the CPP macro @THYME_MASTER@ is defined.
+--
+-- Additional Notes:
+--
+-- *   Commit @aaa49dbcb98c0a1122b947c562ebe753ddebcca5@ in the thyme master branch
+--     changes the name of the @UTCView@ constructor from @UTCTime@ to @UTCView@.
+--     For this reason this module hides @UTCView@. Instead
+--     the accessors @utctDay@ and @utctDayTime should be used.
+--
+-- *   Commit @722eb63a773788812ccc5c8b5ace3109b2dcd8d7@ in the thyme master branch
+--     changes the type of mkUTCTime to
+--
+--     @
+--     mkUTCTime :: Year -> Month -> DayOfMonth -> Hour -> Minute -> Double -> UTCTime
+--     @
+--
+--     For this reason this module hides @mkUTCTime@. Instead the extensions
+--     function @utcTimeFromDaysAndDayTime@ should be used.
+--
+-- *   The type of TimeLocale changed in master. Versions based
+--     on 0.3.5.5 require TimeLocale from System.Locale which conflicts with the
+--     type defined in thyme master. (Data.Time (>= 1.5) defines it's own TimeLocale
+--     type.)
+--
+--     There is currently no way to distinguish between which type of TimeLocale is
+--     used when the version is 0.3.5.5 (which is also used by thyme-master).
+--     Therefor we require that @THYME_MASTER@ is defined when the master
+--     branch is used.
+--
+module Pact.Types.TimeCompat.Thyme
+( module Exported
+
+#ifndef THYME_MASTER
+, TimeLocale
+, defaultTimeLocale
+#endif
+
+-- * Ported Implementations
+, parseTime
+, formatTime
+
+-- * Extensions
+, utcTimeFromDaysAndDayTime
+) where
+
+-- -------------------------------------------------------------------------- --
+-- Imports
+
+#if !MIN_VERSION_base(4,11,0) && !MIN_VERSION_thyme(0,3,6) && !defined(THYME_MASTER)
+import Data.Semigroup ((<>))
+#endif
+import Data.Serialize
+import qualified Data.Time as Time (UTCTime(..))
+import Data.Thyme hiding (parseTime, formatTime)
+import qualified Data.Thyme as Internal (parseTime, formatTime)
+import Data.Thyme.Format.Aeson ()
+import Data.Thyme.Internal.Micro
+
+-- A symbol is exported from a module export only it it is in scope qualified
+-- /and/ unqualified.
+--
+import Data.Thyme.Time hiding (parseTime, formatTime)
+import qualified Data.Thyme.Time as Exported hiding (UTCView(..), mkUTCTime, unUTCTime)
+
+#ifndef THYME_MASTER
+-- required for 0.3.5.5 and thyme-kadena
+import System.Locale
+#endif
+
+-- -------------------------------------------------------------------------- --
+-- Orphans
+
+instance Serialize Micro
+instance Serialize NominalDiffTime
+instance Serialize UTCTime
+
+-- -------------------------------------------------------------------------- --
+-- Ported Implementations
+
+parseTime :: ParseTime t => TimeLocale -> String -> String -> Maybe t
+formatTime :: FormatTime t => TimeLocale -> String -> t -> String
+
+#if MIN_VERSION_thyme(0,3,6) || defined(THYME_MASTER)
+
+parseTime = Internal.parseTime
+formatTime = Internal.formatTime
+{-# INLINE parseTime #-}
+{-# INLINE formatTime #-}
+
+#else /* thyme 0.3.5 */
+
+parseTime locale formatStr = Internal.parseTime locale (mapFormat formatStr)
+  where
+    mapFormat ('%':'%':t) = "%%" <> mapFormat t
+    mapFormat ('.':'%':'v':t) = "%Q" <> mapFormat t
+    mapFormat ('%':'N':t) = "%z" <> mapFormat t
+    mapFormat [] = []
+    mapFormat (h:t) = h : mapFormat t
+
+formatTime locale formatStr timeValue = concat . snd $ go0 formatStr
+  where
+    format f = Internal.formatTime locale f timeValue
+    n = let (h,m) = splitAt 3 $ format "%z" in h <> ":" <> m
+    v = take 6 $ format "%q"
+
+    go0 s = let (a, b) = go1 s in ("", format a : b)
+
+    go1 ('%':'%':t) = let (a, b) = go1 t in ("", "%" : format a : b)
+    go1 ('%':'v':t) = let (a, b) = go1 t in ("", v : format a : b)
+    go1 ('%':'N':t) = let (a, b) = go1 t in ("", n : format a : b)
+    go1 (h:t) = let (a, b) = go1 t in (h:a, b)
+    go1 "" = ("", [])
+
+#endif /* MIN_VERSION_thyme(0,3,6) */
+
+-- -------------------------------------------------------------------------- --
+-- Extensions
+
+utcTimeFromDaysAndDayTime :: Day -> DiffTime -> UTCTime
+utcTimeFromDaysAndDayTime d s = toThyme $ Time.UTCTime (fromThyme d) (fromThyme s)
+{-# INLINE utcTimeFromDaysAndDayTime #-}
+
+{-# ANN module "HLint: ignore Unnecessary hiding" #-}
+

--- a/src/Pact/Types/TimeCompat/Time.hs
+++ b/src/Pact/Types/TimeCompat/Time.hs
@@ -1,0 +1,167 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- |
+-- Module: Pact.Types.Time
+-- Copyright: Copyright © 2018 Kadena LLC
+-- License:  BSD-style (see the file LICENSE)
+-- Maintainer:  Stuart Popejoy <stuart@kadena.io>
+--
+module Pact.Types.TimeCompat.Time
+( module Exported
+
+-- * Ported Implementations
+, parseTime
+, formatTime
+
+-- * Extensions
+, _utctDay
+, _utctDayTime
+, utcTimeFromDaysAndDayTime
+, toSeconds
+, fromSeconds
+, toMicroseconds
+, fromMicroseconds
+) where
+
+-- -------------------------------------------------------------------------- --
+-- Imports
+
+import Control.Lens
+import Data.AdditiveGroup
+import Data.AffineSpace
+import Data.Decimal
+import Data.Fixed (Fixed(..), Pico)
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
+#if !MIN_VERSION_time(1,9,0)
+import Data.Serialize
+#endif
+
+-- A symbol is exported from a module export only it it is in scope qualified
+-- /and/ unqualified.
+import Data.Time hiding (parseTime, formatTime)
+import qualified Data.Time as Exported
+
+import qualified Data.Time as Internal (formatTime)
+
+import GHC.Generics
+import GHC.Int (Int64)
+
+-- -------------------------------------------------------------------------- --
+-- Orphans
+
+deriving instance Generic Pico
+deriving instance Generic Day
+deriving instance Generic UTCTime
+
+instance AdditiveGroup NominalDiffTime where
+    zeroV = 0
+    (^+^) = (+)
+    negateV v = -v
+    (^-^) = (-)
+    {-# INLINE zeroV #-}
+    {-# INLINE (^+^) #-}
+    {-# INLINE negateV #-}
+    {-# INLINE (^-^) #-}
+
+instance AffineSpace UTCTime where
+    type Diff UTCTime = NominalDiffTime
+    (.-.) = diffUTCTime
+    (.+^) = flip addUTCTime
+    {-# INLINE (.-.) #-}
+    {-# INLINE (.+^) #-}
+
+instance Serialize DiffTime where
+    put = put . diffTimeToPicoseconds
+    get = picosecondsToDiffTime <$> get
+    {-# INLINE put #-}
+    {-# INLINE get #-}
+
+instance Serialize NominalDiffTime where
+    put = put . (realToFrac :: NominalDiffTime -> Pico)
+    get = (realToFrac :: Pico -> NominalDiffTime) <$> get
+    {-# INLINE put #-}
+    {-# INLINE get #-}
+
+instance Serialize Pico
+instance Serialize Day
+instance Serialize UTCTime
+
+-- -------------------------------------------------------------------------- --
+-- Ported Implementations
+
+parseTime :: Monad m => TimeLocale -> String -> String -> m UTCTime
+parseTime locale formatStr = parseTimeM False locale (mapFormat formatStr)
+    where
+    mapFormat ('%':'%':t) = "%%" <> mapFormat t
+    mapFormat ('.':'%':'v':t) = "%Q" <> mapFormat t
+    mapFormat ('%':'N':t) = "%z" <> mapFormat t
+    mapFormat [] = []
+    mapFormat (h:t) = h : mapFormat t
+
+formatTime :: TimeLocale -> String -> UTCTime -> String
+
+#if MIN_VERSION_time(1,9,0)
+formatTime local formatStr = Internal.formatTime locale (mapFormat formatStr)
+  where
+    mapFormat ('%':'%':t) = "%%" <> mapFormat t
+    mapFormat ('%':'v':t) = "%6q" <> mapFormat t
+    mapFormat ('%':'N':t) = "%Ez" <> mapFormat t
+    mapFormat [] = []
+    mapFormat (h:t) = h : mapFormat t
+
+#else /* time ≥ 1.5 < 1.9 */
+
+formatTime locale formatStr timeValue = concat . snd $ go0 formatStr
+  where
+    format f = Internal.formatTime locale f timeValue
+    n = let (h,m) = splitAt 3 $ format "%z" in h <> ":" <> m
+    v = format "%6q"
+
+    go0 s = let (a, b) = go1 s in ("", format a : b)
+
+    go1 ('%':'%':t) = let (a, b) = go1 t in ("", "%" : format a : b)
+    go1 ('%':'v':t) = let (a, b) = go1 t in ("", v : format a : b)
+    go1 ('%':'N':t) = let (a, b) = go1 t in ("", n : format a : b)
+    go1 (h:t) = let (a, b) = go1 t in (h:a, b)
+    go1 "" = ("", [])
+
+#endif /* MIN_VERSION_time(1,9,0) */
+
+-- -------------------------------------------------------------------------- --
+-- Extensions
+
+toSeconds :: NominalDiffTime -> Decimal
+toSeconds = realToFrac
+{-# INLINE toSeconds #-}
+
+fromSeconds :: Decimal -> NominalDiffTime
+fromSeconds = realToFrac
+{-# INLINE fromSeconds #-}
+
+toMicroseconds :: DiffTime -> Int64
+toMicroseconds dt = round (realToFrac dt * 1000000 :: Pico)
+{-# INLINE toMicroseconds #-}
+
+fromMicroseconds :: Int64 -> DiffTime
+fromMicroseconds ms = realToFrac ((fromIntegral ms :: Pico) / 1000000)
+{-# INLINE fromMicroseconds #-}
+
+_utctDay :: Lens' UTCTime Day
+_utctDay = lens utctDay (\t d -> t { utctDay = d })
+
+_utctDayTime :: Lens' UTCTime DiffTime
+_utctDayTime = lens utctDayTime (\t d -> t { utctDayTime = d })
+
+utcTimeFromDaysAndDayTime :: Day -> DiffTime -> UTCTime
+utcTimeFromDaysAndDayTime = UTCTime
+{-# INLINE utcTimeFromDaysAndDayTime #-}
+


### PR DESCRIPTION
This PR adds support for the following time libraries:

* time >= 1.5 with cabal builds and cabal flag `-f-thyme,
* thyme-0.3.5.5 (latest version on Hackage) with cabal flag `-fthyme` (enabled by default),
* thyme master branch with cabal flag `-fthyme-master`, and
* thyme-0.3.6 (fork at kadena-io/thyme) with stack and cabal flag `-fthyme` (enabled by default).

I think, these are too many options and we should narrow the number of supported packages and versions. This PR makes it easy to add or remove support for a time package.

Thyme:

It seems that the thyme package isn't actively developed or maintained any more. The latest released version on Hackage is about four years old. Development on Github stalled about two years ago. The master branch has diverged both from the released version as well as from recent versions of the time package. I emailed the maintainer of the package about two weeks ago and asked him about his plans for the future of thyme, but haven't gotten a response yet.

Currently with use a private fork of thyme that introduces version 0.3.6. To avoid conflicts with possible future versions of thyme, I think, we should either (a) move to the latest released version of thyme, (b) use the thyme master branch, or (c) rename the package of the thyme fork, for instance, into thyme-kadena.

Time:

The time package is the default time library in the Haskell eco-system and it's actively developed. The functionality seems sufficient. The interface isn't the most modern but it's usable and stable. The main drawback is performance related to the internal representation of `UTCTime`, but I think that in most cases that isn't a bottleneck. I propose that we include support of time.
