### PR TITLE
Generalize `row-read` and `row-write`.

### DIFF
--- a/src/Pact/Analyze/Analyze.hs
+++ b/src/Pact/Analyze/Analyze.hs
@@ -126,8 +126,8 @@ data LatticeAnalyzeState
     , _lasIntColumnDeltas     :: TableMap (ColumnMap (S Integer))
     , _lasDecColumnDeltas     :: TableMap (ColumnMap (S Decimal))
     , _lasTableCells          :: TableMap SymbolicCells
-    , _lasRowsRead            :: TableMap (SFunArray RowKey Bool)
-    , _lasRowsWritten         :: TableMap (SFunArray RowKey Bool)
+    , _lasRowsRead            :: TableMap (SFunArray RowKey Integer)
+    , _lasRowsWritten         :: TableMap (SFunArray RowKey Integer)
     , _lasCellsEnforced       :: TableMap (ColumnMap (SFunArray RowKey Bool))
     -- We currently maintain cellsWritten only for deciding whether a cell has
     -- been "invalidated" for the purposes of keyset enforcement. If a keyset
@@ -202,8 +202,8 @@ mkInitialAnalyzeState tables = AnalyzeState
         , _lasIntColumnDeltas     = intColumnDeltas
         , _lasDecColumnDeltas     = decColumnDeltas
         , _lasTableCells          = mkSymbolicCells tables
-        , _lasRowsRead            = mkPerTableSFunArray false
-        , _lasRowsWritten         = mkPerTableSFunArray false
+        , _lasRowsRead            = mkPerTableSFunArray 0
+        , _lasRowsWritten         = mkPerTableSFunArray 0
         , _lasCellsEnforced       = cellsEnforced
         , _lasCellsWritten        = cellsWritten
         }
@@ -550,12 +550,12 @@ decColumnDelta :: TableName -> ColumnName -> Lens' AnalyzeState (S Decimal)
 decColumnDelta tn cn = latticeState.lasDecColumnDeltas.singular (ix tn).
   singular (ix cn)
 
-rowRead :: TableName -> S RowKey -> Lens' AnalyzeState (S Bool)
-rowRead tn sRk = latticeState.lasRowsRead.singular (ix tn).
+rowReadCount :: TableName -> S RowKey -> Lens' AnalyzeState (S Integer)
+rowReadCount tn sRk = latticeState.lasRowsRead.singular (ix tn).
   symArrayAt sRk.sbv2S
 
-rowWritten :: TableName -> S RowKey -> Lens' AnalyzeState (S Bool)
-rowWritten tn sRk = latticeState.lasRowsWritten.singular (ix tn).
+rowWriteCount :: TableName -> S RowKey -> Lens' AnalyzeState (S Integer)
+rowWriteCount tn sRk = latticeState.lasRowsWritten.singular (ix tn).
   symArrayAt sRk.sbv2S
 
 cellEnforced
@@ -806,7 +806,7 @@ analyzeTermO = \case
   Read tid tn (Schema fields) rowKey -> do
     sRk <- symRowKey <$> analyzeTerm rowKey
     tableRead tn .= true
-    rowRead tn sRk .= true
+    rowReadCount tn sRk += 1
     tagAccessKey modelReads tid sRk
 
     aValFields <- iforM fields $ \fieldName fieldType -> do
@@ -1125,7 +1125,7 @@ analyzeTerm = \case
     Object obj' <- analyzeTermO obj
     sRk <- symRowKey <$> analyzeTerm rowKey
     tableWritten tn .= true
-    rowWritten tn sRk .= true
+    rowWriteCount tn sRk += 1
     tagAccessKey modelWrites tid sRk
 
     mValFields <- iforM obj' $ \colName (fieldType, aval') -> do
@@ -1463,10 +1463,18 @@ analyzeProp (DecColumnDelta tableName colName) = view $
   qeAnalyzeState.decColumnDelta tableName colName
 analyzeProp (RowRead tn pRk)  = do
   sRk <- analyzeProp pRk
-  view $ qeAnalyzeState.rowRead tn sRk
+  numReads <- view $ qeAnalyzeState.rowReadCount tn sRk
+  pure $ sansProv $ numReads .== 1
+analyzeProp (RowReadCount tn pRk)  = do
+  sRk <- analyzeProp pRk
+  view $ qeAnalyzeState.rowReadCount tn sRk
 analyzeProp (RowWrite tn pRk) = do
   sRk <- analyzeProp pRk
-  view $ qeAnalyzeState.rowWritten tn sRk
+  writes <- view $ qeAnalyzeState.rowWriteCount tn sRk
+  pure $ sansProv $ writes .== 1
+analyzeProp (RowWriteCount tn pRk) = do
+  sRk <- analyzeProp pRk
+  view $ qeAnalyzeState.rowWriteCount tn sRk
 
 -- Authorization
 analyzeProp (KsNameAuthorized ksn) = nameAuthorized $ literalS ksn

--- a/src/Pact/Analyze/Parse.hs
+++ b/src/Pact/Analyze/Parse.hs
@@ -319,12 +319,18 @@ checkPreProp ty preProp = case (ty, preProp) of
   (TBool, PreApp "row-read" [TableLit tn, rk]) -> do
     _ <- expectTableExists tn
     RowRead tn <$> checkPreProp TStr rk
+  (TInt, PreApp "row-read-count" [TableLit tn, rk]) -> do
+    _ <- expectTableExists tn
+    RowReadCount tn <$> checkPreProp TStr rk
   --
   -- TODO: should be "row-written"
   --
   (TBool, PreApp "row-write" [TableLit tn, rk]) -> do
     _ <- expectTableExists tn
     RowWrite tn <$> checkPreProp TStr rk
+  (TInt, PreApp "row-write-count" [TableLit tn, rk]) -> do
+    _ <- expectTableExists tn
+    RowWriteCount tn <$> checkPreProp TStr rk
   (TBool, PreApp "authorized-by" [PreStringLit ks])
     -> pure (KsNameAuthorized (KeySetName ks))
   (TBool, PreApp "row-enforced" [TableLit tn, ColumnLit cn, rk]) -> do

--- a/src/Pact/Analyze/PrenexNormalize.hs
+++ b/src/Pact/Analyze/PrenexNormalize.hs
@@ -69,7 +69,9 @@ floatIntegerQuantifiers p = case p of
   PModOp a b            -> PModOp              <$> float a <*> float b
   PRoundingLikeOp1 op a -> PRoundingLikeOp1 op <$> float a
   IntCellDelta tn cn a  -> IntCellDelta tn cn  <$> float a
-  IntColumnDelta{} -> ([], p)
+  RowWriteCount tn pRk  -> RowWriteCount tn    <$> float pRk
+  RowReadCount tn pRk   -> RowReadCount tn     <$> float pRk
+  IntColumnDelta{}      -> ([], p)
 
 floatDecimalQuantifiers :: Prop Decimal -> ([Quantifier], Prop Decimal)
 floatDecimalQuantifiers p = case p of
@@ -118,8 +120,8 @@ floatBoolQuantifiers p = case p of
   PNot a       -> bimap (fmap flipQuantifier) PNot (float a)
   PLogical _ _ -> error ("ill-defined logical op: " ++ show p)
 
-  RowRead tn pRk     -> RowRead tn <$> float pRk
-  RowWrite tn pRk    -> RowWrite tn <$> float pRk
+  RowRead  tn pRk -> RowRead  tn <$> float pRk
+  RowWrite tn pRk -> RowWrite tn <$> float pRk
 
 reassembleFloated :: [Quantifier] -> Prop Bool -> Prop Bool
 reassembleFloated qs prop =

--- a/src/Pact/Analyze/Types.hs
+++ b/src/Pact/Analyze/Types.hs
@@ -588,10 +588,14 @@ data Prop a where
   DecColumnDelta :: TableName  -> ColumnName                 -> Prop Decimal
   -- ^ The difference (@after-before@) in a column's decimal sum across a transaction
 
-  RowRead  :: TableName  -> Prop RowKey -> Prop Bool
+  RowRead       :: TableName  -> Prop RowKey -> Prop Bool
   -- ^ Whether a row is read
-  RowWrite :: TableName  -> Prop RowKey -> Prop Bool
+  RowReadCount  :: TableName  -> Prop RowKey -> Prop Integer
+  -- ^ Number of times a row is read
+  RowWrite      :: TableName  -> Prop RowKey -> Prop Bool
   -- ^ Whether a row is written
+  RowWriteCount :: TableName  -> Prop RowKey -> Prop Integer
+  -- ^ Number of times a row is written
 
   --
   -- TODO: StaleRead?


### PR DESCRIPTION
* introduce `row-read-count`
* and `row-write-count`

These, (probably) along with generalized quantification, are key to
multiple-read / multiple-write lints.