### PR TITLE
Add object unification typechecker cases

### DIFF
--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -525,6 +525,8 @@ unifyTypes l r = case (l,r) of
   (s,TyVar v) -> unifyVar Right Left v s
   (TyList a,TyList b) -> unifyParam a b
   (TySchema sa a,TySchema sb b) | sa == sb -> unifyParam a b
+  (TySchema _ a,b@(TyUser _)) -> unifyParam a b
+  (a@(TyUser _),TySchema _ b) -> unifyParam a b
   _ -> Nothing
   where
     unifyParam a b = fmap (either (const (Left l)) (const (Right r))) (unifyTypes a b)

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -115,6 +115,17 @@
   (defun fails-return-type:bool (x:integer)
     (if (< x 10) 10 x))
 
+  (defschema token-row
+    name:string
+    balance:integer)
+
+  (defun tc-obj-let:{token-row} ()
+    (let ((stu:object{token-row} {"balance": 5, "name": "stu"}))
+      stu))
+
+  (defun tc-obj-return:{token-row} ()
+    {"balance": 5, "name": "stu"})
+
   )
 
 (create-table persons)


### PR DESCRIPTION
Fixes #75. /cc @slpopejoy 

In the first (`tc-obj-let`) test case, we have `TyUser` on one hand and `TySchema` wrapping `TyUser` on the other.

In the second (`tc-obj-return`) use case, we have `TyUser` vs `TySchema` wrapping `TyAny`.