### PR TITLE
Add format, format-time, parse-time, hash.

### DIFF
--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -89,6 +89,24 @@ pattern AST_EnforceKeyset :: forall a. AST a -> AST a
 pattern AST_EnforceKeyset ks <-
   App _node (NativeFunc "enforce-keyset") [ks] -- can be string or object
 
+pattern AST_Format :: forall a. AST a -> [AST a] -> AST a
+pattern AST_Format str vars <-
+  App _node (NativeFunc "format") [str, List _ vars]
+
+pattern AST_FormatTime :: forall a. AST a -> AST a -> AST a
+pattern AST_FormatTime str time <-
+  App _node (NativeFunc "format-time") [str, time]
+
+pattern AST_Time :: forall a. AST a -> AST a
+pattern AST_Time timeStr <- App _node (NativeFunc "time") [timeStr]
+
+pattern AST_ParseTime :: forall a. AST a -> AST a -> AST a
+pattern AST_ParseTime formatStr timeStr <-
+  App _node (NativeFunc "parse-time") [formatStr, timeStr]
+
+pattern AST_Hash :: forall a. AST a -> AST a
+pattern AST_Hash val <- App _node (NativeFunc "hash") [val]
+
 pattern AST_AddTime :: forall a. AST a -> AST a -> AST a
 pattern AST_AddTime time seconds <- App _ (NativeFunc "add-time") [time, seconds]
 

--- a/src/Pact/Analyze/Term.hs
+++ b/src/Pact/Analyze/Term.hs
@@ -110,6 +110,11 @@ data Term ret where
 
   PactVersion     :: Term String
 
+  Format          :: Term String         -> [ETerm]     -> Term String
+  FormatTime      :: Term String         -> Term Time   -> Term String
+  ParseTime       :: Maybe (Term String) -> Term String -> Term Time
+  Hash            :: ETerm                              -> Term String
+
 deriving instance Show a => Show (Term a)
 deriving instance Show ETerm
 

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -293,22 +293,22 @@ translateNode astNode = case astNode of
   AST_Days days -> do
     ETerm days' daysTy <- translateNode days
     case daysTy of
-      TInt     -> pure $ ETerm (IntArithOp Mul (1000000 * 60 * 60 * 24) days') TInt
-      TDecimal -> pure $ ETerm (DecArithOp Mul (1000000 * 60 * 60 * 24) days') TDecimal
+      TInt     -> pure $ ETerm (IntArithOp Mul (60 * 60 * 24) days') TInt
+      TDecimal -> pure $ ETerm (DecArithOp Mul (60 * 60 * 24) days') TDecimal
       _        -> throwError $ BadTimeType astNode
 
   AST_Hours hours -> do
     ETerm hours' hoursTy <- translateNode hours
     case hoursTy of
-      TInt     -> pure $ ETerm (IntArithOp Mul (1000000 * 60 * 60) hours') TInt
-      TDecimal -> pure $ ETerm (DecArithOp Mul (1000000 * 60 * 60) hours') TDecimal
+      TInt     -> pure $ ETerm (IntArithOp Mul (60 * 60) hours') TInt
+      TDecimal -> pure $ ETerm (DecArithOp Mul (60 * 60) hours') TDecimal
       _        -> throwError $ BadTimeType astNode
 
   AST_Minutes minutes -> do
     ETerm minutes' minutesTy <- translateNode minutes
     case minutesTy of
-      TInt     -> pure $ ETerm (IntArithOp Mul (1000000 * 60) minutes') TInt
-      TDecimal -> pure $ ETerm (DecArithOp Mul (1000000 * 60) minutes') TDecimal
+      TInt     -> pure $ ETerm (IntArithOp Mul 60 minutes') TInt
+      TDecimal -> pure $ ETerm (DecArithOp Mul 60 minutes') TDecimal
       _        -> throwError $ BadTimeType astNode
 
   AST_NFun _node "time" [AST_Lit (LString timeLit)]

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -251,6 +251,29 @@ translateNode astNode = case astNode of
     ETerm condTerm TBool <- translateNode cond
     pure $ ETerm (Enforce condTerm) TBool
 
+  AST_Format formatStr vars -> do
+    ETerm formatStr' TStr <- translateNode formatStr
+    vars' <- for vars translateNode
+    pure $ ETerm (Format formatStr' vars') TStr
+
+  AST_FormatTime formatStr time -> do
+    ETerm formatStr' TStr <- translateNode formatStr
+    ETerm time' TTime     <- translateNode time
+    pure $ ETerm (FormatTime formatStr' time') TStr
+
+  AST_ParseTime formatStr timeStr -> do
+    ETerm formatStr' TStr <- translateNode formatStr
+    ETerm timeStr' TStr   <- translateNode timeStr
+    pure $ ETerm (ParseTime (Just formatStr') timeStr') TTime
+
+  AST_Time timeStr -> do
+    ETerm timeStr' TStr <- translateNode timeStr
+    pure $ ETerm (ParseTime Nothing timeStr') TTime
+
+  AST_Hash val -> do
+    val' <- translateNode val
+    pure $ ETerm (Hash val') TStr
+
   AST_ReadKeyset nameA -> do
     ETerm nameT TStr <- translateNode nameA
     return $ ETerm (ReadKeySet nameT) TKeySet

--- a/src/Pact/Analyze/Types.hs
+++ b/src/Pact/Analyze/Types.hs
@@ -11,9 +11,10 @@
 
 module Pact.Analyze.Types where
 
-import           Control.Lens       (Iso, Lens', both, from, iso, lens,
-                                     makeLenses, over, to, (%~), (&), (^.))
+import           Control.Lens       (Iso, Iso', Lens', both, from, iso, lens,
+                                     makeLenses, over, view, (%~), (&))
 import           Data.Aeson         (FromJSON, ToJSON)
+import           Data.AffineSpace   ((.-.), (.+^))
 import           Data.Data          (Data)
 import qualified Data.Decimal       as Decimal
 import           Data.Map.Strict    (Map)
@@ -35,8 +36,7 @@ import qualified Data.Set           as Set
 import           Data.String        (IsString (..))
 import           Data.Text          (Text)
 import qualified Data.Text          as T
-import           Data.Thyme         (UTCTime, microseconds, toModifiedJulianDay,
-                                     _utctDay, _utctDayTime)
+import           Data.Thyme         (UTCTime, microseconds)
 import           Data.Typeable      ((:~:) (Refl), Typeable, eqT)
 
 import           Pact.Types.Util    (AsString)
@@ -128,10 +128,13 @@ type Decimal = AlgReal
 type Time = Int64
 
 mkTime :: UTCTime -> Time
-mkTime utct
-  = ((utct ^. _utctDay . to toModifiedJulianDay . to fromIntegral)
-    * (1000000 * 60 * 60 * 24))
-  + (utct ^. _utctDayTime . microseconds)
+mkTime utct = view microseconds (utct .-. toEnum 0)
+
+unMkTime :: Time -> UTCTime
+unMkTime time = toEnum 0 .+^ view (from microseconds) time
+
+timeIso :: Iso' UTCTime Time
+timeIso = iso mkTime unMkTime
 
 data LogicalOp = AndOp | OrOp | NotOp
   deriving (Show, Eq)

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -720,6 +720,10 @@ spec = describe "analyze" $ do
                   (= (add-time (time "2016-07-22T12:00:00Z") (minutes 1.5))
                      (time "2016-07-22T12:01:30Z"))
                   "1.5 minutes later")
+                (enforce
+                  (= (add-time (time "2016-07-23T13:30:45Z") 0.001002)
+                     (parse-time "%Y-%m-%d %H:%M:%S.%v" "2016-07-23 13:30:45.001002"))
+                  "0.001002 seconds later")
               ))
           |]
     in expectPass code $ Valid $ bnot Abort
@@ -905,7 +909,6 @@ spec = describe "analyze" $ do
                 (enforce
                   (= (format-time "%a, %_d %b %Y %H:%M:%S %Z" (time "2016-07-23T13:30:45Z"))
                      "Sat, 23 Jul 2016 13:30:45 UTC"))
-                ; XXX we somehow lose the subseconds here
                 (enforce
                   (= (format-time "%Y-%m-%d %H:%M:%S.%v" (add-time (time "2016-07-23T13:30:45Z") 0.001002))
                      "2016-07-23 13:30:45.001002"))

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -886,3 +886,77 @@ spec = describe "analyze" $ do
 
     expectPass code $ Valid Success
 
+  describe "format-time / parse-time" $ do
+    let code =
+          [text|
+            (defun test:bool ()
+              (let* ((time1in  "2016-09-12")
+                     (time1    (parse-time "%F" time1in))
+                     (time1out (format-time "%F" time1))
+                     (time2in  "2016-07-22T11:26:35Z")
+                     (time2    (time time2in))
+                     (time2out (format-time "%Y-%m-%dT%H:%M:%SZ" time2)))
+                (enforce (= time1in time1out))
+                (enforce (= time2in time2out)))
+
+                (enforce
+                  (= (format-time "%Y-%m-%dT%H:%M:%S%N" (time "2016-07-23T13:30:45Z"))
+                     "2016-07-23T13:30:45+00:00"))
+                (enforce
+                  (= (format-time "%a, %_d %b %Y %H:%M:%S %Z" (time "2016-07-23T13:30:45Z"))
+                     "Sat, 23 Jul 2016 13:30:45 UTC"))
+                ; XXX we somehow lose the subseconds here
+                (enforce
+                  (= (format-time "%Y-%m-%d %H:%M:%S.%v" (add-time (time "2016-07-23T13:30:45Z") 0.001002))
+                     "2016-07-23 13:30:45.001002"))
+                     )
+          |]
+    expectPass code $ Valid Success
+
+  describe "format" $ do
+    let code =
+          [text|
+            (defun test:bool (str:string)
+              (enforce (= (format "{}-{}" ["a" "z"]) "a-z"))
+              (enforce (= (format "{}/{}" [11 26]) "11/26"))
+              (enforce (= (format "{} or {}" [true false]) "true or false"))
+
+              (enforce (= (format "{}" [str]) str))
+            )
+          |]
+    expectPass code $ Valid Success
+
+  describe "hash" $ do
+    let code =
+          [text|
+            (defun test:bool ()
+              (enforce (=
+                (hash "hello")
+                "e4cfa39a3d37be31c59609e807970799caa68a19bfaa15135f165085e01d41a65ba1e1b146aeb6bd0092b49eac214c103ccfa3a365954bbbe52f74a2b3620c94"))
+
+              (enforce (=
+                (hash (- 2 1))
+                "1ced8f5be2db23a6513eba4d819c73806424748a7bc6fa0d792cc1c7d1775a9778e894aa91413f6eb79ad5ae2f871eafcc78797e4c82af6d1cbfb1a294a10d10"))
+
+              (enforce (=
+                (hash (or true false))
+                "5c07e85b3afb949077f2fa42181bb0498f5945f2086d37df5676ebf424ec137d0c21292c943098e22914cdca350e9140d185ca1b2b2bf0522acfcdde09b395dd"))
+
+              (enforce (=
+                (hash (and true false))
+                "625ad9c6965af1a145e3c7514065eab913702c615a8fc9f4699767684f9e97e65dd50f715eae7fdbceee39a03cecf29d5f6a7e79e6a802244b65f6f915283491"))
+
+
+              ; TODO:
+              ; (enforce (=
+              ;   (hash 3.14)
+              ;   "dee8179a1755a745174f334ddc81ade0cf3e2d0bdfd1170cc42c1a1d1d0b16f9bfab86592e9ad31123ce9d470f6aa9388cc2a4f9cda1eb7328ae0a7e26cd450e"))
+
+              ; TODO:
+              ; (enforce (=
+              ;   (hash { 'foo: 1 })
+              ;   "61d3c8775e151b4582ca7f9a885a9b2195d5aa6acc58ddca61a504e9986bb8c06eeb37af722ad848f9009053b6379677bf111e25a680ab41a209c4d56ff1e183"))
+            )
+          |]
+    expectPass code $ Valid Success
+


### PR DESCRIPTION
For `format-time`, `parse-time`, and `hash` we can only analyze them if
their arguments are entirely statically determined. For `format`, we can
generate a symbolic analysis as long as the format string is static.