### PR TITLE
Accept keyset name as string

### DIFF
--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -150,7 +150,8 @@ doModule (EAtom n Nothing Nothing _ : ESymbol k _ : es) li ai =
 
 doModule _ li _ = syntaxError li "Invalid module definition"
 
-handleModule (EAtom n Nothing Nothing _:ESymbol k _:es) li ai =
+handleModule :: Text -> Text -> [Exp] -> Info -> Info -> Compile (Term Name)
+handleModule n k es li ai =  
   case es of
     MetaBodyExp meta body -> mkModule body =<< meta
     _ -> syntaxError ai "Empty module"

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -142,12 +142,10 @@ doMetaBody exp  = case exp of
   body              -> Just (pure Nothing, body)
 
 doModule :: [Exp] -> Info -> Info -> Compile (Term Name)
-doModule (EAtom n Nothing Nothing _ : ELiteral (LString k) _ : es) li ai =
+doModule (EAtom n Nothing Nothing _:ESymbol k _:es) li ai =
   handleModule n k es li ai 
-
-doModule (EAtom n Nothing Nothing _ : ESymbol k _ : es) li ai =
+doModule (EAtom n Nothing Nothing _:ELiteral (LString k) _:es) li ai =
   handleModule n k es li ai 
-
 doModule _ li _ = syntaxError li "Invalid module definition"
 
 handleModule :: Text -> Text -> [Exp] -> Info -> Info -> Compile (Term Name)

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -142,7 +142,15 @@ doMetaBody exp  = case exp of
   body              -> Just (pure Nothing, body)
 
 doModule :: [Exp] -> Info -> Info -> Compile (Term Name)
-doModule (EAtom n Nothing Nothing _:ESymbol k _:es) li ai =
+doModule (EAtom n Nothing Nothing _ : ELiteral (LString k) _ : es) li ai =
+  handleModule n k es li ai 
+
+doModule (EAtom n Nothing Nothing _ : ESymbol k _ : es) li ai =
+  handleModule n k es li ai 
+
+doModule _ li _ = syntaxError li "Invalid module definition"
+
+handleModule (EAtom n Nothing Nothing _:ESymbol k _:es) li ai =
   case es of
     MetaBodyExp meta body -> mkModule body =<< meta
     _ -> syntaxError ai "Empty module"
@@ -176,7 +184,6 @@ doModule (EAtom n Nothing Nothing _:ESymbol k _:es) li ai =
               (Module modName (KeySetName k) docs code modHash blessed)
               (abstract (const Nothing) (TList bd TyAny li)) li
 
-doModule _ li _ = syntaxError li "Invalid module definition"
 
 currentModule :: Info -> Compile (ModuleName,Hash)
 currentModule i = use csModule >>= \m -> case m of

--- a/tests/pact/keysets.repl
+++ b/tests/pact/keysets.repl
@@ -1,9 +1,9 @@
 
 (begin-tx)
 (env-data { "kall": ["a" "b" "c"] })
-(define-keyset 'k (sig-keyset))
+(define-keyset "k" (sig-keyset))
 (define-keyset 'kall (read-keyset "kall"))
-(module keysets 'k
+(module keysets "k"
   (defschema sch value:bool)
   (deftable tbl:{sch})
   (defun keys-3 (count matched) (>= matched 3))


### PR DESCRIPTION
Added a new pattern match to accept keyset name as string in Module definition.