### PR TITLE
Improve property parsing / checking.

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -25,7 +25,8 @@ Flag server
 
 library
 
-  exposed-modules:     Pact.Compile
+  exposed-modules:     Pact.Analyze.PrenexNormalize
+                     , Pact.Compile
                      , Pact.Eval
                      , Pact.Native
                      , Pact.Native.Db

--- a/pact.cabal
+++ b/pact.cabal
@@ -25,8 +25,7 @@ Flag server
 
 library
 
-  exposed-modules:     Pact.Analyze.PrenexNormalize
-                     , Pact.Compile
+  exposed-modules:     Pact.Compile
                      , Pact.Eval
                      , Pact.Native
                      , Pact.Native.Db

--- a/src/Pact/Analyze/Parse.hs
+++ b/src/Pact/Analyze/Parse.hs
@@ -1,16 +1,19 @@
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms   #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 module Pact.Analyze.Parse
   ( expToCheck
+  , expToProp
   , expToInvariant
   ) where
 
 import           Control.Lens         ((^.), at, view)
-import           Control.Monad.Gen    -- (Gen)
-import           Control.Monad.Reader -- ReaderT
+import           Control.Monad.Gen    (GenT, gen, runGenT)
+import           Control.Monad.Reader (ReaderT, local, runReaderT)
 import           Control.Monad.Trans  (lift)
 import           Data.Foldable        (asum, find)
 import           Data.Map             (Map)
@@ -22,249 +25,118 @@ import           Data.Traversable     (for)
 import           Data.Type.Equality   ((:~:) (Refl))
 
 import           Pact.Types.Lang      hiding (KeySet, KeySetName, SchemaVar,
-                                       TKeySet, TableName)
+                                       TKeySet, TableName, Type)
 import qualified Pact.Types.Lang      as Pact
 import           Pact.Types.Typecheck (UserType)
--- import           Pact.Types.Util      (tShow)
 
 import           Pact.Analyze.PrenexNormalize
 import           Pact.Analyze.Types
 
-textToArithOp :: Text -> PropParse ArithOp
-textToArithOp = lift . lift . textToArithOp' where
+textToArithOp :: Text -> Maybe ArithOp
+textToArithOp = \case
+  "+"   -> Just Add
+  "-"   -> Just Sub
+  "*"   -> Just Mul
+  "/"   -> Just Div
+  "^"   -> Just Pow
+  "log" -> Just Log
+  _     -> Nothing
 
-  textToArithOp' :: Text -> Maybe ArithOp
-  textToArithOp' = \case
-    "+"   -> Just Add
-    "-"   -> Just Sub
-    "*"   -> Just Mul
-    "/"   -> Just Div
-    "^"   -> Just Pow
-    "log" -> Just Log
-    _     -> Nothing
+textToUnaryArithOp :: Text -> Maybe UnaryArithOp
+textToUnaryArithOp = \case
+  "-"    -> Just Negate
+  "sqrt" -> Just Sqrt
+  "ln"   -> Just Ln
+  "exp"  -> Just Exp
+  "abs"  -> Just Abs
+  -- explicitly no signum
+  _      -> Nothing
 
-textToUnaryArithOp :: Text -> PropParse UnaryArithOp
-textToUnaryArithOp = lift . lift . textToUnaryArithOp' where
+textToComparisonOp :: Text -> Maybe ComparisonOp
+textToComparisonOp = \case
+  ">"  -> Just Gt
+  "<"  -> Just Lt
+  ">=" -> Just Gte
+  "<=" -> Just Lte
+  "="  -> Just Eq
+  "!=" -> Just Neq
+  _    -> Nothing
 
-  textToUnaryArithOp' :: Text -> Maybe UnaryArithOp
-  textToUnaryArithOp' = \case
-    "-"    -> Just Negate
-    "sqrt" -> Just Sqrt
-    "ln"   -> Just Ln
-    "exp"  -> Just Exp
-    "abs"  -> Just Abs
-    -- explicitly no signum
-    _      -> Nothing
+textToRoundingLikeOp :: Text -> Maybe RoundingLikeOp
+textToRoundingLikeOp = \case
+  "round"   -> Just Round
+  "ceiling" -> Just Ceiling
+  "floor"   -> Just Floor
+  _         -> Nothing
 
-textToComparisonOp :: Text -> PropParse ComparisonOp
-textToComparisonOp = lift . lift . textToComparisonOp' where
+textToLogicalOp :: Text -> Maybe LogicalOp
+textToLogicalOp = \case
+  "and" -> Just AndOp
+  "or"  -> Just OrOp
+  "not" -> Just NotOp
+  _     -> Nothing
 
-  textToComparisonOp' :: Text -> Maybe ComparisonOp
-  textToComparisonOp' = \case
-    ">"  -> Just Gt
-    "<"  -> Just Lt
-    ">=" -> Just Gte
-    "<=" -> Just Lte
-    "="  -> Just Eq
-    "!=" -> Just Neq
-    _    -> Nothing
+textToQuantifier
+  :: Text -> Maybe (UniqueId -> Text -> Ty -> PreProp -> PreProp)
+textToQuantifier = \case
+  "forall" -> Just PreForall
+  "exists" -> Just PreExists
+  _        -> Nothing
 
-mkT :: Text -> TableName
-mkT = TableName . T.unpack
+stringLike :: Exp -> Maybe Text
+stringLike = \case
+  ESymbol str _  -> Just str
+  ELitString str -> Just str
+  _              -> Nothing
 
-mkC :: Text -> ColumnName
-mkC = ColumnName . T.unpack
+pattern TableLit :: TableName -> PreProp
+pattern TableLit tn <- PreStringLit (TableName . T.unpack -> tn)
 
-mkK :: Text -> KeySetName
-mkK = KeySetName
+pattern ColumnLit :: ColumnName -> PreProp
+pattern ColumnLit tn <- PreStringLit (ColumnName . T.unpack -> tn)
 
+-- TODO: Maybe -> Either
 type PropParse = ReaderT (Map Text UniqueId) (GenT UniqueId Maybe)
 
-noParse :: PropParse a
-noParse = lift (lift Nothing)
+-- TODO: Maybe -> Either
+type PropCheck = ReaderT (Map UniqueId EType) Maybe
 
-mkVar :: Text -> PropParse (Prop a)
-mkVar var = do
-  mUid <- view (at var)
-  case mUid of
-    Nothing  -> noParse
-    Just uid -> pure (PVar uid var)
+-- The conversion from @Exp@ to @PreProp@
+--
+--
+-- The biggest thing it handles is generating unique ids for variables and
+-- binding them.
+--
+-- We also handle literals and disambiguating identifiers.
+--
+-- One thing which is not done yet is the conversion from @Text@ to @ArithOp@,
+-- @ComparisonOp@, etc. We handle this in @checkPreProp@ as it doesn't cause
+-- any difficulty there and is less burdensome than creating a new data type
+-- for these operators.
+expToPreProp :: Exp -> PropParse PreProp
+expToPreProp = \case
+  ELiteral (LDecimal d) _ -> pure (PreDecimalLit (mkDecimal d))
+  ELiteral (LInteger i) _ -> pure (PreIntegerLit i)
+  (stringLike -> Just s)  -> pure (PreStringLit s)
+  ELiteral (LTime t) _    -> pure (PreTimeLit (mkTime t))
+  ELiteral (LBool b) _    -> pure (PreBoolLit b)
 
-expToPropRowKey :: Exp -> PropParse (Prop RowKey)
-expToPropRowKey = \case
-  EAtom' "result" -> pure (PVar (-1) "result")
-  EAtom' var      -> mkVar var
-  _               -> noParse
-
-expToPropInteger :: Exp -> PropParse (Prop Integer)
-expToPropInteger = \case
-  EAtom' "result"                    -> pure (PVar (-1) "result")
-  EAtom' var                         -> mkVar var
-  ELiteral (LInteger i) _            -> pure (PLit i)
-  EList' [EAtom' "string-length", a] -> PStrLength <$> expToPropString a
-
-  EList' [EAtom' "mod", a, b]
-    -> PModOp <$> expToPropInteger a <*> expToPropInteger b
-
-  EList' [EAtom' op, a]
-    | op `Set.member` Set.fromList [ "round", "ceiling", "floor" ] -> do
-    let op' = case op of
-          "round"   -> Round
-          "ceiling" -> Ceiling
-          "floor"   -> Floor
-          _         -> error "impossible"
-    PRoundingLikeOp1 op' <$> expToPropDecimal a
-
-  EList' [EAtom' op, a]
-    -> PIntUnaryArithOp <$> textToUnaryArithOp op <*> expToPropInteger a
-
-  EList' [EAtom' op, a, b] -> PIntArithOp
-    <$> textToArithOp op
-    <*> expToPropInteger a
-    <*> expToPropInteger b
-
-  EList' [EAtom' "column-delta", ELitString tab, ELitString col]
-    -> pure (IntColumnDelta (mkT tab) (mkC col))
-
-  _ -> noParse
-
-expToPropString :: Exp -> PropParse (Prop String)
-expToPropString = \case
-  EAtom' "result"        -> pure (PVar (-1) "result")
-  EAtom' var             -> mkVar var
-  ELiteral (LString s) _ -> pure (PLit (T.unpack s))
-  EList' [EAtom' "+", a, b]
-    -> PStrConcat <$> expToPropString a <*> expToPropString b
-  _ -> noParse
-
-expToPropDecimal :: Exp -> PropParse (Prop Decimal)
-expToPropDecimal = \case
-  EAtom' "result"         -> pure (PVar (-1) "result")
-  EAtom' var              -> mkVar var
-  ELiteral (LDecimal d) _ -> pure (PLit (mkDecimal d))
-  EList' [EAtom' op, a, b]
-    | op `Set.member` Set.fromList [ "round", "ceiling", "floor" ] -> do
-    let op' = case op of
-          "round"   -> Round
-          "ceiling" -> Ceiling
-          "floor"   -> Floor
-          _         -> error "impossible"
-    PRoundingLikeOp2 op' <$> expToPropDecimal a <*> expToPropInteger b
-
-  EList' [EAtom' op, a, b] -> asum
-    [ PDecArithOp
-      <$> textToArithOp op <*> expToPropDecimal a <*> expToPropDecimal b
-    , PDecIntArithOp
-      <$> textToArithOp op <*> expToPropDecimal a <*> expToPropInteger b
-    , PIntDecArithOp
-      <$> textToArithOp op <*> expToPropInteger a <*> expToPropDecimal b
-    ]
-
-  EList' [EAtom' op, a]
-    -> PDecUnaryArithOp <$> textToUnaryArithOp op <*> expToPropDecimal a
-
-  EList' [EAtom' "column-delta", ELitString tab, ELitString col]
-    -> pure (DecColumnDelta (mkT tab) (mkC col))
-
-  _ -> noParse
-
-expToPropTime :: Exp -> PropParse (Prop Time)
-expToPropTime = \case
-  EAtom' "result"      -> pure (PVar (-1) "result")
-  EAtom' var           -> mkVar var
-  ELiteral (LTime t) _ -> pure (PLit (mkTime t))
-  EList' [EAtom' "add-time", a, b] -> do
-    a' <- expToPropTime a
-    asum
-      [ PIntAddTime a' <$> expToPropInteger b
-      , PDecAddTime a' <$> expToPropDecimal b
-      ]
-  _ -> noParse
-
-expToPropKeySet :: Exp -> PropParse (Prop KeySet)
-expToPropKeySet = \case
-  EAtom' "result" -> pure (PVar (-1) "result")
-  EAtom' var      -> mkVar var
-  _               -> noParse
-
-expToPropBool :: Exp -> PropParse (Prop Bool)
-expToPropBool = \case
-  EAtom' "result"      -> pure (PVar (-1) "result")
-  ELiteral (LBool b) _ -> pure (PLit b)
-
-  EList' [EAtom' "when", a, b] -> do
-    propNotA <- PLogical NotOp <$> traverse expToPropBool [a]
-    PLogical OrOp . (propNotA:) <$> traverse expToPropBool [b]
-
-  EList' [EAtom' "row-read", ELitString tab, rowKey] ->
-    RowRead (mkT tab) <$> expToPropRowKey rowKey
-  EList' [EAtom' "row-write", ELitString tab, rowKey] ->
-    RowWrite (mkT tab) <$> expToPropRowKey rowKey
-
-  EAtom' "abort"   -> pure Abort
-  EAtom' "success" -> pure Success
-
-  EList' [EAtom' "not", a]     -> PLogical NotOp <$> traverse expToPropBool [a]
-  EList' [EAtom' "and", a, b]  -> PLogical AndOp <$> traverse expToPropBool [a, b]
-  EList' [EAtom' "or", a, b]   -> PLogical OrOp  <$> traverse expToPropBool [a, b]
-
-  EList' [EAtom' "table-write", ELitString tab] -> pure (TableWrite (mkT tab))
-  EList' [EAtom' "table-read", ELitString tab] -> pure (TableRead (mkT tab))
-  EList' [EAtom' "column-write", ELitString tab, ELitString col]
-    -> pure (ColumnWrite (mkT tab) (mkC col))
-  EList' [EAtom' "cell-increase", ELitString tab, ELitString col]
-    -> pure (CellIncrease (mkT tab) (mkC col))
-
-  -- TODO: in the future, these should be moved into a stdlib:
-  EList' [EAtom' "column-conserve", ELitString tab, ELitString col]
-    -> pure (PIntegerComparison Eq 0 $ IntColumnDelta (mkT tab) (mkC col))
-  EList' [EAtom' "column-increase", ELitString tab, ELitString col]
-    -> pure (PIntegerComparison Lt 0 $ IntColumnDelta (mkT tab) (mkC col))
-
-  --
-  -- TODO: add support for DecColumnDelta. but we need type info...
-  --
-
-  EList' [EAtom' "row-enforced", ELitString tab, ELitString col, body] -> do
-    body' <- expToPropRowKey body
-    pure (RowEnforced (mkT tab) (mkC col) body')
-
-  EList' [EAtom' "authorized-by", ELitString name]
-    -> pure (KsNameAuthorized (mkK name))
-
-  EList' [EAtom' "authorized-by", ESymbol name _]
-    -> pure (KsNameAuthorized (mkK name))
-
-  EList' [EAtom' "forall", EList' bindings, body] -> do
+  EList' [EAtom' (textToQuantifier -> Just q), EList' bindings, body] -> do
     bindings' <- propBindings bindings
-    let theseBindingsMap = Map.fromList $ fmap (\(uid, name, _ty) -> (name, uid)) bindings'
-    body'     <- local (Map.union theseBindingsMap) (expToPropBool body)
+    let theseBindingsMap = Map.fromList $
+          fmap (\(uid, name, _ty) -> (name, uid)) bindings'
+    body'     <- local (Map.union theseBindingsMap) (expToPreProp body)
     pure $ foldr
-      (\(uid, name, ty) accum -> Forall uid name ty accum)
-      body'
-      bindings'
-  EList' [EAtom' "exists", EList' bindings, body] -> do
-    bindings' <- propBindings bindings
-    let theseBindingsMap = Map.fromList $ fmap (\(uid, name, _ty) -> (name, uid)) bindings'
-    body'     <- local (Map.union theseBindingsMap) (expToPropBool body)
-    pure $ foldr
-      (\(uid, name, ty) accum -> Exists uid name ty accum)
+      (\(uid, name, ty) accum -> q uid name ty accum)
       body'
       bindings'
 
-  EList' [EAtom' op, a, b] -> do
-    op' <- textToComparisonOp op
-    asum
-      [ PIntegerComparison op' <$> expToPropInteger a <*> expToPropInteger b
-      , PDecimalComparison op' <$> expToPropDecimal a <*> expToPropDecimal b
-      , PTimeComparison op'    <$> expToPropTime a    <*> expToPropTime b
-      , PBoolComparison op'    <$> expToPropBool a    <*> expToPropBool b
-      , PStringComparison op'  <$> expToPropString a  <*> expToPropString b
-      -- TODO: how to disambiguate row keys from strings?
-      , PKeySetComparison op'  <$> expToPropKeySet a  <*> expToPropKeySet b
-      ]
+  EList' (EAtom' funName:args) -> PreApp funName <$> traverse expToPreProp args
 
-  EAtom' var           -> mkVar var
+  EAtom' "abort"   -> pure PreAbort
+  EAtom' "success" -> pure PreSuccess
+  EAtom' "result"  -> pure PreResult
+  EAtom' var       -> mkVar var
 
   _ -> noParse
 
@@ -276,20 +148,126 @@ expToPropBool = \case
           nameTy <- case ty of
             TyPrim TyString -> do
               uid <- gen
-              pure (uid, name, Ty (Rep @RowKey))
+              pure (uid, name, Ty (Rep @String))
             _               -> noParse
           (nameTy:) <$> propBindings exps
         propBindings _ = noParse
 
+        noParse :: PropParse a
+        noParse = lift (lift Nothing)
+
+        mkVar :: Text -> PropParse PreProp
+        mkVar var = do
+          mUid <- view (at var)
+          case mUid of
+            Nothing  -> noParse
+            Just uid -> pure (PreVar uid var)
+
+checkPreProp :: Type a -> PreProp -> PropCheck (Prop a)
+checkPreProp ty preProp = case (ty, preProp) of
+  -- literals
+  (TDecimal, PreDecimalLit a) -> pure (PLit a)
+  (TInt, PreIntegerLit a)     -> pure (PLit a)
+  (TStr, PreStringLit a)      -> pure (PLit (T.unpack a))
+  (TTime, PreTimeLit a)       -> pure (PLit a)
+  (TBool, PreBoolLit a)       -> pure (PLit a)
+
+  -- identifiers
+  (TBool, PreAbort)    -> pure Abort
+  (TBool, PreSuccess)  -> pure Success
+  (_, PreResult)       -> pure Result
+  (_, PreVar uid name) -> pure (PVar uid name)
+
+  -- quantifiers
+  (a, PreForall uid name ty' p) -> Forall uid name ty' <$> checkPreProp a p
+  (a, PreExists uid name ty' p) -> Exists uid name ty' <$> checkPreProp a p
+
+  -- TODO: PreAt / PAt
+
+  -- applications
+  (TInt, PreApp "str-length" [str]) -> PStrLength <$> checkPreProp TStr str
+  (TStr, PreApp "+" [a, b])
+    -> PStrConcat <$> checkPreProp TStr a <*> checkPreProp TStr b
+
+  (TDecimal, PreApp (textToArithOp -> Just op) [a, b]) -> asum
+    [ PDecArithOp    op <$> checkPreProp TDecimal a <*> checkPreProp TDecimal b
+    , PDecIntArithOp op <$> checkPreProp TDecimal a <*> checkPreProp TInt b
+    , PIntDecArithOp op <$> checkPreProp TInt a     <*> checkPreProp TDecimal b
+    ]
+  (TInt, PreApp (textToArithOp -> Just op) [a, b])
+    -> PIntArithOp op <$> checkPreProp TInt a <*> checkPreProp TInt b
+  (TDecimal, PreApp (textToUnaryArithOp -> Just op) [a])
+    -> PDecUnaryArithOp op <$> checkPreProp TDecimal a
+  (TInt, PreApp (textToUnaryArithOp -> Just op) [a])
+    -> PIntUnaryArithOp op <$> checkPreProp TInt a
+
+  (TInt, PreApp "mod" [a, b])
+    -> PModOp <$> checkPreProp TInt a <*> checkPreProp TInt b
+  (TInt, PreApp (textToRoundingLikeOp -> Just op) [a])
+    -> PRoundingLikeOp1 op <$> checkPreProp TDecimal a
+  (TDecimal, PreApp (textToRoundingLikeOp -> Just op) [a, b])
+    -> PRoundingLikeOp2 op <$> checkPreProp TDecimal a <*> checkPreProp TInt b
+  (TTime, PreApp "add-time" [a, b]) -> do
+    a' <- checkPreProp TTime a
+    asum
+      [ PIntAddTime a' <$> checkPreProp TInt b
+      , PDecAddTime a' <$> checkPreProp TDecimal b
+      ]
+
+  (TBool, PreApp (textToComparisonOp -> Just op) [a, b]) -> asum
+    [ PIntegerComparison op <$> checkPreProp TInt a     <*> checkPreProp TInt b
+    , PDecimalComparison op <$> checkPreProp TDecimal a <*> checkPreProp TDecimal b
+    , PTimeComparison op    <$> checkPreProp TTime a    <*> checkPreProp TTime b
+    , PBoolComparison op    <$> checkPreProp TBool a    <*> checkPreProp TBool b
+    , PStringComparison op  <$> checkPreProp TStr a     <*> checkPreProp TStr b
+    , PKeySetComparison op  <$> checkPreProp TKeySet a  <*> checkPreProp TKeySet b
+    ]
+
+  (TBool, PreApp (textToLogicalOp -> Just op) args) -> case (op, args) of
+    (NotOp, [a])    -> PNot <$> checkPreProp TBool a
+    (AndOp, [a, b]) -> PAnd <$> checkPreProp TBool a <*> checkPreProp TBool b
+    (OrOp, [a, b])  -> POr  <$> checkPreProp TBool a <*> checkPreProp TBool b
+    _               -> lift Nothing
+
+  (TBool, PreApp "table-write" [TableLit tn]) -> pure (TableWrite tn)
+  (TBool, PreApp "table-read" [TableLit tn])  -> pure (TableRead tn)
+  (TBool, PreApp "column-write" [TableLit tn, ColumnLit cn])
+    -> pure (ColumnWrite tn cn)
+  (TBool, PreApp "cell-increase" [TableLit tn, ColumnLit cn])
+    -> pure (CellIncrease tn cn)
+  (TInt, PreApp "cell-delta" [TableLit tn, ColumnLit cn, rk])
+    -> IntCellDelta tn cn <$> checkPreProp TStr rk
+  (TDecimal, PreApp "cell-delta" [TableLit tn, ColumnLit cn, rk])
+    -> DecCellDelta tn cn <$> checkPreProp TStr rk
+  (TInt, PreApp "column-delta" [TableLit tn, ColumnLit cn])
+    -> pure (IntColumnDelta tn cn)
+  (TDecimal, PreApp "column-delta" [TableLit tn, ColumnLit cn])
+    -> pure (DecColumnDelta tn cn)
+  (TBool, PreApp "row-read" [TableLit tn, rk])
+    -> RowRead tn <$> checkPreProp TStr rk
+  (TBool, PreApp "row-write" [TableLit tn, rk])
+    -> RowWrite tn <$> checkPreProp TStr rk
+  (TBool, PreApp "authorized-by" [PreStringLit ks])
+    -> pure (KsNameAuthorized (KeySetName ks))
+  (TBool, PreApp "row-enforced" [TableLit tn, ColumnLit cn, rk])
+    -> RowEnforced tn cn <$> checkPreProp TStr rk
+
+  _ -> lift Nothing
 
 --
 -- TODO: the one property this can't parse yet is PAt because it includes an
 -- EType.
 --
 expToCheck :: Exp -> Maybe Check
-expToCheck body =
-  let body' = runGenT (runReaderT (expToPropBool body) Map.empty)
-  in PropertyHolds . prenexConvert <$> body'
+expToCheck body = do
+  preTypedBody <- runGenT (runReaderT (expToPreProp body) Map.empty)
+  typedBody    <- runReaderT (checkPreProp TBool preTypedBody) Map.empty
+  pure $ PropertyHolds $ prenexConvert typedBody
+
+expToProp :: Type a -> Exp -> Maybe (Prop a)
+expToProp ty body = do
+  preTypedBody <- runGenT (runReaderT (expToPreProp body) Map.empty)
+  runReaderT (checkPreProp ty preTypedBody) Map.empty
 
 -- We pass in the type of the variable so we can use it to construct
 -- `SomeSchemaInvariant` when we encounter a var.
@@ -311,26 +289,19 @@ expToInvariant schemaTys = \case
     (SomeSchemaInvariant (SchemaDecimalLiteral (mkDecimal d)) TDecimal)
   ELiteral (LInteger i) _ -> Just
     (SomeSchemaInvariant (SchemaIntLiteral i) TInt)
-  ELiteral (LString s) _ -> Just
+  (stringLike -> Just s) -> Just
     (SomeSchemaInvariant (SchemaStringLiteral s) TStr)
+  ELiteral (LString _) _ -> error "impossible (handled by stringLike)"
   ELiteral (LTime t) _ -> Just
     (SomeSchemaInvariant (SchemaTimeLiteral (mkTime t)) TTime)
   ELiteral (LBool b) _ -> Just
     (SomeSchemaInvariant (SchemaBoolLiteral b) TBool)
 
   EList' [EAtom' op, a, b]
-    | op `Set.member` Set.fromList [">", "<", ">=", "<=", "=", "!="] -> do
+    | Just op' <- textToComparisonOp op -> do
     SomeSchemaInvariant a' aTy <- expToInvariant schemaTys a
     SomeSchemaInvariant b' bTy <- expToInvariant schemaTys b
-    let op' = case op of
-          ">"  -> Gt
-          "<"  -> Lt
-          ">=" -> Gte
-          "<=" -> Lte
-          "="  -> Eq
-          "!=" -> Neq
-          _    -> error "impossible"
-        opEqNeq = case op of
+    let opEqNeq = case op of
           "="  -> Just Eq'
           "!=" -> Just Neq'
           _    -> Nothing

--- a/src/Pact/Analyze/PrenexNormalize.hs
+++ b/src/Pact/Analyze/PrenexNormalize.hs
@@ -53,9 +53,6 @@ instance Float Object where
 instance Float KeySet where
   float p = case p of STANDARD_INSTANCES
 
-instance Float RowKey where
-  float p = case p of STANDARD_INSTANCES
-
 flipQuantifier :: Quantifier -> Quantifier
 flipQuantifier = \case
   Forall' uid name ty -> Exists' uid name ty

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -257,7 +257,7 @@ fold' :: NativeFun e
 fold' i [app@TApp {},initv,l] = reduce l >>= \l' -> case l' of
            TList ls _ _ -> reduce initv >>= \initv' ->
                          foldM (\r a -> apply' app [r,a]) initv' ls
-           t -> evalError' i $ "map: expecting list: " ++ abbrev t
+           t -> evalError' i $ "fold: expecting list: " ++ abbrev t
 fold' i as = argsError' i as
 
 


### PR DESCRIPTION
The biggest improvement here is that we no longer have to specify
`int-column-conserves` / `dec-column-conserves` -- we can infer the type
and instead just specify `column-conserves`.

This change also improves handling of string-like identifiers, so
`"foo"` and `'foo` are handled uniformly.

We remove the `RowKey` `newtype`, so row keys are now treated
(correctly) as strings.

Lastly, parsing is simplified and more extensible.