### PR TITLE
Gas model implementation with simple fixed-rate model

### DIFF
--- a/docs/pact-functions.md
+++ b/docs/pact-functions.md
@@ -1225,6 +1225,40 @@ Set environment confidential ENTITY id, or unset with no argument. Clears any pr
 ```
 
 
+### env-gas {#env-gas}
+
+ *&rarr;*&nbsp;`integer`
+
+*gas*&nbsp;`integer` *&rarr;*&nbsp;`string`
+
+
+Query gas state, or set it to GAS
+
+
+### env-gaslimit {#env-gaslimit}
+
+*limit*&nbsp;`integer` *&rarr;*&nbsp;`string`
+
+
+Set environment gas limit to LIMIT
+
+
+### env-gasprice {#env-gasprice}
+
+*price*&nbsp;`decimal` *&rarr;*&nbsp;`string`
+
+
+Set environment gas price to PRICE
+
+
+### env-gasrate {#env-gasrate}
+
+*rate*&nbsp;`integer` *&rarr;*&nbsp;`string`
+
+
+Update gas model to charge constant RATE
+
+
 ### env-hash {#env-hash}
 
 *hash*&nbsp;`string` *&rarr;*&nbsp;`string`

--- a/pact.cabal
+++ b/pact.cabal
@@ -20,6 +20,7 @@ library
 
   exposed-modules:     Pact.Compile
                      , Pact.Eval
+                     , Pact.Gas
                      , Pact.Native
                      , Pact.Native.Db
                      , Pact.Native.Internal

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -30,6 +30,7 @@ import qualified Data.Map.Strict as M
 import Pact.Persist.MockPersist
 import Pact.Persist
 import Unsafe.Coerce
+import Pact.Gas
 
 longStr :: Int -> Text
 longStr n = pack $ "\"" ++ take n (cycle "abcdefghijklmnopqrstuvwxyz") ++ "\""
@@ -73,7 +74,7 @@ loadBenchModule db = do
            (object ["keyset" .= object ["keys" .= ["benchadmin"::Text], "pred" .= (">"::Text)]])
            Nothing
            initialHash
-  erRefStore <$> evalExec (setupEvalEnv db entity (Transactional 1) md initRefStore) pc
+  erRefStore <$> evalExec (setupEvalEnv db entity (Transactional 1) md initRefStore freeGasEnv) pc
 
 parseCode :: Text -> IO ParsedCode
 parseCode m = ParsedCode m <$> eitherDie (parseExprs m)
@@ -84,7 +85,7 @@ benchNFIO bname = bench bname . nfIO
 runPactExec :: PactDbEnv e -> RefStore -> ParsedCode -> IO Value
 runPactExec dbEnv refStore pc = do
   t <- Transactional . fromIntegral <$> getCPUTime
-  toJSON . erOutput <$> evalExec (setupEvalEnv dbEnv entity t (initMsgData initialHash) refStore) pc
+  toJSON . erOutput <$> evalExec (setupEvalEnv dbEnv entity t (initMsgData initialHash) refStore freeGasEnv) pc
 
 benchKeySet :: KeySet
 benchKeySet = KeySet [PublicKey "benchadmin"] (Name ">" def)

--- a/src-ghc/Pact/Interpreter.hs
+++ b/src-ghc/Pact/Interpreter.hs
@@ -69,8 +69,8 @@ evalContinuation ee pact = interpret ee [pact]
 
 
 setupEvalEnv :: PactDbEnv e -> Maybe EntityName -> ExecutionMode ->
-                MsgData -> RefStore -> EvalEnv e
-setupEvalEnv dbEnv ent mode msgData refStore =
+                MsgData -> RefStore -> GasEnv -> EvalEnv e
+setupEvalEnv dbEnv ent mode msgData refStore gasEnv =
   EvalEnv {
     _eeRefStore = refStore
   , _eeMsgSigs = mdSigs msgData
@@ -82,6 +82,7 @@ setupEvalEnv dbEnv ent mode msgData refStore =
   , _eePactDbVar = pdPactDbVar dbEnv
   , _eePurity = PImpure
   , _eeHash = mdHash msgData
+  , _eeGasEnv = gasEnv
   }
   where modeToTx (Transactional t) = Just t
         modeToTx Local = Nothing

--- a/src-ghc/Pact/Main.hs
+++ b/src-ghc/Pact/Main.hs
@@ -39,7 +39,7 @@ import Crypto.Ed25519.Pure
 
 import Pact.Repl
 import Pact.Parse
-import Pact.Types.Runtime hiding ((<>),PublicKey)
+import Pact.Types.Runtime hiding (PublicKey)
 import Pact.Server.Server
 #ifndef mingw32_HOST_OS
 import System.Posix.Terminal (queryTerminal)

--- a/src-ghc/Pact/ReplTools.hs
+++ b/src-ghc/Pact/ReplTools.hs
@@ -21,6 +21,7 @@ import System.Console.Haskeline
   (runInputT, withInterrupt, InputT, getInputLine, handleInterrupt,
    CompletionFunc, completeQuotedWord, completeWord, listFiles,
    filenameWordBreakChars, Settings(Settings), simpleCompletion)
+import Data.Monoid
 
 import Pact.Parse
 import Pact.Types.Runtime

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -29,6 +29,7 @@ import Pact.Types.RPC
 import Pact.Types.Runtime hiding (PublicKey)
 import Pact.Types.Server
 import Pact.Types.Logger
+import Pact.Gas
 
 import Pact.Interpreter
 
@@ -100,6 +101,7 @@ applyExec rk (ExecMsg parsedCode edata) Command{..} = do
   (CommandState refStore) <- liftIO $ readMVar _ceState
   let evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode
                 (MsgData (userSigsToPactKeySet _cmdSigs) edata Nothing _cmdHash) refStore
+                freeGasEnv
   pr <- liftIO $ evalExec evalEnv parsedCode
   void $ liftIO $ swapMVar _ceState $ CommandState (erRefStore pr)
   return $ jsonResult _ceMode rk $ CommandSuccess (last (erOutput pr))

--- a/src-ghc/Pact/Server/Server.hs
+++ b/src-ghc/Pact/Server/Server.hs
@@ -35,7 +35,7 @@ import System.Log.FastLogger
 import Data.Default
 
 import Pact.Types.Command
-import Pact.Types.Runtime hiding (Update,(<>))
+import Pact.Types.Runtime hiding (Update)
 import Pact.Types.SQLite
 import Pact.Types.Server
 import Pact.Types.Logger

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -49,7 +49,7 @@ import qualified Data.Map.Strict as M
 import Pact.Types.Lang
 import Pact.Types.Util
 import Pact.Parse (exprsOnly,parseExprs)
-import Pact.Types.Runtime (PactError(..))
+import Pact.Types.Runtime (PactError(..),PactErrorType(..))
 import Pact.Types.Hash
 
 type MkInfo = Exp -> Info
@@ -85,7 +85,7 @@ compileExps mi exps = sequence $ compile mi <$> exps
 
 
 syntaxError :: Info -> String -> Compile a
-syntaxError i s = throwError $ SyntaxError i def (pack s)
+syntaxError i s = throwError $ PactError SyntaxError i def (pack s)
 
 syntaxError' :: Exp -> String -> Compile a
 syntaxError' e s = mkInfo e >>= \i -> syntaxError i s

--- a/src/Pact/Gas.hs
+++ b/src/Pact/Gas.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TupleSections #-}
+module Pact.Gas where
+
+import Data.Text
+import Pact.Types.Runtime
+import Control.Lens
+import Control.Arrow
+import Data.Monoid
+import Data.Word
+
+-- | Compute gas for some application or evaluation.
+computeGas :: Either (Info,Text) FunApp -> GasArgs -> Eval e Gas
+computeGas i args = do
+  GasEnv {..} <- view eeGasEnv
+  g0 <- use evalGas
+  let
+    (info,name) = either id (_faInfo &&& _faName) i
+    g1 = g0 + runGasModel _geGasModel name args
+  evalGas .= g1
+  if (g1 > fromIntegral _geGasLimit) then
+    throwErr (GasError g1 _geGasLimit) info $ "Gas limit (" <> tShow _geGasLimit <> ") exceeded: " <> tShow g1
+    else return g1
+
+
+-- | Pre-compute gas for some application before some action.
+computeGas' :: FunApp -> GasArgs -> Eval e a -> Eval e (Gas,a)
+computeGas' i gs action = computeGas (Right i) gs >>= \g -> (g,) <$> action
+
+-- | Pre-compute gas for some application with unreduced args before some action.
+gasUnreduced :: FunApp -> [Term Ref] -> Eval e a -> Eval e (Gas,a)
+gasUnreduced i as = computeGas' i (GUnreduced as)
+
+-- | GasEnv for suppressing gas charging.
+freeGasEnv :: GasEnv
+freeGasEnv = GasEnv 0 0.0 (constGasModel 0)
+
+-- | Gas model that charges a fixed (positive) rate per tracked operation.
+constGasModel :: Word64 -> GasModel
+constGasModel r = GasModel $ \_ _ -> fromIntegral r

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -17,13 +18,15 @@ module Pact.Native.Internal
   (success
   ,parseMsgKey
   ,bindReduce
-  ,defNative,defRNative
+  ,defNative,defGasRNative,defRNative
   ,foldDefs
   ,funType,funType'
   ,getModule
   ,module Pact.Types.Native
   ,tTyInteger,tTyDecimal,tTyTime,tTyBool,tTyString,tTyValue,tTyKeySet,tTyObject
   ,colsToList
+  ,module Pact.Gas
+  ,(<>)
   ) where
 
 import Control.Monad
@@ -37,9 +40,11 @@ import Control.Arrow
 import qualified Data.Aeson.Lens as A
 import Bound
 import qualified Data.HashMap.Strict as HM
+import Data.Semigroup ((<>))
 
 import Pact.Types.Runtime
 import Pact.Types.Native
+import Pact.Gas
 
 success :: Functor m => Text -> m a -> m (Term Name)
 success = fmap . const . toTerm
@@ -73,15 +78,23 @@ bindReduce ps bd bi lkpFun = do
                                 Just v -> return v
             t -> evalError bi $ "Invalid column identifier in binding: " ++ show t
   let bd'' = instantiate (resolveArg bi (map snd vs)) bd
-  call (StackFrame (pack $ "(bind: " ++ show (map (second abbrev) vs) ++ ")") bi Nothing) $! reduceBody bd''
+  -- | NB stack frame here just documents scope, but does not incur gas
+  call (StackFrame (pack $ "(bind: " ++ show (map (second abbrev) vs) ++ ")") bi Nothing) $!
+    ((0,) <$> reduceBody bd'')
 
-
+-- | Specify a 'NativeFun'
 defNative :: NativeDefName -> NativeFun e -> FunTypes (Term Name) -> Text -> NativeDef
 defNative n fun ftype docs = (n, TNative n (NativeDFun n (unsafeCoerce fun)) ftype docs def)
 
+-- | Specify a 'GasRNativeFun'
+defGasRNative :: NativeDefName -> GasRNativeFun e -> FunTypes (Term Name) -> Text -> NativeDef
+defGasRNative name fun = defNative name (reduced fun)
+    where reduced f fi as = preGas fi as >>= \(g,as') -> f g fi as'
+
+-- | Specify a 'RNativeFun'
 defRNative :: NativeDefName -> RNativeFun e -> FunTypes (Term Name) -> Text -> NativeDef
 defRNative name fun = defNative name (reduced fun)
-    where reduced f fi as = mapM reduce as >>= \as' -> f fi as'
+    where reduced f fi as = preGas fi as >>= \(g,as') -> (g,) <$> f fi as'
 
 foldDefs :: Monad m => [m a] -> m [a]
 foldDefs = foldM (\r d -> d >>= \d' -> return (d':r)) []

--- a/src/Pact/Native/Keysets.hs
+++ b/src/Pact/Native/Keysets.hs
@@ -15,6 +15,7 @@ import Control.Lens
 import Control.Monad
 import Data.Default
 import Prelude
+import Data.Semigroup ((<>))
 
 import Pact.Eval
 import Pact.Native.Internal
@@ -37,7 +38,7 @@ keyDefs =
      "Define keyset as NAME with KEYSET. \
      \If keyset NAME already exists, keyset will be enforced before updating to new value.\
      \`$(define-keyset 'admin-keyset (read-keyset \"keyset\"))`"
-    ,defNative "enforce-keyset" enforceKeyset' (funType tTyBool [("keyset-or-name",mkTyVar "k" [tTyString,tTyKeySet])])
+    ,defRNative "enforce-keyset" enforceKeyset' (funType tTyBool [("keyset-or-name",mkTyVar "k" [tTyString,tTyKeySet])])
      "Special form to enforce KEYSET-OR-NAME against message keys before running BODY. \
      \KEYSET-OR-NAME can be a symbol of a keyset name or a keyset object. \
      \`$(with-keyset 'admin-keyset ...)` `$(with-keyset (read-keyset \"keyset\") ...)`"
@@ -67,9 +68,8 @@ defineKeyset fi [TLitString name,TKeySet ks _] = do
 defineKeyset i as = argsError i as
 
 
-enforceKeyset' :: NativeFun e
-enforceKeyset' i [k] = do
-  t <- reduce k
+enforceKeyset' :: RNativeFun e
+enforceKeyset' i [t] = do
   (ksn,ks) <- case t of
     TLitString name -> do
       let ksn = KeySetName name

--- a/src/Pact/Native/Ops.hs
+++ b/src/Pact/Native/Ops.hs
@@ -103,7 +103,7 @@ defLogic n bop shortC = defNative n fun (binTy tTyBool tTyBool tTyBool) $
                  "Boolean logic with short-circuit. `(" <> asString n <> " true false)`"
     where
       fun :: NativeFun e
-      fun i as@[a,b] = reduce a >>= \a' -> case a' of
+      fun i as@[a,b] = gasUnreduced i as $ reduce a >>= \a' -> case a' of
         TLitBool x | x == shortC -> return $ toTerm x
                    | otherwise -> reduce b >>= \b' -> case b' of
                        TLitBool y -> return $ toTerm $ x `bop` y
@@ -128,7 +128,7 @@ liftLogic n bop desc shortCircuit =
     "`(" <> asString n <> " (> 20) (> 10) 15)`")
   where
     r = mkTyVar "r" []
-    fun _ [a@TApp{},b@TApp{},v'] = reduce v' >>= \v -> do
+    fun i as@[a@TApp{},b@TApp{},v'] = gasUnreduced i as $ reduce v' >>= \v -> do
       ar <- apply' a [v]
       case ar of
         TLitBool ab
@@ -142,7 +142,7 @@ liftLogic n bop desc shortCircuit =
     fun i as = argsError' i as
 
 liftNot :: NativeFun e
-liftNot _ [app@TApp{},v'] = reduce v' >>= \v -> apply' app [v] >>= \r -> case r of
+liftNot i as@[app@TApp{},v'] = gasUnreduced i as $ reduce v' >>= \v -> apply' app [v] >>= \r -> case r of
   TLitBool b -> return $ toTerm $ not b
   _ -> delegateError "not?" app r
 liftNot i as = argsError' i as

--- a/src/Pact/Persist.hs
+++ b/src/Pact/Persist.hs
@@ -25,7 +25,7 @@ import Data.Monoid
 import Data.Hashable
 import Data.Typeable
 
-import Pact.Types.Runtime hiding ((<>))
+import Pact.Types.Runtime
 
 type Persist s a = s -> IO (s,a)
 

--- a/src/Pact/PersistPactDb.hs
+++ b/src/Pact/PersistPactDb.hs
@@ -43,7 +43,7 @@ import Data.Monoid
 import qualified Data.Map.Strict as M
 import Data.Maybe
 
-import Pact.Types.Runtime hiding ((<>))
+import Pact.Types.Runtime
 import Pact.Persist as P
 import Pact.Types.Logger
 

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE BangPatterns #-}
@@ -46,8 +47,9 @@ import Statistics.Resampling.Bootstrap
 #endif
 import Pact.Typechecker
 import Pact.Types.Typecheck
-
-import Pact.Native.Internal
+-- intentionally hidden unused functions to prevent lib functions from consuming gas
+import Pact.Native.Internal hiding (defRNative,defGasRNative,defNative)
+import qualified Pact.Native.Internal as Native
 import Pact.Types.Runtime
 import Pact.Eval
 import Pact.Persist.Pure
@@ -64,19 +66,32 @@ initLibState loggers = do
   createSchema m
   return (LibState m Noop def def)
 
+-- | Native function with no gas consumption.
+type ZNativeFun e = FunApp -> [Term Ref] -> Eval e (Term Name)
+
+zeroGas :: Eval e a -> Eval e (Gas,a)
+zeroGas = fmap (0,)
+
+defZNative :: NativeDefName -> ZNativeFun e -> FunTypes (Term Name) -> Text -> NativeDef
+defZNative name fun = Native.defNative name $ \fi as -> zeroGas $ fun fi as
+
+defZRNative :: NativeDefName -> RNativeFun e -> FunTypes (Term Name) -> Text -> NativeDef
+defZRNative name fun = Native.defNative name (reduced fun)
+    where reduced f fi as = mapM reduce as >>= zeroGas . f fi
+
 replDefs :: NativeModule
 replDefs = ("Repl",
      [
-      defRNative "load" load (funType tTyString [("file",tTyString)] <>
+      defZRNative "load" load (funType tTyString [("file",tTyString)] <>
                               funType tTyString [("file",tTyString),("reset",tTyBool)]) $
       "Load and evaluate FILE, resetting repl state beforehand if optional NO-RESET is true. " <>
       "`$(load \"accounts.repl\")`"
-     ,defRNative "env-keys" setsigs (funType tTyString [("keys",TyList tTyString)])
+     ,defZRNative "env-keys" setsigs (funType tTyString [("keys",TyList tTyString)])
       "Set transaction signature KEYS. `(env-keys [\"my-key\" \"admin-key\"])`"
-     ,defRNative "env-data" setmsg (funType tTyString [("json",json)]) $
+     ,defZRNative "env-data" setmsg (funType tTyString [("json",json)]) $
       "Set transaction JSON data, either as encoded string, or as pact types coerced to JSON. " <>
       "`(env-data { \"keyset\": { \"keys\": [\"my-key\" \"admin-key\"], \"pred\": \"keys-any\" } })`"
-     ,defRNative "env-step"
+     ,defZRNative "env-step"
       setstep (funType tTyString [] <>
                funType tTyString [("step-idx",tTyInteger)] <>
                funType tTyString [("step-idx",tTyInteger),("rollback",tTyBool)] <>
@@ -84,43 +99,50 @@ replDefs = ("Repl",
       ("Set pact step state. With no arguments, unset step. With STEP-IDX, set step index to execute. " <>
        "ROLLBACK instructs to execute rollback expression, if any. RESUME sets a value to be read via 'resume'." <>
        "Clears any previous pact execution state. `$(env-step 1)` `$(env-step 0 true)`")
-     ,defRNative "pact-state" pactState (funType (tTyObject TyAny) [])
+     ,defZRNative "pact-state" pactState (funType (tTyObject TyAny) [])
       ("Inspect state from previous pact execution. Returns object with fields " <>
       "'yield': yield result or 'false' if none; 'step': executed step; " <>
       "'executed': indicates if step was skipped because entity did not match. `$(pact-state)`")
-     ,defRNative "env-entity" setentity
+     ,defZRNative "env-entity" setentity
       (funType tTyString [] <> funType tTyString [("entity",tTyString)])
       ("Set environment confidential ENTITY id, or unset with no argument. " <>
       "Clears any previous pact execution state. `$(env-entity \"my-org\")` `$(env-entity)`")
-     ,defRNative "begin-tx" (tx Begin) (funType tTyString [] <>
+     ,defZRNative "begin-tx" (tx Begin) (funType tTyString [] <>
                                         funType tTyString [("name",tTyString)])
        "Begin transaction with optional NAME. `$(begin-tx \"load module\")`"
-     ,defRNative "commit-tx" (tx Commit) (funType tTyString []) "Commit transaction. `$(commit-tx)`"
-     ,defRNative "rollback-tx" (tx Rollback) (funType tTyString []) "Rollback transaction. `$(rollback-tx)`"
-     ,defRNative "expect" expect (funType tTyString [("doc",tTyString),("expected",a),("actual",a)])
+     ,defZRNative "commit-tx" (tx Commit) (funType tTyString []) "Commit transaction. `$(commit-tx)`"
+     ,defZRNative "rollback-tx" (tx Rollback) (funType tTyString []) "Rollback transaction. `$(rollback-tx)`"
+     ,defZRNative "expect" expect (funType tTyString [("doc",tTyString),("expected",a),("actual",a)])
       "Evaluate ACTUAL and verify that it equals EXPECTED. `(expect \"Sanity prevails.\" 4 (+ 2 2))`"
-     ,defNative "expect-failure" expectFail (funType tTyString [("doc",tTyString),("exp",a)]) $
+     ,defZNative "expect-failure" expectFail (funType tTyString [("doc",tTyString),("exp",a)]) $
       "Evaluate EXP and succeed only if it throws an error. " <>
       "`(expect-failure \"Enforce fails on false\" (enforce false \"Expected error\"))`"
-     ,defNative "bench" bench' (funType tTyString [("exprs",TyAny)])
+     ,defZNative "bench" bench' (funType tTyString [("exprs",TyAny)])
       "Benchmark execution of EXPRS. `$(bench (+ 1 2))`"
-     ,defRNative "typecheck" tc (funType tTyString [("module",tTyString)] <>
+     ,defZRNative "typecheck" tc (funType tTyString [("module",tTyString)] <>
                                  funType tTyString [("module",tTyString),("debug",tTyBool)])
        "Typecheck MODULE, optionally enabling DEBUG output."
-
+     ,defZRNative "env-gaslimit" setGasLimit (funType tTyString [("limit",tTyInteger)])
+       "Set environment gas limit to LIMIT"
+     ,defZRNative "env-gas" envGas (funType tTyInteger [] <> funType tTyString [("gas",tTyInteger)])
+       "Query gas state, or set it to GAS"
+     ,defZRNative "env-gasprice" setGasPrice (funType tTyString [("price",tTyDecimal)])
+       "Set environment gas price to PRICE"
+     ,defZRNative "env-gasrate" setGasRate (funType tTyString [("rate",tTyInteger)])
+       "Update gas model to charge constant RATE"
 #if !defined(ghcjs_HOST_OS)
-     ,defRNative "verify" verify (funType tTyString [("module",tTyString)]) "Verify MODULE, checking that all properties hold."
+     ,defZRNative "verify" verify (funType tTyString [("module",tTyString)]) "Verify MODULE, checking that all properties hold."
 #endif
 
-     ,defRNative "json" json' (funType tTyValue [("exp",a)]) $
+     ,defZRNative "json" json' (funType tTyValue [("exp",a)]) $
       "Encode pact expression EXP as a JSON value. " <>
       "This is only needed for tests, as Pact values are automatically represented as JSON in API output. " <>
       "`(json [{ \"name\": \"joe\", \"age\": 10 } {\"name\": \"mary\", \"age\": 25 }])`"
-     ,defRNative "sig-keyset" sigKeyset (funType tTyKeySet [])
+     ,defZRNative "sig-keyset" sigKeyset (funType tTyKeySet [])
      "Convenience to build a keyset from keys present in message signatures, using 'keys-all' as the predicate."
-     ,defRNative "print" print' (funType tTyString [("value",a)])
+     ,defZRNative "print" print' (funType tTyString [("value",a)])
      "Print a string, mainly to format newlines correctly"
-     ,defRNative "env-hash" envHash (funType tTyString [("hash",tTyString)])
+     ,defZRNative "env-hash" envHash (funType tTyString [("hash",tTyString)])
      "Set current transaction hash. HASH must be a valid BLAKE2b 512-bit hash. `(env-hash (hash \"hello\"))`"
      ])
      where
@@ -264,7 +286,7 @@ expect i [TLitString a,b,c] =
   else testFailure i a $ "FAILURE: " <> a <> ": expected " <> pack (show b) <> ", received " <> pack (show c)
 expect i as = argsError i as
 
-expectFail :: NativeFun LibState
+expectFail :: ZNativeFun LibState
 expectFail i as@[a,b] = do
   a' <- reduce a
   case a' of
@@ -276,7 +298,7 @@ expectFail i as@[a,b] = do
     _ -> argsError' i as
 expectFail i as = argsError' i as
 
-bench' :: NativeFun LibState
+bench' :: ZNativeFun LibState
 #if !defined(ghcjs_HOST_OS)
 bench' i as = do
   e <- ask
@@ -361,3 +383,29 @@ envHash i [TLitString s] = case fromText' s of
     setenv eeHash h
     return $ tStr $ "Set tx hash to " <> s
 envHash i as = argsError i as
+
+setGasLimit :: RNativeFun LibState
+setGasLimit _ [TLitInteger l] = do
+  setenv (eeGasEnv . geGasLimit) (fromIntegral l)
+  return $ tStr $ "Set gas limit to " <> tShow l
+setGasLimit i as = argsError i as
+
+envGas :: RNativeFun LibState
+envGas _ [] = use evalGas >>= \g -> return (tLit $ LInteger $ fromIntegral g)
+envGas _ [TLitInteger g] = do
+  evalGas .= fromIntegral g
+  return $ tStr $ "Set gas to " <> tShow g
+envGas i as = argsError i as
+
+setGasPrice :: RNativeFun LibState
+setGasPrice _ [TLiteral (LDecimal d) _] = do
+  setenv (eeGasEnv . geGasPrice) (GasPrice d)
+  return $ tStr $ "Set gas price to " <> tShow d
+setGasPrice i as = argsError i as
+
+setGasRate :: RNativeFun LibState
+setGasRate _ [TLitInteger r] = do
+    setenv (eeGasEnv . geGasModel) (constGasModel $ fromIntegral r)
+    return $ tStr $ "Set gas rate to " <> tShow r
+
+setGasRate i as = argsError i as

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -48,6 +48,7 @@ import Data.Foldable
 import Text.PrettyPrint.ANSI.Leijen hiding ((<$>),(<>))
 import Data.String
 import Data.List
+import Data.Monoid
 
 
 import Pact.Types.Typecheck

--- a/src/Pact/Types/Lang.hs
+++ b/src/Pact/Types/Lang.hs
@@ -81,7 +81,8 @@ module Pact.Types.Lang
    pattern TLitString,pattern TLitInteger,pattern TLitBool,
    tLit,tStr,termEq,abbrev,
    Text,pack,unpack,
-   mDocs,mMetas
+   mDocs,mMetas,
+   Gas(..),GasPrice(..)
    ) where
 
 
@@ -121,6 +122,7 @@ import Data.Maybe
 import qualified Data.HashSet as HS
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as M
+import Data.Int (Int64)
 
 import Data.Serialize (Serialize)
 
@@ -622,9 +624,23 @@ instance Show Ref where
     show (Direct t) = abbrev t
     show (Ref t) = abbrev t
 
+-- | Gas compute cost unit.
+newtype Gas = Gas Int64
+  deriving (Eq,Ord,Num,Real,Integral,Enum)
+instance Show Gas where show (Gas g) = show g
+instance Monoid Gas where
+  mempty = 0
+  (Gas a) `mappend` (Gas b) = Gas $ a + b
+
+
+-- | Price per 'Gas' unit.
+newtype GasPrice = GasPrice Decimal
+  deriving (Eq,Ord,Num,Real,Fractional,RealFrac,NFData,Enum)
+instance Show GasPrice where show (GasPrice p) = show p
+
 data NativeDFun = NativeDFun {
       _nativeName :: NativeDefName,
-      _nativeFun :: forall m . Monad m => FunApp -> [Term Ref] -> m (Term Name)
+      _nativeFun :: forall m . Monad m => FunApp -> [Term Ref] -> m (Gas,Term Name)
     }
 instance Eq NativeDFun where a == b = _nativeName a == _nativeName b
 instance Show NativeDFun where show a = show $ _nativeName a

--- a/src/Pact/Types/Native.hs
+++ b/src/Pact/Types/Native.hs
@@ -34,12 +34,15 @@ isSpecialForm :: NativeDefName -> Maybe SpecialForm
 isSpecialForm = (`M.lookup` sfLookup)
 
 
--- | Native function with un-reduced arguments. Must fire call stack.
-type NativeFun e = FunApp -> [Term Ref] -> Eval e (Term Name)
+-- | Native function with un-reduced arguments that computes gas. Must fire call stack.
+type NativeFun e = FunApp -> [Term Ref] -> Eval e (Gas,Term Name)
 
--- | Native function with pre-reduced arguments, call stack fired.
+-- | Native function with reduced arguments, initial gas pre-compute that computes final gas.
+-- Call stack fired.
+type GasRNativeFun e = Gas -> FunApp -> [Term Name] -> Eval e (Gas,Term Name)
+
+-- | Native function with reduced arguments, final gas pre-compute, call stack fired.
 type RNativeFun e = FunApp -> [Term Name] -> Eval e (Term Name)
-
 
 type NativeDef = (NativeDefName,Term Name)
 type NativeModule = (ModuleName,[NativeDef])

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -29,8 +29,8 @@
 --
 
 module Pact.Types.Runtime
- ( PactError(..),
-   evalError,evalError',failTx,argsError,argsError',throwDbError,throwEither,
+ ( PactError(..),PactErrorType(..),
+   evalError,evalError',failTx,argsError,argsError',throwDbError,throwEither,throwErr,
    Persistable(..),ToPersistable(..),
    ColumnId(..),
    RowKey(..),
@@ -46,19 +46,20 @@ module Pact.Types.Runtime
    ModuleData,
    RefStore(..),rsNatives,rsModules,updateRefStore,
    EntityName(..),
-   EvalEnv(..),eeRefStore,eeMsgSigs,eeMsgBody,eeTxId,eeEntity,eePactStep,eePactDbVar,eePactDb,eePurity,eeHash,
+   EvalEnv(..),eeRefStore,eeMsgSigs,eeMsgBody,eeTxId,eeEntity,eePactStep,eePactDbVar,eePactDb,eePurity,eeHash,eeGasEnv,
    Purity(..),PureNoDb,PureSysRead,EnvNoDb(..),EnvSysRead(..),mkNoDbEnv,mkSysReadEnv,
    StackFrame(..),sfName,sfLoc,sfApp,
    PactExec(..),peStepCount,peYield,peExecuted,pePactId,peStep,
    RefState(..),rsLoaded,rsLoadedModules,rsNew,
-   EvalState(..),evalRefs,evalCallStack,evalPactExec,
+   EvalState(..),evalRefs,evalCallStack,evalPactExec,evalGas,
    Eval(..),runEval,runEval',
    call,method,
    readRow,writeRow,keys,txids,createUserTable,getUserTableInfo,beginTx,commitTx,rollbackTx,getTxLog,
    KeyPredBuiltins(..),keyPredBuiltins,
    module Pact.Types.Lang,
    module Pact.Types.Util,
-   (<>)
+   GasEnv(..),geGasLimit,geGasPrice,geGasModel,
+   ReadValue(..),GasModel(..),GasArgs(..),GasLimit(..)
    ) where
 
 
@@ -90,7 +91,6 @@ import GHC.Generics
 import Data.Decimal
 import Control.Concurrent.MVar
 import Data.Serialize (Serialize)
-import Data.Semigroup
 import Text.Read (readMaybe)
 import Data.Hashable
 
@@ -110,22 +110,37 @@ instance Show StackFrame where
       Just (_,as) -> "(" ++ unpack n ++ concatMap (\a -> " " ++ unpack (asString a)) as ++ ")"
 makeLenses ''StackFrame
 
+newtype GasLimit = GasLimit Word64
+  deriving (Eq,Ord,Num,Real,Integral,Enum)
+instance Show GasLimit where show (GasLimit g) = show g
 
-data PactError =
-    EvalError { peInfo :: Info, peCallStack :: [StackFrame], peText :: Text } |
-    ArgsError { peInfo :: Info, peCallStack :: [StackFrame], peText :: Text } |
-    DbError { peInfo :: Info, peCallStack :: [StackFrame], peText :: Text } |
-    TxFailure { peInfo :: Info, peCallStack :: [StackFrame], peText :: Text } |
-    SyntaxError { peInfo :: Info, peCallStack :: [StackFrame], peText :: Text }
+data PactErrorType
+  = EvalError
+  | ArgsError
+  | DbError
+  | TxFailure
+  | SyntaxError
+  | GasError Gas GasLimit
+
+data PactError = PactError
+  { peType :: PactErrorType
+  , peInfo :: Info
+  , peCallStack :: [StackFrame]
+  , peText :: Text }
 
 instance Exception PactError
 
 instance Show PactError where
-    show (EvalError i _ s) = show i ++ ": Failure: " ++ unpack s
-    show (ArgsError i _ s) = show i ++ ": " ++ show s
-    show (TxFailure i _ s) = show i ++ ": Failure: Tx Failed: " ++ unpack s
-    show (DbError i _ s) = show i ++ ": Failure: Database exception: " ++ unpack s
-    show (SyntaxError i _ s) = show i ++ ": Failure: Syntax error: " ++ unpack s
+    show (PactError t i _ s) = show i ++ ": Failure: " ++ maybe "" (++ ": ") msg ++ unpack s
+      where msg = case t of
+              EvalError -> Nothing
+              ArgsError -> Nothing
+              TxFailure -> Just "Tx Failed"
+              DbError -> Just "Database exception"
+              SyntaxError -> Just "Syntax error"
+              GasError charged limit ->
+                Just $ "GasError (charged: " ++ show charged ++ ", limit: " ++ show limit ++ ")"
+
 
 
 
@@ -426,10 +441,40 @@ data Purity =
 instance Default Purity where def = PImpure
 
 -- | Marker class for 'PNoDb' environments.
-class PureNoDb e where
+class PureNoDb e
 -- | Marker class for 'PSysRead' environments.
 -- SysRead supports pure operations as well.
-class PureNoDb e => PureSysRead e where
+class PureNoDb e => PureSysRead e
+
+-- | DB Read value for per-row gas costing.
+-- Data is included if variable-size.
+data ReadValue
+  = ReadData (Columns Persistable)
+  | ReadKey RowKey
+  | ReadTxId
+
+
+data GasArgs
+  = GPostRead ReadValue
+  | GSelect (Maybe [(Info,ColumnId)]) (Term Ref) (Term Name)
+  | GUnreduced [Term Ref]
+  | GReduced [Term Name]
+  | GUse ModuleName (Maybe Hash)
+  | GModule Module
+  | GModuleMember Module
+  | GUser
+
+
+newtype GasModel = GasModel { runGasModel :: Text -> GasArgs -> Gas }
+instance Show GasModel where show _ = "[GasModel]"
+
+data GasEnv = GasEnv
+  { _geGasLimit :: GasLimit
+  , _geGasPrice :: GasPrice
+  , _geGasModel :: GasModel
+  }
+makeLenses ''GasEnv
+
 
 -- | Interpreter reader environment, parameterized over back-end MVar state type.
 data EvalEnv e = EvalEnv {
@@ -453,6 +498,8 @@ data EvalEnv e = EvalEnv {
     , _eePurity :: Purity
       -- | Transaction hash
     , _eeHash :: Hash
+      -- | Gas Environment
+    , _eeGasEnv :: GasEnv
     } -- deriving (Eq,Show)
 makeLenses ''EvalEnv
 
@@ -485,11 +532,11 @@ data EvalState = EvalState {
     , _evalCallStack :: ![StackFrame]
       -- | Pact execution trace, if any
     , _evalPactExec :: !(Maybe PactExec)
-    }
+      -- | Gas tally
+    , _evalGas :: Gas
+    } deriving (Show)
 makeLenses ''EvalState
-instance Show EvalState where
-    show (EvalState m y _) = "EvalState " ++ show m ++ " " ++ show y
-instance Default EvalState where def = EvalState def def def
+instance Default EvalState where def = EvalState def def def 0
 
 -- | Interpreter monad, parameterized over back-end MVar state type.
 newtype Eval e a =
@@ -510,16 +557,15 @@ runEval' :: EvalState -> EvalEnv e -> Eval e a ->
 runEval' s env act =
   runStateT (catches (Right <$> runReaderT (unEval act) env)
               [Handler (\(e :: PactError) -> return $ Left e)
-              ,Handler (\(e :: SomeException) -> return $ Left . EvalError def def . pack . show $ e)
+              ,Handler (\(e :: SomeException) -> return $ Left . PactError EvalError def def . pack . show $ e)
               ]) s
 
 
-
 -- | Bracket interpreter action pushing and popping frame on call stack.
-call :: StackFrame -> Eval e a -> Eval e a
+call :: StackFrame -> Eval e (Gas,a) -> Eval e a
 call s act = do
   evalCallStack %= (s:)
-  r <- act
+  (_gas,r) <- act -- TODO opportunity for per-call gas logging here
   evalCallStack %= \st -> case st of (_:as) -> as; [] -> []
   return r
 {-# INLINE call #-}
@@ -594,8 +640,8 @@ throwArgsError FunApp {..} args s = throwErr ArgsError _faInfo $ pack $
   unpack s ++ ", received [" ++ intercalate "," (map abbrev args) ++ "] for " ++
             showFunTypes _faTypes
 
-throwErr :: (Info -> [StackFrame] -> Text -> PactError) -> Info -> Text -> Eval e a
-throwErr ctor i err = get >>= \s -> throwM (ctor i (_evalCallStack s) err)
+throwErr :: PactErrorType -> Info -> Text -> Eval e a
+throwErr ctor i err = get >>= \s -> throwM (PactError ctor i (_evalCallStack s) err)
 
 evalError :: Info -> String -> Eval e a
 evalError i = throwErr EvalError i . pack
@@ -607,7 +653,7 @@ failTx :: Info -> String -> Eval e a
 failTx i = throwErr TxFailure i . pack
 
 throwDbError :: MonadThrow m => String -> m a
-throwDbError s = throwM $ DbError def def (pack s)
+throwDbError s = throwM $ PactError DbError def def (pack s)
 
 -- | Throw an error coming from an Except/Either context.
 throwEither :: (MonadThrow m,Exception e) => Either e a -> m a
@@ -632,7 +678,7 @@ instance PureSysRead (EnvSysRead e)
 instance PureNoDb (EnvSysRead e)
 
 diePure :: Method e a
-diePure _ = throwM $ EvalError def def "Illegal database access in pure context"
+diePure _ = throwM $ PactError EvalError def def "Illegal database access in pure context"
 
 -- | Construct a delegate pure eval environment.
 mkPureEnv :: (EvalEnv e -> f) -> Purity ->
@@ -663,6 +709,8 @@ mkPureEnv holder purity readRowImpl env@EvalEnv{..} = do
     }
     purity
     _eeHash
+    _eeGasEnv
+
 
 mkNoDbEnv :: EvalEnv e -> Eval e (EvalEnv (EnvNoDb e))
 mkNoDbEnv = mkPureEnv EnvNoDb PNoDb (\_ _ -> diePure)

--- a/tests/TypecheckSpec.hs
+++ b/tests/TypecheckSpec.hs
@@ -14,6 +14,7 @@ import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import Control.Monad
 import Data.Foldable
 import qualified Data.Text as T
+import Data.Monoid
 
 spec :: Spec
 spec = do

--- a/tests/pact/gas.repl
+++ b/tests/pact/gas.repl
@@ -1,0 +1,4 @@
+(env-gaslimit 10)
+(env-gasrate 1)
+(map (+ 1) (make-list 8 8))
+(expect-failure "out of gas" (+ 1 2))


### PR DESCRIPTION
For #87. A detailed gasmodel for public is not implemented. 

Notes:
 1. Gas costing on natives is enforced by the `NativeDef` signature as a return value, with support for operations to compute and accumulate gas values. However this return value is ignored currently; the gas calculation itself is by side-effect in order to eagerly abort on out-of-gas. This value could nonetheless be useful in the `call` function to trace per-operation gas usage (ie, find out what `with-read` cost without including the cost of the body functions).
2. The provided `constGasModel` is suitable for private blockchain to enforce an instruction limit, as `gas.repl` tests.
3. A full public model would need to match on string names and `GasArgs` constructors, and as such there's no typechecking for totality. Making a native def name Enum seemed too much but could still be considered; however that means things like the functions in Lib would need to be added too, and makes Pact-the-library less extensible. The expression problem bites again.
4. Un-costed things include literal evaluation, binding forms, entering scopes. Things like attacks using super-long literal strings or lists bear consideration.
5. The general model is to cost eagerly, ie "top-down", before evaluating arguments.
