### PR TITLE
Update verified accounts example syntax.

### DIFF
--- a/examples/verified-accounts/accounts.pact
+++ b/examples/verified-accounts/accounts.pact
@@ -14,7 +14,7 @@
 
   (defschema account
     ("Row type for accounts table."
-      (invariants [(>= balance 0.0)]))
+      (invariant (>= balance 0.0)))
      balance:decimal
      amount:decimal
      ccy:string
@@ -40,7 +40,7 @@
 
   (defun transfer (src:string dest:string amount:decimal)
     ("transfer AMOUNT from SRC to DEST"
-      (properties [(column-conserve 'account 'balance)]))
+      (property (= (column-delta 'accounts 'balance) 0.0)))
     (debit src amount)
     (credit dest amount))
 
@@ -57,11 +57,11 @@
 
   (defun read-account-admin (id)
     ("Read data for account ID, admin version"
-      (properties
-        [ (when
-             (not (authorized-by 'accounts-admin-keyset))
-             abort)
-        ]))
+      (property
+        (when
+          (not (authorized-by 'accounts-admin-keyset))
+          abort)
+        ))
     (enforce-keyset 'accounts-admin-keyset)
     (read accounts id ['balance 'ccy 'amount]))
 


### PR DESCRIPTION
* Use `invariant` and `property` rather than `invariants` and `properties`
  where convenient.
* Use `column-delta` instead of `column-conserve`.