### PR TITLE
Re-enable server code

### DIFF
--- a/src-ghc/Pact/Main.hs
+++ b/src-ghc/Pact/Main.hs
@@ -40,9 +40,7 @@ import Crypto.Ed25519.Pure
 import Pact.Repl
 import Pact.Parse
 import Pact.Types.Runtime hiding ((<>),PublicKey)
-#if defined(BUILD_SERVER)
 import Pact.Server.Server
-#endif
 #ifndef mingw32_HOST_OS
 import System.Posix.Terminal (queryTerminal)
 import System.Posix.IO (stdInput)
@@ -60,9 +58,7 @@ data Option =
   | OLoad { _oFindScript :: Bool, _oDebug :: Bool, _oFile :: String }
   | ORepl
   | OApiReq { _oReqYaml :: FilePath, _oReqLocal :: Bool }
-#if defined(BUILD_SERVER)
   | OServer { _oConfigYaml :: FilePath }
-#endif
   deriving (Eq,Show)
 
 replOpts :: O.Parser Option
@@ -70,10 +66,8 @@ replOpts =
     O.flag' OVersion (O.short 'v' <> O.long "version" <> O.help "Display version") <|>
     O.flag' OBuiltins (O.short 'b' <> O.long "builtins" <> O.help "List builtins") <|>
     O.flag' OGenKey (O.short 'g' <> O.long "genkey" <> O.help "Generate ED25519 keypair") <|>
-#if defined(BUILD_SERVER)
     (OServer <$> O.strOption (O.short 's' <> O.long "serve" <> O.metavar "config" <>
                               O.help "Launch REST API server with config file")) <|>
-#endif
     (OLoad
      <$> O.flag False True
          (O.short 'r' <> O.long "findscript" <>
@@ -102,9 +96,7 @@ main = do
       exitEither m (Right t) = m t >> exitSuccess
       exitLoad = exitEither (\_ -> hPutStrLn stderr "Load successful" >> hFlush stderr)
   case as of
-#if defined(BUILD_SERVER)
     OServer conf -> serve conf
-#endif
     OVersion -> putStrLn $ "pact version " ++ unpack pactVersion
     OBuiltins -> echoBuiltins
     OLoad findScript dolog fp


### PR DESCRIPTION
The `server` build flag went away in the recent GHCJS refactoring but the CPP macros for conditionally compiling that code didn't get removed along with the flag.  This means that the server is currently not available.  This PR fixes it.