### PR TITLE
Remove hlint and weeder from build

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -198,21 +198,17 @@ test-suite hspec
               , unordered-containers
               , ansi-wl-pprint
               , bytestring
-              , hlint >= 2.0
               , mtl
               , text
               , sbv
               , neat-interpolation
-              , weeder >= 1.0.5
   other-modules:
                 AnalyzeSpec
               , Blake2Spec
               , DocgenSpec
               , KeysetSpec
-              , HlintSpec
               , PactTestsSpec
               , ParserSpec
               , PersistSpec
               , TypecheckSpec
               , TypesSpec
-              , WeederSpec

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,14 +22,6 @@ extra-deps:
   - ed25519-donna-0.1.1
   - hashable-1.2.6.1
   - containers-0.5.8.2
-  - hlint-2.1.5
-  - extra-1.6.6
-  - aeson-1.1.2.0
-  - haskell-src-exts-1.20.2
-  - haskell-src-exts-util-0.2.3
-  - weeder-1.0.5
-  - foundation-0.0.20
-  - basement-0.0.7
 
 flags: {}
 

--- a/tests/HlintSpec.hs
+++ b/tests/HlintSpec.hs
@@ -1,9 +1,0 @@
-module HlintSpec where
-
-import Test.Hspec
-import Language.Haskell.HLint3
-
-spec :: Spec
-spec = do
-  ws <- runIO $ hlint ["."]
-  it "No hlint warnings" $ ws `shouldBe` []

--- a/tests/WeederSpec.hs
+++ b/tests/WeederSpec.hs
@@ -1,9 +1,0 @@
-module WeederSpec where
-
-import Test.Hspec
-import Weeder
-
-spec :: Spec
-spec = do
-  ws <- runIO $ weeder ["."]
-  it "No weeder warnings" $ ws `shouldBe` 0


### PR DESCRIPTION
With the recent addition of pact-analyze deps, the build has gotten too memory intensive which is most likely due to haskell-src-exts and other consequences of adding hlint and weeder to the test build deps. This removes those deps. We can revisit whether to incorporate hlint and weeder into our builds but for now this PR restores Pact to not depending on them in the build.

If the build still does not succeed then this PR may be unnecessary. However the dep shave is quite desirable in its own right.