### PR TITLE
Add cell delta support

### DIFF
--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -139,10 +139,8 @@ checkFunctionBody tables (Just check) body argTys nodeNames =
       checkResult <- runCheck check $ do
         let tables' = tables & traverse %~ (\(a, b, _c) -> (a, b))
         aEnv <- mkAnalyzeEnv argTys tables
-        state0
-          <- mkInitialAnalyzeState tables' <$> allocateSymbolicCells tables'
-
-        let prop = check ^. ckProp
+        let state0 = mkInitialAnalyzeState tables'
+            prop = check ^. ckProp
 
             go :: Analyze AVal -> Symbolic (S Bool)
             go act = do
@@ -183,10 +181,9 @@ checkFunctionBody tables Nothing body argTys nodeNames =
       checkResult <- runProvable $ do
         let tables' = tables & traverse %~ (\(a, b, _c) -> (a, b))
         aEnv <- mkAnalyzeEnv argTys tables
-        state0
-          <- mkInitialAnalyzeState tables' <$> allocateSymbolicCells tables'
+        let state0 = mkInitialAnalyzeState tables'
 
-        let go :: Analyze AVal -> Symbolic (S Bool)
+            go :: Analyze AVal -> Symbolic (S Bool)
             go act = do
               let eAnalysis = runIdentity $ runExceptT $ runRWST (runAnalyze act) aEnv state0
               case eAnalysis of

--- a/src/Pact/Analyze/Types.hs
+++ b/src/Pact/Analyze/Types.hs
@@ -398,8 +398,12 @@ data Prop a where
   TableRead        :: TableName  ->                Prop Bool    -- anything in table is read
   ColumnWrite      :: TableName  -> ColumnName  -> Prop Bool    -- particular column is written
   CellIncrease     :: TableName  -> ColumnName  -> Prop Bool    -- any cell at all in col increases
-  IntColumnDelta   :: TableName  -> ColumnName  -> Prop Integer -- sum of all changes in int col
-  DecColumnDelta   :: TableName  -> ColumnName  -> Prop Decimal -- sum of all changes in dec col
+
+  IntCellDelta     :: TableName  -> ColumnName  -> Prop RowKey -> Prop Integer
+  DecCellDelta     :: TableName  -> ColumnName  -> Prop RowKey -> Prop Decimal
+  IntColumnDelta   :: TableName  -> ColumnName                 -> Prop Integer
+  DecColumnDelta   :: TableName  -> ColumnName                 -> Prop Decimal
+
   RowRead          :: TableName  -> Prop RowKey -> Prop Bool
   RowWrite         :: TableName  -> Prop RowKey -> Prop Bool
   --


### PR DESCRIPTION
Just paired on this with Joel.

This switches from our previous `SArray` encoding for cells to a combination of `uninterpret`+`SFunArray` per [Levent's suggestion](https://github.com/LeventErkok/sbv/issues/378).

@slpopejoy @buckie we now support the feature that we mentioned needing during the live-coding in the presentation on Monday:

```lisp
(forall (k:string)
  (when (and (!= k to) (!= k from)))
    (= (int-cell-delta 'accounts 'balance k) 0))
```

Which proves that in a balance transfer function, only the sender and the recipient will see balance changes.