### PR TITLE
Update unique id generation.

### DIFF
--- a/src/Pact/Analyze/Parse.hs
+++ b/src/Pact/Analyze/Parse.hs
@@ -11,9 +11,9 @@ module Pact.Analyze.Parse
   , expToInvariant
   ) where
 
-import           Control.Lens         (at, ifoldrM, view, (^.))
+import           Control.Lens         (at, view, (^.))
 import           Control.Monad.Except (mzero, throwError)
-import           Control.Monad.Gen    (GenT, gen, runGen, runGenTFrom)
+import           Control.Monad.Gen    (GenT, gen, runGenTFrom)
 import           Control.Monad.Reader (ReaderT, ask, local, runReaderT)
 import           Control.Monad.Trans  (lift)
 import           Data.Foldable        (asum, find)
@@ -269,28 +269,13 @@ checkPreProp ty preProp = case (ty, preProp) of
 
   _ -> mzero
 
-envToEnvs :: Map Text EType -> (Map Text UniqueId, Map UniqueId EType)
-envToEnvs env = runGen $ ifoldrM
-  (\name ty (nameEnv, idEnv) -> do
-    id' <- gen
-    pure $ (Map.insert name id' nameEnv, Map.insert id' ty idEnv))
-  (Map.empty, Map.empty)
-  env
-
 -- Convert an @Exp@ to a @Check@ in an environment where the variables have
 -- types.
-expToCheck :: Map Text EType -> Exp -> Maybe Check
-expToCheck env =
-  let (nameEnv, idEnv) = envToEnvs env
-  in expToCheck' (UniqueId (Map.size env)) nameEnv idEnv
-
--- Helper for @expToCheck@. Useful for testing when you want unique ids to be
--- predictable.
 --
 -- TODO: the one property this can't parse yet is PAt because it includes an
 -- EType.
 --
-expToCheck'
+expToCheck
   :: UniqueId
   -- ^ ID to start issuing from
   -> Map Text UniqueId
@@ -300,7 +285,7 @@ expToCheck'
   -> Exp
   -- ^ Exp to convert
   -> Maybe Check
-expToCheck' genStart nameEnv idEnv body = do
+expToCheck genStart nameEnv idEnv body = do
   preTypedBody <- runGenTFrom genStart (runReaderT (expToPreProp body) nameEnv)
   typedBody    <- runReaderT (checkPreProp TBool preTypedBody) idEnv
   pure $ PropertyHolds $ prenexConvert typedBody


### PR DESCRIPTION
We need `moduleFunChecks` and `checkTopFunction` to generate the same
unique ids or we can trigger a z3 error:

```
*** Data.SBV: Unexpected non-success response from Z3:
***
***    Sent      : (define-fun s21 () Bool (= s13 s1))
***    Expected  : success
***    Received  : (error "line 36 column 33: Sorts Int and String are incompatible")
***
***    Exit code : ExitFailure (-15)
***    Executable: /usr/local/bin/z3
***    Options   : -nw -in -smt2
***
***    Reason    : Check solver response for further information. If your code is correct,
***                please report this as an issue either with SBV or the solver itself!
```