### PR TITLE
Implement metaprogramming support

### DIFF
--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -1040,6 +1040,34 @@ Tables and objects can only take a schema type literal.
 Special forms {#special-forms}
 ---
 
+### Docs and metadata
+Many special forms like [defun](#defun) accept optional documentation strings,
+in the following form:
+
+```lisp
+(defun foo (bar)
+  "Do the thing with BAR"
+  ...)
+```
+
+However, in this position an optional _metadata section_ can specify docs and
+metadata, where metadata can be tagged with any key desired.
+The following code provides a docstring of "does the thing with BAR" and specifies metadata of type
+`property` and `example`:
+
+```lisp
+(defun foo (bar)
+  ("does the thing with BAR"
+    (property [(when something abort)])
+    (example (foo "my house")))
+  ...)
+```
+
+Thus, the metadata form is DOC [PAIR [PAIR [...]]], where a PAIR is (ATOM EXPR). The Pact
+language lexer/compiler ignores all EXPR forms, to be lexed/compiled at some later stage
+by whatever tool recognizes ATOM.
+
+
 ### bless {#bless}
 ```
 (bless HASH)
@@ -1060,10 +1088,10 @@ See [Dependency managment](#dependency-management) for a discussion of the bless
 ### defun {#defun}
 
 ```lisp
-(defun NAME ARGLIST [DOCSTRING] BODY...)
+(defun NAME ARGLIST [DOC-OR-META] BODY...)
 ```
 
-Define NAME as a function, accepting ARGLIST arguments, with optional DOCSTRING.
+Define NAME as a function, accepting ARGLIST arguments, with optional DOC-OR-META.
 Arguments are in scope for BODY, one or more expressions.
 
 ```lisp
@@ -1075,10 +1103,10 @@ Arguments are in scope for BODY, one or more expressions.
 
 ### defconst {#defconst}
 ```lisp
-(defun NAME VALUE [DOCSTRING])
+(defun NAME VALUE [DOC-OR-META])
 ```
 
-Define NAME as VALUE, with option DOCSTRING. Value is evaluated upon module load and "memoized".
+Define NAME as VALUE, with option DOC-OR-META. Value is evaluated upon module load and "memoized".
 
 ```lisp
 (defconst COLOR_RED="#FF0000" "Red in hex")
@@ -1089,7 +1117,7 @@ Define NAME as VALUE, with option DOCSTRING. Value is evaluated upon module load
 ### defpact {#defpact}
 
 ```
-(defpact NAME ARGLIST [DOCSTRING] STEPS...)
+(defpact NAME ARGLIST [DOC-OR-META] STEPS...)
 ```
 
 Define NAME as a _pact_, a multistep computation intended for private transactions.
@@ -1111,7 +1139,7 @@ or "private" (with entity indicator). With private steps, failures result in a r
 ### defschema {#defschema}
 
 ```
-(defschema NAME [DOCSTRING] FIELDS...)
+(defschema NAME [DOC-OR-META] FIELDS...)
 ```
 
 Define NAME as a _schema_, which specifies a list of FIELDS. Each field
@@ -1129,7 +1157,7 @@ is in the form `FIELDNAME[:FIELDTYPE]`.
 ### deftable {#deftable}
 
 ```
-(deftable NAME[:SCHEMA] [DOCSTRING])
+(deftable NAME[:SCHEMA] [DOC-OR-META])
 ```
 
 Define NAME as a _table_, used in database functions. Note the
@@ -1211,10 +1239,10 @@ hash of a loaded module on the chain.
 
 ### module {#module}
 ```
-(module NAME KEYSET [DOCSTRING] DEFS...)
+(module NAME KEYSET [DOC-OR-META] DEFS...)
 ```
 
-Define and install module NAME, guarded by keyset KEYSET, with optional DOCSTRING.
+Define and install module NAME, guarded by keyset KEYSET, with optional DOC-OR-META.
 DEFS must be [defun](#defun) or [defpact](#defpact) expressions only.
 
 ```lisp

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -1063,7 +1063,7 @@ The following code provides a docstring of "does the thing with BAR" and specifi
   ...)
 ```
 
-Thus, the metadata form is DOC [PAIR [PAIR [...]]], where a PAIR is (ATOM EXPR). The Pact
+Thus, the metadata form is DOC PAIR*, where a PAIR is (ATOM EXPR). The Pact
 language lexer/compiler ignores all EXPR forms, to be lexed/compiled at some later stage
 by whatever tool recognizes ATOM.
 

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -604,7 +604,7 @@ toFun TDef {..} = do -- TODO currently creating new vars every time, is this ide
     Named n <$> trackNode t' an <*> pure an
   tcs <- scopeToBody _tInfo (map (\ai -> Var (_nnNamed ai)) args) _tDefBody
   ft' <- traverse toUserType _tFunType
-  return $ FDefun _tInfo fn ft' args tcs _tDocs
+  return $ FDefun _tInfo fn ft' args tcs _tMeta
 toFun t = die (_tInfo t) "Non-var in fun position"
 
 

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -31,7 +31,7 @@ module Pact.Types.Typecheck
     PrimValue (..),
     TopLevel (..),tlFun,tlInfo,tlName,tlType,tlConstVal,tlUserType,
     Special (..),
-    Fun (..),fInfo,fName,fTypes,fSpecial,fType,fArgs,fBody,fDocs,
+    Fun (..),fInfo,fName,fTypes,fSpecial,fType,fArgs,fBody,fMeta,
     Node (..),aId,aTy,
     Named (..),
     AST (..),aNode,aAppFun,aAppArgs,aBindings,aBody,aBindType,aList,aObject,aPrimValue,aEntity,aExec,aRollback,aTableName,
@@ -214,7 +214,7 @@ data Fun t =
     _fType :: FunType UserType,
     _fArgs :: [Named t],
     _fBody :: [AST t],
-    _fDocs :: Maybe Text
+    _fMeta :: Maybe Meta
     }
   deriving (Eq,Functor,Foldable,Traversable,Show)
 

--- a/tests/pact/meta.repl
+++ b/tests/pact/meta.repl
@@ -1,0 +1,18 @@
+(define-keyset 'k (sig-keyset))
+
+(module mod 'k
+  ("this defines mod"
+   (property (do (crazy stuff))))
+
+  (defun foo ()
+    ("foo the town"
+     (example (foo)))
+    1)
+
+  (defconst BAR 1 ("barring disbelief" (anything 1)))
+
+  (defschema schema
+    ("a schema" (property stuff)))
+
+  (deftable tbl ("a table" (baz quux)))
+)


### PR DESCRIPTION
Related to discussion in https://github.com/kadena-io/pact-analyze/issues/3, add support for metaprogramming/metadata with a new form that can be used in the place of the docstring.