### PR TITLE
Linearized execution traces in model reports

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -195,6 +195,7 @@ test-suite hspec
   build-depends:
                 base
               , hspec
+              , HUnit
               , pact
               , aeson
               , containers

--- a/pact.cabal
+++ b/pact.cabal
@@ -106,6 +106,7 @@ library
 
   build-depends:       Decimal >= 0.4.2 && < 0.6
                      , aeson >= 0.11.3.0 && < 1.4
+                     , algebraic-graphs >= 0.1.1 && < 0.2
                      , ansi-wl-pprint >= 0.6.7.3 && < 0.7
                      , attoparsec >= 0.13.0.2 && < 0.14
                      , base >=4.9.0.0 && < 4.12

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -243,12 +243,12 @@ verifyFunctionInvariants'
   -> [AST Node]
   -> IO (Either CheckFailure (TableMap [CheckResult]))
 verifyFunctionInvariants' funInfo tables pactArgs body = runExceptT $ do
-    (args, tm, tagAllocs) <- hoist generalize $
+    (args, tm, events) <- hoist generalize $
       withExcept translateToCheckFailure $ runTranslation funInfo pactArgs body
 
     ExceptT $ catchingExceptions $ runSymbolic $ runExceptT $ do
       modelArgs' <- lift $ allocArgs args
-      tags <- lift $ allocModelTags (Located funInfo tm) tagAllocs
+      tags <- lift $ allocModelTags (Located funInfo tm) events
       resultsTable <- withExceptT analyzeToCheckFailure $
         runInvariantAnalysis tables (analysisArgs modelArgs') tm tags funInfo
 
@@ -294,12 +294,12 @@ verifyFunctionProperty
   -> IO (Either CheckFailure CheckSuccess)
 verifyFunctionProperty funInfo tables pactArgs body (Located propInfo check) =
     runExceptT $ do
-      (args, tm, tagAllocs) <- hoist generalize $
+      (args, tm, events) <- hoist generalize $
         withExcept translateToCheckFailure $
           runTranslation funInfo pactArgs body
       ExceptT $ catchingExceptions $ runSymbolic $ runExceptT $ do
         modelArgs' <- lift $ allocArgs args
-        tags <- lift $ allocModelTags (Located funInfo tm) tagAllocs
+        tags <- lift $ allocModelTags (Located funInfo tm) events
         AnalysisResult prop ksProvs <- withExceptT analyzeToCheckFailure $
           runPropertyAnalysis check tables (analysisArgs modelArgs') tm tags funInfo
         void $ lift $ SBV.output prop

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -14,6 +14,7 @@ module Pact.Analyze.Check
   , describeCheckResult
   , describeParseFailure
   , describeVerificationWarnings
+  , falsifyingModel
   , showModel
   , CheckFailure(..)
   , CheckFailureNoLoc(..)
@@ -173,6 +174,10 @@ describeCheckFailure (CheckFailure info failure) =
 
 describeCheckResult :: CheckResult -> Text
 describeCheckResult = either describeCheckFailure describeCheckSuccess
+
+falsifyingModel :: CheckFailure -> Maybe (Model 'Concrete)
+falsifyingModel (CheckFailure _ (SmtFailure (Invalid m))) = Just m
+falsifyingModel _ = Nothing
 
 -- TODO: don't throw out these Infos
 translateToCheckFailure :: TranslateFailure -> CheckFailure

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -243,12 +243,12 @@ verifyFunctionInvariants'
   -> [AST Node]
   -> IO (Either CheckFailure (TableMap [CheckResult]))
 verifyFunctionInvariants' funInfo tables pactArgs body = runExceptT $ do
-    (args, tm, events) <- hoist generalize $
+    (args, tm, graph) <- hoist generalize $
       withExcept translateToCheckFailure $ runTranslation funInfo pactArgs body
 
     ExceptT $ catchingExceptions $ runSymbolic $ runExceptT $ do
       modelArgs' <- lift $ allocArgs args
-      tags <- lift $ allocModelTags (Located funInfo tm) events
+      tags <- lift $ allocModelTags (Located funInfo tm) graph
       resultsTable <- withExceptT analyzeToCheckFailure $
         runInvariantAnalysis tables (analysisArgs modelArgs') tm tags funInfo
 
@@ -294,12 +294,12 @@ verifyFunctionProperty
   -> IO (Either CheckFailure CheckSuccess)
 verifyFunctionProperty funInfo tables pactArgs body (Located propInfo check) =
     runExceptT $ do
-      (args, tm, events) <- hoist generalize $
+      (args, tm, graph) <- hoist generalize $
         withExcept translateToCheckFailure $
           runTranslation funInfo pactArgs body
       ExceptT $ catchingExceptions $ runSymbolic $ runExceptT $ do
         modelArgs' <- lift $ allocArgs args
-        tags <- lift $ allocModelTags (Located funInfo tm) events
+        tags <- lift $ allocModelTags (Located funInfo tm) graph
         AnalysisResult prop ksProvs <- withExceptT analyzeToCheckFailure $
           runPropertyAnalysis check tables (analysisArgs modelArgs') tm tags funInfo
         void $ lift $ SBV.output prop

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -261,7 +261,7 @@ verifyFunctionInvariants' funInfo tables pactArgs body = runExceptT $ do
             queryResult <- runExceptT $
               inNewAssertionStack $ do
                 void $ lift $ SBV.constrain $ SBV.bnot prop
-                resultQuery goal $ Model modelArgs' tags ksProvs
+                resultQuery goal $ Model modelArgs' tags ksProvs graph
 
             -- Either SmtFailure CheckSuccess -> CheckResult
             pure $ case queryResult of
@@ -305,7 +305,7 @@ verifyFunctionProperty funInfo tables pactArgs body (Located propInfo check) =
           runPropertyAnalysis check tables (analysisArgs modelArgs') tm tags funInfo
         void $ lift $ SBV.output prop
         hoist SBV.query $ withExceptT (smtToCheckFailure propInfo) $
-          resultQuery goal $ Model modelArgs' tags ksProvs
+          resultQuery goal $ Model modelArgs' tags ksProvs graph
 
   where
     goal :: Goal

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns        #-}
@@ -88,14 +89,14 @@ describeVerificationWarnings (VerificationWarnings dups) = case dups of
   _  -> "Warning: duplicated property definitions for " <> T.intercalate ", " dups
 
 data CheckSuccess
-  = SatisfiedProperty Model
+  = SatisfiedProperty (Model 'Concrete)
   | ProvedTheorem
   deriving (Eq, Show)
 
 type ParseFailure = (Exp, String)
 
 data SmtFailure
-  = Invalid Model
+  = Invalid (Model 'Concrete)
   | Unsatisfiable
   | Unknown SBV.SMTReasonUnknown
   | UnexpectedFailure SBV.SMTException
@@ -190,8 +191,8 @@ smtToCheckFailure info = CheckFailure info . SmtFailure
 --
 
 resultQuery
-  :: Goal                                      -- ^ are we in sat or valid mode?
-  -> Model                                     -- ^ unsaturated/symbolic model
+  :: Goal
+  -> Model 'Symbolic
   -> ExceptT SmtFailure SBV.Query CheckSuccess
 resultQuery goal model0 = do
   satResult <- lift SBV.checkSat

--- a/src/Pact/Analyze/Eval.hs
+++ b/src/Pact/Analyze/Eval.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Pact.Analyze.Eval
   ( module Pact.Analyze.Eval.Invariant
   , module Pact.Analyze.Eval.Numerical
@@ -81,7 +83,7 @@ runAnalysis'
   -> [Table]
   -> Map VarId AVal
   -> ETerm
-  -> ModelTags
+  -> ModelTags 'Symbolic
   -> Info
   -> ExceptT AnalyzeFailure Symbolic (f AnalysisResult)
 runAnalysis' query tables args tm tags info = do
@@ -109,7 +111,7 @@ runPropertyAnalysis
   -> [Table]
   -> Map VarId AVal
   -> ETerm
-  -> ModelTags
+  -> ModelTags 'Symbolic
   -> Info
   -> ExceptT AnalyzeFailure Symbolic AnalysisResult
 runPropertyAnalysis check tables args tm tags info =
@@ -120,7 +122,7 @@ runInvariantAnalysis
   :: [Table]
   -> Map VarId AVal
   -> ETerm
-  -> ModelTags
+  -> ModelTags 'Symbolic
   -> Info
   -> ExceptT AnalyzeFailure Symbolic (TableMap [Located AnalysisResult])
 runInvariantAnalysis tables args tm tags info =

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -257,7 +257,7 @@ evalTermO = \case
 
   Sequence eterm objT -> evalETerm eterm *> evalTermO objT
 
-  IfThenElse cond then' else' -> do
+  IfThenElse cond (_thenCp, then') (_elseCp, else') _postCp -> do
     testPasses <- evalTerm cond
     case unliteralS testPasses of
       Just True  -> evalTermO then'
@@ -288,7 +288,7 @@ evalTerm :: (Show a, SymWord a) => Term a -> Analyze (S a)
 evalTerm = \case
   CoreTerm a -> evalCore a
 
-  IfThenElse cond then' else' -> do
+  IfThenElse cond (_thenCp, then') (_elseCp, else') _postCp -> do
     testPasses <- evalTerm cond
     iteS testPasses (evalTerm then') (evalTerm else')
 

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -257,7 +257,7 @@ evalTermO = \case
 
   Sequence eterm objT -> evalETerm eterm *> evalTermO objT
 
-  IfThenElse cond (_thenCp, then') (_elseCp, else') -> do
+  IfThenElse cond (_thenPath, then') (_elsePath, else') -> do
     testPasses <- evalTerm cond
     case unliteralS testPasses of
       Just True  -> evalTermO then'
@@ -288,7 +288,7 @@ evalTerm :: (Show a, SymWord a) => Term a -> Analyze (S a)
 evalTerm = \case
   CoreTerm a -> evalCore a
 
-  IfThenElse cond (_thenCp, then') (_elseCp, else') -> do
+  IfThenElse cond (_thenPath, then') (_elsePath, else') -> do
     testPasses <- evalTerm cond
     iteS testPasses (evalTerm then') (evalTerm else')
 

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -257,7 +257,7 @@ evalTermO = \case
 
   Sequence eterm objT -> evalETerm eterm *> evalTermO objT
 
-  IfThenElse cond (_thenCp, then') (_elseCp, else') _postCp -> do
+  IfThenElse cond (_thenCp, then') (_elseCp, else') -> do
     testPasses <- evalTerm cond
     case unliteralS testPasses of
       Just True  -> evalTermO then'
@@ -288,7 +288,7 @@ evalTerm :: (Show a, SymWord a) => Term a -> Analyze (S a)
 evalTerm = \case
   CoreTerm a -> evalCore a
 
-  IfThenElse cond (_thenCp, then') (_elseCp, else') _postCp -> do
+  IfThenElse cond (_thenCp, then') (_elseCp, else') -> do
     testPasses <- evalTerm cond
     iteS testPasses (evalTerm then') (evalTerm else')
 

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE OverloadedStrings          #-}
@@ -109,7 +110,7 @@ instance (Mergeable a) => Mergeable (Analyze a) where
              )
 
 tagAccessKey
-  :: Lens' ModelTags (Map TagId (Located (S RowKey, Object)))
+  :: Lens' (ModelTags 'Symbolic) (Map TagId (Located (S RowKey, Object)))
   -> TagId
   -> S RowKey
   -> Analyze ()
@@ -124,7 +125,7 @@ tagAccessKey lens' tid srk = do
 -- | "Tag" an uninterpreted read value with value from our Model that was
 -- allocated in Symbolic.
 tagAccessCell
-  :: Lens' ModelTags (Map TagId (Located (S RowKey, Object)))
+  :: Lens' (ModelTags 'Symbolic) (Map TagId (Located (S RowKey, Object)))
   -> TagId
   -> Text
   -> AVal

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -322,6 +322,9 @@ evalTerm = \case
     succeeds %= (&&& cond')
     pure true
 
+  -- TODO: check that each cond is pure. checking that @Enforce@ terms are pure
+  -- does *NOT* suffice; we can have arbitrary expressions in an @enforce-one@
+  -- list.
   EnforceOne conds -> do
     initSucceeds <- use succeeds
 

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -108,6 +108,12 @@ instance (Mergeable a) => Mergeable (Analyze a) where
              , ()
              )
 
+--
+-- NOTE: for these tagging functions, at the moment we allow a "partial" model.
+--       we could also decide to 'throwError'; right now we simply don't tag in
+--       these cases where a tag is not found.
+--
+
 tagAccessKey
   :: Lens' (ModelTags 'Symbolic) (Map TagId (Located (S RowKey, Object)))
   -> TagId
@@ -116,8 +122,6 @@ tagAccessKey
 tagAccessKey lens' tid srk = do
   mTup <- preview $ aeModelTags.lens'.at tid._Just.located._1
   case mTup of
-    -- NOTE: ATM we allow a "partial" model. we could also decide to
-    -- 'throwError' here; we simply don't tag.
     Nothing     -> pure ()
     Just tagSrk -> addConstraint $ sansProv $ srk .== tagSrk
 
@@ -133,8 +137,6 @@ tagAccessCell lens' tid fieldName av = do
   mTag <- preview $
     aeModelTags.lens'.at tid._Just.located._2.objFields.at fieldName._Just._2
   case mTag of
-    -- NOTE: ATM we allow a "partial" model. we could also decide to
-    -- 'throwError' here; we simply don't tag.
     Nothing    -> pure ()
     Just tagAv -> addConstraint $ sansProv $ av .== tagAv
 
@@ -142,8 +144,6 @@ tagEnforceTree :: TagId -> S Bool -> Analyze ()
 tagEnforceTree tid sb = do
   mTag <- preview $ aeModelTags.mtEnforceTrees.at tid._Just.located
   case mTag of
-    -- NOTE: ATM we allow a "partial" model. we could also decide to
-    -- 'throwError' here; we simply don't tag.
     Nothing  -> pure ()
     Just sbv -> addConstraint $ sansProv $ sbv .== _sSbv sb
 
@@ -151,8 +151,6 @@ tagAssert :: TagId -> S Bool -> Analyze ()
 tagAssert tid sb = do
   mTag <- preview $ aeModelTags.mtAsserts.at tid._Just.located
   case mTag of
-    -- NOTE: ATM we allow a "partial" model. we could also decide to
-    -- 'throwError' here; we simply don't tag.
     Nothing  -> pure ()
     Just sbv -> addConstraint $ sansProv $ sbv .== _sSbv sb
 
@@ -162,8 +160,6 @@ tagAuth :: TagId -> S KeySet -> S Bool -> Analyze ()
 tagAuth tid sKs sb = do
   mTup <- preview $ aeModelTags.mtAuths.at tid._Just.located
   case mTup of
-    -- NOTE: ATM we allow a "partial" model. we could also decide to
-    -- 'throwError' here; we simply don't tag.
     Nothing  -> pure ()
     Just (ksTag, sbv) -> do
       addConstraint $ sansProv $ ksTag .== sKs
@@ -174,8 +170,6 @@ tagSubpathStart :: TagId -> Analyze ()
 tagSubpathStart tid = do
   mTag <- preview $ aeModelTags.mtPaths.at tid._Just
   case mTag of
-    -- NOTE: ATM we allow a "partial" model. we could also decide to
-    -- 'throwError' here; we simply don't tag.
     Nothing  -> pure ()
     Just sbv -> do
       sb <- use purelyReachable
@@ -190,8 +184,6 @@ tagVarBinding :: VarId -> AVal -> Analyze ()
 tagVarBinding vid av = do
   mTag <- preview $ aeModelTags.mtVars.at vid._Just.located._2._2
   case mTag of
-    -- NOTE: ATM we allow a "partial" model. we could also decide to
-    -- 'throwError' here; we simply don't tag.
     Nothing    -> pure ()
     Just tagAv -> addConstraint $ sansProv $ av .== tagAv
 

--- a/src/Pact/Analyze/Model.hs
+++ b/src/Pact/Analyze/Model.hs
@@ -61,6 +61,7 @@ allocModelTags locatedTm graph = ModelTags
     <*> allocWrites
     <*> allocAuths
     <*> allocResult
+    <*> allocCheckpoints
 
   where
     -- For the purposes of symbolic value allocation, we just grab all of the
@@ -105,10 +106,15 @@ allocModelTags locatedTm graph = ModelTags
       EObject sch _ ->
         (EObjectTy sch,) . AnObj <$> allocSchema sch
 
+    allocCheckpoints :: Symbolic (Map TagId (SBV Bool))
+    allocCheckpoints = fmap Map.fromList $
+      for (toListOf (traverse._TraceCheckpoint) events) $ \tid ->
+        (tid,) <$> alloc
+
 -- NOTE: we indent the entire model two spaces so that the atom linter will
 -- treat it as one message.
 showModel :: Model -> Text
-showModel (Model args (ModelTags vars reads' writes auths res) ksProvs) =
+showModel (Model args (ModelTags vars reads' writes auths res _cps) ksProvs) =
     T.intercalate "\n" $ T.intercalate "\n" . map indent <$>
       [ ["Arguments:"]
       , indent <$> fmapToList showVar args

--- a/src/Pact/Analyze/Model.hs
+++ b/src/Pact/Analyze/Model.hs
@@ -15,14 +15,12 @@ module Pact.Analyze.Model
   , allocModelTags
   , linearizedTrace
   , saturateModel
-  , showEntireModel
   , showModel
   ) where
 
 import           Control.Lens         (Lens', Prism', Traversal', at, ifoldr,
-                                       imap, set, to, toListOf, traverseOf,
-                                       traversed, (<&>), (?~), (^.), (^?), _1,
-                                       _2, _Just)
+                                       to, toListOf, traverseOf, traversed,
+                                       (<&>), (?~), (^.), (^?), _1, _2, _Just)
 import           Control.Monad        (when, (>=>))
 import           Data.Bool            (bool)
 import qualified Data.Foldable        as Foldable
@@ -69,28 +67,16 @@ allocModelTags locatedTm graph = ModelTags
     <$> allocVars
     <*> allocReads
     <*> allocWrites
-    <*> allocEnforceTrees
     <*> allocAsserts
     <*> allocAuths
     <*> allocResult
     <*> allocPaths
 
   where
-    events :: [TraceEvent]
-    events = flatten =<< toplevelEvents
-
-    flatten :: TraceEvent -> [TraceEvent]
-    flatten e@(TraceEnforceTree _) = withoutChildren : flattenedChildren
-      where
-        withoutChildren   = set treeCases mempty e
-        childEvents       = toListOf (treeCases.caseEvents) e
-        flattenedChildren = flatten =<< childEvents
-    flatten e = [e]
-
     -- For the purposes of symbolic value allocation, we just grab all of the
     -- events from the graph indiscriminately:
-    toplevelEvents :: [TraceEvent]
-    toplevelEvents = toListOf (egEdgeEvents.traverse.traverse) graph
+    events :: [TraceEvent]
+    events = toListOf (egEdgeEvents.traverse.traverse) graph
 
     allocVars :: Symbolic (Map VarId (Located (Text, TVal)))
     allocVars = fmap Map.fromList $
@@ -116,19 +102,14 @@ allocModelTags locatedTm graph = ModelTags
     allocWrites :: Symbolic (Map TagId (Located (S RowKey, Object)))
     allocWrites = allocAccesses _TraceWrite
 
-    allocEnforceTrees :: Symbolic (Map TagId (Located (SBV Bool)))
-    allocEnforceTrees = fmap Map.fromList $
-      for (toListOf (traverse._TraceEnforceTree) events) $ \(Located info (tid, _)) ->
-        (tid,) . Located info <$> alloc
-
     allocAsserts :: Symbolic (Map TagId (Located (SBV Bool)))
     allocAsserts = fmap Map.fromList $
-      for (toListOf (traverse._TraceAssert) events) $ \(Located info tid) ->
+      for (toListOf (traverse._TraceAssert._2) events) $ \(Located info tid) ->
         (tid,) . Located info <$> alloc
 
     allocAuths :: Symbolic (Map TagId (Located (S KeySet, SBV Bool)))
     allocAuths = fmap Map.fromList $
-      for (toListOf (traverse._TraceAuth) events) $ \(Located info tid) ->
+      for (toListOf (traverse._TraceAuth._2) events) $ \(Located info tid) ->
         (tid,) . Located info <$> ((,) <$> allocS <*> alloc)
 
     allocResult :: Symbolic (Located TVal)
@@ -154,51 +135,62 @@ allocModelTags locatedTm graph = ModelTags
           pure (tid, sbool)
 
 linearizedTrace :: Model 'Concrete -> ExecutionTrace
-linearizedTrace model = foldr
-    (\event (ExecutionTrace futureEvents mRes) ->
-      let continue = ExecutionTrace (event : futureEvents) mRes
-          stop     = ExecutionTrace [event] Nothing
-
-          --
-          -- TODO: we need to handle enforce-one, and nested enforce-ones
-          --
-          handleEnforce
-            :: Traversal' (ModelTags 'Concrete) (SBV Bool)
-            -> ExecutionTrace
-          handleEnforce tagsBool =
-            let mPassesEnforce =
-                  model ^? modelTags.tagsBool.to (SBV.unliteral)._Just
-            in case mPassesEnforce of
-                 Nothing ->
-                   error "impossible: missing enforce tag, or symbolic value"
-                 Just False ->
-                   stop
-                 Just True ->
-                   continue
-      in case event of
-           TraceEnforceTree (_located -> (tid, _subEvents)) ->
-             --
-             -- TODO: add stopping early amongst child events, for any depth:
-             --
-             handleEnforce $ mtEnforceTrees.at tid._Just.located
-           TraceAssert (_located -> tid) ->
-             handleEnforce $ mtAsserts.at tid._Just.located
-           TraceAuth (_located -> tid) ->
-             handleEnforce $ mtAuths.at tid._Just.located._2
-           _ ->
-             continue)
-    (ExecutionTrace [] (Just $ model ^. modelTags.mtResult.located))
-    fullTrace
+linearizedTrace model = mkTrace traceEvents
 
   where
+    mkTrace :: [TraceEvent] -> ExecutionTrace
+    mkTrace = foldr
+      (\event (ExecutionTrace futureEvents mRes) ->
+        let continue = ExecutionTrace (event : futureEvents) mRes
+            stop     = ExecutionTrace [event] Nothing
+
+            handleEnforce
+              :: Recoverability
+              -> Traversal' (ModelTags 'Concrete) (SBV Bool)
+              -> ExecutionTrace
+            handleEnforce recov tagsBool =
+              let mPassesEnforce =
+                    model ^? modelTags.tagsBool.to (SBV.unliteral)._Just
+                 in case mPassesEnforce of
+                   Nothing ->
+                     error "impossible: missing enforce tag, or symbolic value"
+                   Just False ->
+                     case recov of
+                       Recoverable _resumptionPath ->
+                         --
+                         -- TODO: instead of just continuing, we should
+                         -- actually skip future events (in the same case)
+                         -- until we hit this "resumption path".  this would
+                         -- produce better output for cases with any events
+                         -- after a failed enforce:
+                         --
+                         --   (enforce-one
+                         --     [(let ((x (enforce false)))
+                         --        (enforce true)) ; <- we should not see this
+                         --      true
+                         --      ])
+                         --
+                         continue
+                       Unrecoverable ->
+                         stop
+                   Just True ->
+                     continue
+        in case event of
+             TraceAssert recov (_located -> tid) ->
+               handleEnforce recov $ mtAsserts.at tid._Just.located
+             TraceAuth recov (_located -> tid) ->
+               handleEnforce recov $ mtAuths.at tid._Just.located._2
+             _ ->
+               continue)
+      (ExecutionTrace [] (Just $ model ^. modelTags.mtResult.located))
+
     -- NOTE: 'Map' is ordered, so our @(Vertex, Vertex)@ 'Edge' representation
     -- over monotonically increasing 'Vertex's across the execution graph
     -- yields a topological sort. Additionally the 'TraceEvent's on each 'Edge'
     -- are ordered, so we now have a linear trace of events. But we still have
-    -- the possibility of 'TraceAssert', 'TraceAuth', and 'TraceEnforceTree'
-    -- events resulting in transaction failure.
-    fullTrace :: [TraceEvent]
-    fullTrace = concat $ restrictKeys edgeEvents reachableEdges
+    -- the possibility of 'TraceAssert' and 'TraceAuth' affecting control flow.
+    traceEvents :: [TraceEvent]
+    traceEvents = concat $ restrictKeys edgeEvents reachableEdges
 
     -- TODO: use Map.restrictKeys once using containers >= 0.5.8
     restrictKeys :: Ord k => Map k a -> Set k -> Map k a
@@ -217,7 +209,8 @@ linearizedTrace model = foldr
     reachablePaths :: Set TagId
     reachablePaths = Map.foldlWithKey'
       (\paths path sbool -> maybe
-        (error $ "impossible: found symbolic value in concrete model for path " <> show path)
+        (error $ "impossible: found symbolic value in concrete model for path "
+              <> show path)
         (bool paths (Set.insert path paths))
         (SBV.unliteral sbool))
       Set.empty
@@ -252,48 +245,52 @@ showObjMapping key val = key <> ": " <> showTVal val
 showVar :: Located (Text, TVal) -> Text
 showVar (Located _ (nm, tval)) = nm <> " := " <> showTVal tval
 
-showAccess :: Located (S RowKey, Object) -> Text
-showAccess (Located _ (srk, obj)) = showS srk <> " => " <> showObject obj
-
 --
 -- TODO: this should display the table name
 --
 showRead :: Located (S RowKey, Object) -> Text
-showRead (Located _ (srk, obj)) = "read " <> showObject obj <> " for key " <> showS srk
+showRead (Located _ (srk, obj)) = "read " <> showObject obj
+                               <> " for key " <> showS srk
 
 --
 -- TODO: this should display the table name
 --
 showWrite :: Located (S RowKey, Object) -> Text
-showWrite (Located _ (srk, obj)) = "write " <> showObject obj <> " to key " <> showS srk
+showWrite (Located _ (srk, obj)) = "write " <> showObject obj
+                                <> " to key " <> showS srk
 
 showKsn :: S KeySetName -> Text
 showKsn sKsn = case SBV.unliteral (_sSbv sKsn) of
   Nothing               -> "[unknown]"
   Just (KeySetName ksn) -> "'" <> ksn
 
-showEnforceOne :: Located (SBV Bool) -> Text
-showEnforceOne (_located -> sbool) = case SBV.unliteral sbool of
-  Nothing    -> "[ERROR:symbolic enforce-one]"
-  Just True  -> "satisfied one of the following:"
-  Just False -> "failed to satisfy one of the following:"
+showFailure :: Recoverability -> Text
+showFailure = \case
+  Recoverable _ -> "recovered from failure"
+  Unrecoverable -> "failed"
 
-showAssert :: Located (SBV Bool) -> Text
-showAssert (Located (Pact.Info mInfo) lsb) = case SBV.unliteral lsb of
+showAssert :: Recoverability -> Located (SBV Bool) -> Text
+showAssert recov (Located (Pact.Info mInfo) lsb) = case SBV.unliteral lsb of
     Nothing    -> "[ERROR:symbolic assert]"
     Just True  -> "satisfied assertion" <> context
-    Just False -> "failed to satisfy assertion" <> context
+    Just False -> showFailure recov <> " to satisfy assertion" <> context
 
   where
     context = maybe "" (\(Pact.Code code, _) -> ": " <> code) mInfo
 
-showAuth :: Maybe Provenance -> Located (S KeySet, SBV Bool) -> Text
-showAuth mProv (_located -> (srk, sbool)) = status <> " " <> ksDescription
+showAuth
+  :: Recoverability
+  -> Maybe Provenance
+  -> Located (S KeySet, SBV Bool)
+  -> Text
+showAuth recov mProv (_located -> (srk, sbool)) =
+  status <> " " <> ksDescription
+
   where
     status = case SBV.unliteral sbool of
       Nothing    -> "[ERROR:symbolic auth]"
       Just True  -> "satisfied"
-      Just False -> "failed to satisfy"
+      Just False -> showFailure recov <> " to satisfy"
 
     ks :: Text
     ks = showS srk
@@ -301,7 +298,7 @@ showAuth mProv (_located -> (srk, sbool)) = status <> " " <> ksDescription
     ksDescription = case mProv of
       Nothing ->
         "unknown " <> ks
-      Just (FromCell (OriginatingCell (TableName tn) (ColumnName cn) sRk _dirty)) ->
+      Just (FromCell (OriginatingCell (TableName tn) (ColumnName cn) sRk _)) ->
         ks <> " from database at ("
           <> T.pack tn <> ", "
           <> "'" <> T.pack cn <> ", "
@@ -311,32 +308,28 @@ showAuth mProv (_located -> (srk, sbool)) = status <> " " <> ksDescription
       Just (FromInput arg) ->
         ks <> " from argument " <> arg
 
-showResult :: Located TVal -> Text
-showResult = showTVal . _located
-
 showEvent :: Map TagId Provenance -> ModelTags 'Concrete -> TraceEvent -> [Text]
 showEvent ksProvs tags = \case
     TraceRead (_located -> (tid, _)) ->
       [display mtReads tid showRead]
     TraceWrite (_located -> (tid, _)) ->
       [display mtWrites tid showWrite]
-    TraceEnforceTree (_located -> (tid, toListOf caseEvents -> children)) ->
-      display mtEnforceTrees tid showEnforceOne :
-        fmap indent (showEvent' =<< children)
-    TraceAssert (_located -> tid) ->
-      [display mtAsserts tid showAssert]
-    TraceAuth (_located -> tid) ->
-      [display mtAuths tid (showAuth $ tid `Map.lookup` ksProvs)]
+    TraceAssert recov (_located -> tid) ->
+      [display mtAsserts tid (showAssert recov)]
+    TraceAuth recov (_located -> tid) ->
+      [display mtAuths tid (showAuth recov $ tid `Map.lookup` ksProvs)]
     TraceBind (_located -> (vid, _, _)) ->
       [display mtVars vid showVar]
     TraceSubpathStart _ ->
       [] -- not shown to end-users
 
   where
-    showEvent' :: TraceEvent -> [Text]
-    showEvent' = showEvent ksProvs tags
-
-    display :: Ord k => Lens' (ModelTags 'Concrete) (Map k v) -> k -> (v -> Text) -> Text
+    display
+      :: Ord k
+      => Lens' (ModelTags 'Concrete) (Map k v)
+      -> k
+      -> (v -> Text)
+      -> Text
     display l ident f = maybe "[ERROR:missing tag]" f $ tags ^. l.at ident
 
 showModel :: Model 'Concrete -> Text
@@ -361,37 +354,6 @@ showModel model =
 
     showEvent' = showEvent (model ^. modelKsProvs) (model ^. modelTags)
 
--- NOTE: we indent the entire model two spaces so that the atom linter will
--- treat it as one message.
-showEntireModel :: Model 'Concrete -> Text
-showEntireModel (Model args (ModelTags vars reads' writes trees asserts auths res _paths) ksProvs _graph) =
-  T.intercalate "\n" $ T.intercalate "\n" . map indent <$>
-    [ ["Arguments:"]
-    , indent <$> Foldable.toList (showVar <$> args)
-    , []
-    , ["Variables:"]
-    , indent <$> Foldable.toList (showVar <$> vars)
-    , []
-    , ["Reads:"]
-    , indent <$> Foldable.toList (showAccess <$> reads')
-    , []
-    , ["Writes:"]
-    , indent <$> Foldable.toList (showAccess <$> writes)
-    , []
-    , ["Enforce Trees:"]
-    , indent <$> Foldable.toList (showAssert <$> trees)
-    , []
-    , ["Assertions:"]
-    , indent <$> Foldable.toList (showAssert <$> asserts)
-    , []
-    , ["Keysets:"]
-    , indent <$> Foldable.toList
-        (imap (\tid a -> showAuth (tid `Map.lookup` ksProvs) a) auths)
-    , []
-    , ["Result:"]
-    , indent <$> [showResult res]
-    ]
-
 -- | Builds a new 'Model' by querying the SMT model to concretize the provided
 -- symbolic 'Model'.
 saturateModel :: Model 'Symbolic -> SBV.Query (Model 'Concrete)
@@ -400,7 +362,6 @@ saturateModel =
     traverseOf (modelTags.mtVars.traversed.located._2)      fetchTVal   >=>
     traverseOf (modelTags.mtReads.traversed.located)        fetchAccess >=>
     traverseOf (modelTags.mtWrites.traversed.located)       fetchAccess >=>
-    traverseOf (modelTags.mtEnforceTrees.traversed.located) fetchSbv    >=>
     traverseOf (modelTags.mtAsserts.traversed.located)      fetchSbv    >=>
     traverseOf (modelTags.mtAuths.traversed.located)        fetchAuth   >=>
     traverseOf (modelTags.mtResult.located)                 fetchTVal   >=>

--- a/src/Pact/Analyze/Model.hs
+++ b/src/Pact/Analyze/Model.hs
@@ -283,6 +283,7 @@ saturateModel =
     traverseOf (modelTags.mtWrites.traversed.located)  fetchAccess >=>
     traverseOf (modelTags.mtAuths.traversed.located)   fetchSbv    >=>
     traverseOf (modelTags.mtResult.located)            fetchTVal   >=>
+    traverseOf (modelTags.mtPaths.traversed)           fetchSbv    >=>
     traverseOf (modelKsProvs.traversed)                fetchProv
 
   where

--- a/src/Pact/Analyze/Model.hs
+++ b/src/Pact/Analyze/Model.hs
@@ -17,8 +17,8 @@ module Pact.Analyze.Model
   , showModel
   ) where
 
-import           Control.Lens         (Lens', Prism', at, filtered, ifoldr, imap, isn't,
-                                       to, toListOf, traverseOf, traversed, (<&>),
+import           Control.Lens         (Lens', Prism', at, ifoldr, imap, to,
+                                       toListOf, traverseOf, traversed, (<&>),
                                        (?~), (^.), (^?), _1, _2, _Just)
 import           Control.Lens.Indexed (FunctorWithIndex)
 import           Control.Monad        ((>=>), when)

--- a/src/Pact/Analyze/Model.hs
+++ b/src/Pact/Analyze/Model.hs
@@ -37,6 +37,7 @@ import           Data.Text            (Text)
 import qualified Data.Text            as T
 import           Data.Traversable     (for)
 
+import qualified Pact.Types.Info      as Pact
 import           Pact.Types.Runtime   (tShow)
 import qualified Pact.Types.Typecheck as TC
 
@@ -252,14 +253,14 @@ showKsn sKsn = case SBV.unliteral (_sSbv sKsn) of
   Nothing               -> "[unknown]"
   Just (KeySetName ksn) -> "'" <> ksn
 
---
--- TODO: print the expression and/or the enforce message
---
 showAssert :: Located (SBV Bool) -> Text
-showAssert lsb = case SBV.unliteral (_located lsb) of
-  Nothing    -> "[ERROR:symbolic assert]"
-  Just True  -> "satisfied assertion"
-  Just False -> "failed to satisfy assertion"
+showAssert (Located (Pact.Info mInfo) lsb) = case SBV.unliteral lsb of
+    Nothing    -> "[ERROR:symbolic assert]"
+    Just True  -> "satisfied assertion" <> context
+    Just False -> "failed to satisfy assertion" <> context
+
+  where
+    context = maybe "" (\(Pact.Code code, _) -> ": " <> code) mInfo
 
 --
 -- TODO: synthesize auth + ks connections more thoroughly. in this model

--- a/src/Pact/Analyze/Model.hs
+++ b/src/Pact/Analyze/Model.hs
@@ -102,7 +102,7 @@ allocModelTags locatedTm graph = ModelTags
 
     allocAuths :: Symbolic (Map TagId (Located (SBV Bool)))
     allocAuths = fmap Map.fromList $
-      for (toListOf (traverse._TraceEnforce) events) $ \(Located info tid) ->
+      for (toListOf (traverse._TraceAuth) events) $ \(Located info tid) ->
         (tid,) . Located info <$> alloc
 
     allocResult :: Symbolic (Located TVal)
@@ -136,7 +136,7 @@ linearizedTrace model = foldr
       in case event of
            TraceSubpathStart _ ->
              skipAndContinue
-           TraceEnforce (_located -> tid) ->
+           TraceAuth (_located -> tid) ->
              let mPassesEnforce = model ^?
                    modelTags.mtAuths.at tid._Just.located.to SBV.unliteral._Just
              in case mPassesEnforce of
@@ -269,7 +269,7 @@ showEvent ksProvs tags = \case
       display mtReads tid showRead
     TraceWrite (_located -> (tid, _)) ->
       display mtWrites tid showWrite
-    TraceEnforce (_located -> tid) ->
+    TraceAuth (_located -> tid) ->
       display mtAuths tid (showAuth $ tid `Map.lookup` ksProvs)
     TraceBind (_located -> (vid, _, _)) ->
       display mtVars vid showVar

--- a/src/Pact/Analyze/Model.hs
+++ b/src/Pact/Analyze/Model.hs
@@ -123,7 +123,7 @@ allocModelTags locatedTm graph = ModelTags
 
 -- NOTE: we indent the entire model two spaces so that the atom linter will
 -- treat it as one message.
-showModel :: Model c -> Text
+showModel :: Model 'Concrete -> Text
 showModel (Model args (ModelTags vars reads' writes auths res _paths) ksProvs) =
     T.intercalate "\n" $ T.intercalate "\n" . map indent <$>
       [ ["Arguments:"]
@@ -153,7 +153,7 @@ showModel (Model args (ModelTags vars reads' writes auths res _paths) ksProvs) =
     indent = ("  " <>)
 
     showSbv :: (Show a, SymWord a) => SBV a -> Text
-    showSbv sbv = maybe "[symbolic]" tShow (SBV.unliteral sbv)
+    showSbv sbv = maybe "[ERROR:symbolic]" tShow (SBV.unliteral sbv)
 
     showS :: (Show a, SymWord a) => S a -> Text
     showS = showSbv . _sSbv

--- a/src/Pact/Analyze/Model.hs
+++ b/src/Pact/Analyze/Model.hs
@@ -61,7 +61,7 @@ allocModelTags locatedTm graph = ModelTags
     <*> allocWrites
     <*> allocAuths
     <*> allocResult
-    <*> allocCheckpoints
+    <*> allocPaths
 
   where
     -- For the purposes of symbolic value allocation, we just grab all of the
@@ -106,15 +106,15 @@ allocModelTags locatedTm graph = ModelTags
       EObject sch _ ->
         (EObjectTy sch,) . AnObj <$> allocSchema sch
 
-    allocCheckpoints :: Symbolic (Map TagId (SBV Bool))
-    allocCheckpoints = fmap Map.fromList $
-      for (toListOf (traverse._TraceCheckpoint) events) $ \tid ->
+    allocPaths :: Symbolic (Map TagId (SBV Bool))
+    allocPaths = fmap Map.fromList $
+      for (toListOf (traverse._TracePathStart) events) $ \tid ->
         (tid,) <$> alloc
 
 -- NOTE: we indent the entire model two spaces so that the atom linter will
 -- treat it as one message.
 showModel :: Model -> Text
-showModel (Model args (ModelTags vars reads' writes auths res _cps) ksProvs) =
+showModel (Model args (ModelTags vars reads' writes auths res _paths) ksProvs) =
     T.intercalate "\n" $ T.intercalate "\n" . map indent <$>
       [ ["Arguments:"]
       , indent <$> fmapToList showVar args

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -93,9 +93,9 @@ pattern AST_EnforceKeyset :: forall a. AST a -> AST a
 pattern AST_EnforceKeyset ks <-
   App _node (NativeFunc "enforce-keyset") [ks] -- can be string or object
 
-pattern AST_EnforceOne :: forall a. [AST a] -> AST a
-pattern AST_EnforceOne enforces <-
-  App _node (NativeFunc "enforce-one") [_, List _ enforces]
+pattern AST_EnforceOne :: forall a. a -> [AST a] -> AST a
+pattern AST_EnforceOne node enforces <-
+  App node (NativeFunc "enforce-one") [_, List _ enforces]
 
 pattern AST_Format :: forall a. AST a -> [AST a] -> AST a
 pattern AST_Format str vars <-

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -119,7 +119,7 @@ data TranslateState
     , _tsNextTagId  :: TagId
     , _tsNextVarId  :: VarId
     , _tsGraph      :: Graph Vertex
-    , _tsPrevVertex :: Vertex
+    , _tsPathVertex :: Vertex
     }
 
 makeLenses ''TranslateFailure
@@ -251,13 +251,13 @@ throwError' err = do
   info <- view _1
   throwError $ TranslateFailure info err
 
--- | Generates a new Vertex, sets it to the most recent (tsPrevVertex), and
+-- | Generates a new Vertex, sets it to the most recent (tsPathVertex), and
 -- returns the tuple of the previous and this newly-generated Vertex.
 issueVertex :: TranslateM (Vertex, Vertex)
 issueVertex = do
-  prev <- use tsPrevVertex
+  prev <- use tsPathVertex
   let v = succ prev
-  tsPrevVertex .= v
+  tsPathVertex .= v
   pure (prev, v)
 
 -- | Extends the previous path head to a new Vertex
@@ -269,7 +269,7 @@ extendPath = do
 
 -- | Resets the path head to the supplied Vertex
 resetPath :: Vertex -> TranslateM ()
-resetPath = (tsPrevVertex .=)
+resetPath = (tsPathVertex .=)
 
 -- | Extends multiple separate paths to a single join point.
 joinPaths :: [Vertex] -> TranslateM Vertex

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -121,7 +121,7 @@ data TranslateState
     , _tsGraph             :: Alga.Graph Vertex
     , _tsPathVertex        :: Vertex
     , _tsEdgeStatements    :: Map Edge [TraceStatement]
-    , _tsPendingStatements :: ReversedList TraceStatement
+    , _tsPendingStatements :: SnocList TraceStatement
     }
 
 makeLenses ''TranslateFailure
@@ -266,7 +266,7 @@ issueVertex = do
 -- path.
 flushStatements :: TranslateM [TraceStatement]
 flushStatements = do
-  UnreversedList pathStmts <- use tsPendingStatements
+  ConsList pathStmts <- use tsPendingStatements
   tsPendingStatements .= mempty
   pure pathStmts
 

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -360,8 +360,7 @@ throwError' err = do
 -- 'Vertex' to the graph.
 issueVertex :: TranslateM Vertex
 issueVertex = do
-  v <- use tsNextVertex
-  tsNextVertex %= succ
+  v <- genId tsNextVertex
   tsPathHead .= v
   pure v
 

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -119,9 +119,16 @@ data TranslateState
     , _tsNextTagId         :: TagId
     , _tsNextVarId         :: VarId
     , _tsGraph             :: Alga.Graph Vertex
+      -- ^ The execution graph we've built so far. This is expanded upon as we
+      -- translate an entire function.
     , _tsPathVertex        :: Vertex
+      -- ^ The "latest" vertex/current path of the graph. This starts out as
+      -- the single initial vertex. it splits into two if we hit a conditional,
+      -- and rejoins afterwards.
     , _tsEdgeEvents        :: Map Edge [TraceEvent]
+      -- ^ Events added to each new 'Edge' upon creating a new 'Vertex'.
     , _tsPendingEvents     :: SnocList TraceEvent
+      -- ^ Events being accumulated until created of the next 'Vertex'.
     }
 
 makeLenses ''TranslateFailure

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -13,8 +13,7 @@
 
 module Pact.Analyze.Translate where
 
-import           Algebra.Graph              (Graph, connect, edge, overlay,
-                                             vertices)
+import qualified Algebra.Graph              as Alga
 import           Control.Applicative        (Alternative (empty))
 import           Control.Lens               (at, cons, makeLenses, use, view,
                                              (<&>), (?~), (^.), (^?), (%~),
@@ -119,7 +118,7 @@ data TranslateState
     { _tsTagAllocs         :: [TagAllocation] -- "strict" WriterT isn't; so we use state
     , _tsNextTagId         :: TagId
     , _tsNextVarId         :: VarId
-    , _tsGraph             :: Graph Vertex
+    , _tsGraph             :: Alga.Graph Vertex
     , _tsPathVertex        :: Vertex
     , _tsEdgeStatements    :: Map (Vertex, Vertex) [TraceStatement]
     , _tsPendingStatements :: ReversedList TraceStatement
@@ -280,7 +279,7 @@ resetPath = (tsPathVertex .=)
 extendPath :: TranslateM Vertex
 extendPath = do
   e@(v, v') <- issueVertex
-  tsGraph %= overlay (edge v v')
+  tsGraph %= Alga.overlay (Alga.edge v v')
   edgeTrace <- flushStatements
   tsEdgeStatements.at e ?= edgeTrace
   pure v'
@@ -291,7 +290,7 @@ extendPath = do
 joinPaths :: [Vertex] -> TranslateM Vertex
 joinPaths vs = do
   (_, v') <- issueVertex
-  tsGraph %= overlay (vertices vs `connect` pure v')
+  tsGraph %= Alga.overlay (Alga.vertices vs `Alga.connect` pure v')
   for vs $ \v ->
     tsEdgeStatements.at (v, v') ?= []
   pure v'

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -241,7 +241,7 @@ tagWrite = tagDbAccess TraceWrite
 tagAuth :: Node -> TranslateM TagId
 tagAuth node = do
   tid <- genTagId
-  emit $ TraceEnforce $ Located (nodeInfo node) tid
+  emit $ TraceAuth $ Located (nodeInfo node) tid
   pure tid
 
 tagVarBinding :: Info -> Text -> EType -> VarId -> TranslateM ()

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -120,7 +120,7 @@ data TranslateState
     , _tsNextVarId         :: VarId
     , _tsGraph             :: Alga.Graph Vertex
     , _tsPathVertex        :: Vertex
-    , _tsEdgeStatements    :: Map (Vertex, Vertex) [TraceStatement]
+    , _tsEdgeStatements    :: Map Edge [TraceStatement]
     , _tsPendingStatements :: ReversedList TraceStatement
     }
 
@@ -253,9 +253,9 @@ throwError' err = do
   info <- view _1
   throwError $ TranslateFailure info err
 
--- | Generates a new 'Vertex', setting it as the head, returning a tuple of the
--- previous 'Vertex' and this newly-generated one.
-issueVertex :: TranslateM (Vertex, Vertex)
+-- | Generates a new 'Vertex', setting it as the head, returning the
+-- newly-formed 'Edge'.
+issueVertex :: TranslateM Edge
 issueVertex = do
   prev <- use tsPathVertex
   let v = succ prev

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -18,7 +18,7 @@ import           Control.Applicative        (Alternative (empty))
 import           Control.Lens               (Lens', at, cons, makeLenses, snoc,
                                              to, use, view, (%=), (%~), (.=),
                                              (.~), (<&>), (<&>), (?=), (?~),
-                                             (^.), (^?))
+                                             (^.), (^?), (<>~))
 import           Control.Monad              (replicateM, (>=>))
 import           Control.Monad.Except       (Except, MonadError, throwError)
 import           Control.Monad.Fail         (MonadFail (fail))
@@ -196,7 +196,7 @@ data TranslateState
       --
       -- The \ edges correspond to the execution of each case. The _ edges
       -- correspond to successful exit early due to the lack of a failure.
-      -- Theses three "success" edges all join together at the same vertex.
+      -- These three "success" edges all join together at the same vertex.
     }
 
 makeLenses ''TranslateFailure
@@ -404,7 +404,7 @@ joinPaths branches = do
     addPathEdge path rejoinEdge
 
 withNestedRecoverability :: Recoverability -> TranslateM ETerm -> TranslateM ETerm
-withNestedRecoverability r = local $ teRecoverability %~ (<> r)
+withNestedRecoverability r = local $ teRecoverability <>~ r
 
 translateType
   :: (MonadError TranslateFailure m, MonadReader r m, HasInfo r)
@@ -921,12 +921,9 @@ runTranslation info pactArgs body = do
 
   where
     runArgsTranslation :: Except TranslateFailure ([Arg], VarId)
-    runArgsTranslation =
-      -- Note we add () as a second value in the reader context because some
-      -- methods require a reader in a pair.
-      runStateT
-        (runReaderT (traverse translateArg pactArgs) info)
-        (VarId 1)
+    runArgsTranslation = runStateT
+      (runReaderT (traverse translateArg pactArgs) info)
+      (VarId 1)
 
     runBodyTranslation
       :: [Arg] -> VarId -> Except TranslateFailure (ETerm, ExecutionGraph)

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -493,10 +493,6 @@ translateNode astNode = astContext astNode $ case astNode of
         CoreTerm $ Var vid name
       _        -> throwError' $ BadNegationType astNode
 
-  AST_Enforce _ cond -> do
-    ESimple TBool condTerm <- translateNode cond
-    pure $ ESimple TBool $ Enforce condTerm
-
   AST_Format formatStr vars -> do
     ESimple TStr formatStr' <- translateNode formatStr
     vars' <- for vars translateNode
@@ -530,6 +526,10 @@ translateNode astNode = astContext astNode $ case astNode of
 
   AST_ReadInteger _ -> throwError' $ UnexpectedNode astNode
   AST_ReadMsg _     -> throwError' $ UnexpectedNode astNode
+
+  AST_Enforce _ cond -> do
+    ESimple TBool condTerm <- translateNode cond
+    pure $ ESimple TBool $ Enforce condTerm
 
   AST_EnforceKeyset ksA
     | ksA ^? aNode.aTy == Just (TyPrim TyString)

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -238,17 +238,17 @@ tagRead = tagDbAccess TraceRead
 tagWrite :: Node -> Schema -> TranslateM TagId
 tagWrite = tagDbAccess TraceWrite
 
-tagEnforce :: (Located TagId -> TraceEvent) -> Node -> TranslateM TagId
-tagEnforce mkEvent node = do
+tagAssert :: Node -> TranslateM TagId
+tagAssert node = do
   tid <- genTagId
-  emit $ mkEvent $ Located (nodeInfo node) tid
+  emit $ TraceAssert $ Located (nodeInfo node) tid
   pure tid
 
-tagAssert :: Node -> TranslateM TagId
-tagAssert = tagEnforce TraceAssert
-
 tagAuth :: Node -> TranslateM TagId
-tagAuth = tagEnforce TraceAuth
+tagAuth node = do
+  tid <- genTagId
+  emit $ TraceAuth $ Located (nodeInfo node) tid
+  pure tid
 
 tagVarBinding :: Info -> Text -> EType -> VarId -> TranslateM ()
 tagVarBinding info nm ety vid = emit $ TraceBind (Located info (vid, nm, ety))

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -352,8 +352,8 @@ succeeds = latticeState.lasSucceeds.sbv2S
 -- graph formed by reachable edges, we now have 2 components.
 --
 -- We prefer to give a single-component reachable graph to model reporting, and
--- let that code consider 'TraceEnforce' 'TraceEvent's on its own to determine
--- where linear execution aborts for a concrete program trace.
+-- let that code consider 'TraceAssert' and 'TraceAuth' 'TraceEvent's on its
+-- own to determine where linear execution aborts for a concrete program trace.
 --
 purelyReachable :: Lens' AnalyzeState (S Bool)
 purelyReachable = latticeState.lasPurelyReachable.sbv2S

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleContexts      #-}
@@ -69,12 +70,17 @@ data AnalyzeEnv
     , _aeDecimals  :: !(SFunArray String Decimal)    -- read-only
     , _invariants  :: !(TableMap [Located (Invariant Bool)])
     , _aeColumnIds :: !(TableMap (Map Text VarId))
-    , _aeModelTags :: !ModelTags
+    , _aeModelTags :: !(ModelTags 'Symbolic)
     , _aeInfo      :: !Info
     }
   deriving Show
 
-mkAnalyzeEnv :: [Table] -> Map VarId AVal -> ModelTags -> Info -> Maybe AnalyzeEnv
+mkAnalyzeEnv
+  :: [Table]
+  -> Map VarId AVal
+  -> ModelTags 'Symbolic
+  -> Info
+  -> Maybe AnalyzeEnv
 mkAnalyzeEnv tables args tags info = do
   let keySets'    = mkFreeArray "envKeySets"
       keySetAuths = mkFreeArray "keySetAuths"

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -402,7 +402,7 @@ data Term ret where
   -- TODO(joel): In principle this could be pure and applied to all the
   -- languages. Unfortunately, we can't add this to props because `Query` has
   -- `Symbolic` in its stack, so it can't do an `ite`.
-  IfThenElse      :: Term Bool -> (TagId, Term a) -> (TagId, Term a) -> TagId -> Term a
+  IfThenElse      :: Term Bool -> (TagId, Term a) -> (TagId, Term a) -> Term a
 
   -- Variable binding
   Let             :: Text -> VarId -> ETerm -> Term a -> Term a

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -411,8 +411,8 @@ data Term ret where
   Sequence        :: ETerm     -> Term a ->           Term a
 
   -- Conditional transaction abort
-  Enforce         :: Term Bool   -> Term Bool
-  EnforceOne      :: [Term Bool] -> Term Bool
+  Enforce         :: Maybe TagId -> Term Bool -> Term Bool -- Only a TagId for an assertion; i.e. not keyset enforcement
+  EnforceOne      :: [Term Bool]              -> Term Bool
 
   -- Reading from environment
   ReadKeySet      :: Term String -> Term KeySet

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -402,7 +402,7 @@ data Term ret where
   -- TODO(joel): In principle this could be pure and applied to all the
   -- languages. Unfortunately, we can't add this to props because `Query` has
   -- `Symbolic` in its stack, so it can't do an `ite`.
-  IfThenElse      :: Term Bool -> Term a -> Term a -> Term a
+  IfThenElse      :: Term Bool -> (TagId, Term a) -> (TagId, Term a) -> TagId -> Term a
 
   -- Variable binding
   Let             :: Text -> VarId -> ETerm -> Term a -> Term a

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -411,8 +411,8 @@ data Term ret where
   Sequence        :: ETerm     -> Term a ->           Term a
 
   -- Conditional transaction abort
-  Enforce         :: Maybe TagId -> Term Bool -> Term Bool -- Only a TagId for an assertion; i.e. not keyset enforcement
-  EnforceOne      :: [Term Bool]              -> Term Bool
+  Enforce         :: Maybe TagId -> Term Bool   -> Term Bool -- Only a TagId for an assertion; i.e. not keyset enforcement
+  EnforceOne      :: TagId       -> [Term Bool] -> Term Bool
 
   -- Reading from environment
   ReadKeySet      :: Term String -> Term KeySet

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -88,7 +88,6 @@ pattern Inj :: sub :<: sup => sub a -> sup a
 pattern Inj a <- (project -> Just a) where
   Inj a = inject a
 
-
 -- | Core terms.
 --
 -- These are the expressions shared by all three languages ('Prop',
@@ -412,7 +411,11 @@ data Term ret where
 
   -- Conditional transaction abort
   Enforce         :: Maybe TagId -> Term Bool   -> Term Bool -- Only a TagId for an assertion; i.e. not keyset enforcement
-  EnforceOne      :: TagId       -> [Term Bool] -> Term Bool
+  -- Left to be tagged if the list of cases is empty. We do this because we
+  -- need a way to signal a failure due to this particular scenario in model
+  -- reporting. Right _1 to be tagged if the case fails, Right _2 to be tagged
+  -- if the case succeeds:
+  EnforceOne      :: Either TagId [((TagId, TagId), Term Bool)] -> Term Bool
 
   -- Reading from environment
   ReadKeySet      :: Term String -> Term KeySet

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -33,12 +33,20 @@ newtype Vertex
   = Vertex Natural
   deriving (Num, Enum, Show, Ord, Eq)
 
+data TraceStatement
+  = TraceBinding
+  | TraceEnforce
+  | TraceEnforceKeySet
+  | TraceRead
+  | TraceWrite
+  deriving (Show)
+
 data TagAllocation
   = AllocReadTag (Located (TagId, Schema))
   | AllocWriteTag (Located (TagId, Schema))
   | AllocAuthTag (Located TagId)
   | AllocVarTag (Located (VarId, Text, EType))
-  deriving Show
+  deriving (Show)
 
 data ModelTags
   = ModelTags

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -9,10 +9,10 @@
 module Pact.Analyze.Types.Model where
 
 import qualified Algebra.Graph             as Alga
-import           Control.Lens              (Traversal', _2, makeLenses,
-                                            makePrisms)
+import           Control.Lens              (makeLenses, makePrisms)
 import           Data.Map.Strict           (Map)
 import           Data.SBV                  (SBV)
+import           Data.Semigroup            (Semigroup ((<>)))
 import           Data.Text                 (Text)
 import           GHC.Natural               (Natural)
 import           Prelude                   hiding (Float)
@@ -20,7 +20,6 @@ import           Prelude                   hiding (Float)
 import qualified Pact.Types.Typecheck      as TC
 
 import           Pact.Analyze.Types.Shared
-import           Pact.Analyze.Util         (SnocList)
 
 -- | An argument to a function
 data Arg = Arg
@@ -40,12 +39,37 @@ newtype Vertex
   = Vertex Natural
   deriving (Num, Enum, Show, Ord, Eq)
 
+data Recoverability
+  -- The path upon which to resume inclusion of events. An alternative here
+  -- would be to have more edges in the subgraphs formed by @enforce-one@ --
+  -- have vertices not just for each case, but additionally one after each
+  -- recoverable assert/auth as well, to connect from right after the
+  -- assert/auth to the next case. One would need to be careful here not to try
+  -- to make two edges between a pair of vertices when an assert/auth in a
+  -- preceeding case is right before the next case. We need to explicitly talk
+  -- about the path upon which to resume execution because it's not necessarily
+  -- the next vertex -- there could be more subpaths before where we should
+  -- resume due to nested conditionals or @enforce-one@s.
+  = Recoverable { _resumptionPath :: TagId }
+  | Unrecoverable
+  deriving (Eq, Show)
+
+-- For determining resumption paths for nested @enforce-one@s:
+instance Semigroup Recoverability where
+  --      outer <> inner
+  Recoverable _ <> Recoverable y = Recoverable y
+  Recoverable x <> Unrecoverable = Recoverable x
+  Unrecoverable <> nested        = nested
+
+instance Monoid Recoverability where
+  mempty = Unrecoverable
+  mappend = (<>)
+
 data TraceEvent
   = TraceRead (Located (TagId, Schema))
   | TraceWrite (Located (TagId, Schema))
-  | TraceEnforceTree (Located (TagId, SnocList (SnocList TraceEvent)))
-  | TraceAssert (Located TagId)
-  | TraceAuth (Located TagId)
+  | TraceAssert Recoverability (Located TagId)
+  | TraceAuth Recoverability (Located TagId)
   | TraceBind (Located (VarId, Text, EType))
   | TraceSubpathStart TagId
   deriving (Eq, Show)
@@ -66,25 +90,24 @@ data Concreteness
 
 data ModelTags (c :: Concreteness)
   = ModelTags
-    { _mtVars         :: Map VarId (Located (Text, TVal))
+    { _mtVars    :: Map VarId (Located (Text, TVal))
     -- ^ each intermediate variable binding
-    , _mtReads        :: Map TagId (Located (S RowKey, Object))
+    , _mtReads   :: Map TagId (Located (S RowKey, Object))
     -- ^ one per each read
-    , _mtWrites       :: Map TagId (Located (S RowKey, Object))
+    , _mtWrites  :: Map TagId (Located (S RowKey, Object))
     -- ^ one per each write
-    , _mtEnforceTrees :: Map TagId (Located (SBV Bool))
-    -- ^ one per enforce-one
-    , _mtAsserts      :: Map TagId (Located (SBV Bool))
+    , _mtAsserts :: Map TagId (Located (SBV Bool))
     -- ^ one per non-keyset enforcement
-    , _mtAuths        :: Map TagId (Located (S KeySet, SBV Bool))
+    , _mtAuths   :: Map TagId (Located (S KeySet, SBV Bool))
     -- ^ one per each enforce/auth check. note that this includes all
     -- @(enforce ks)@ and @(enforce-keyset "ks")@ calls.
-    , _mtResult       :: Located TVal
+    , _mtResult  :: Located TVal
     -- ^ return value of the function being checked
-    , _mtPaths        :: Map TagId (SBV Bool)
+    , _mtPaths   :: Map TagId (SBV Bool)
     -- ^ one at the start of the program, and on either side of the branches of
     -- each conditional. after a conditional, the path from before the
-    -- conditional is resumed.
+    -- conditional is resumed. we also split execution for each case of
+    -- @enforce-one@.
     }
   deriving (Eq, Show)
 
@@ -119,11 +142,3 @@ makePrisms ''TraceEvent
 makeLenses ''ExecutionGraph
 makeLenses ''ModelTags
 makeLenses ''Model
-
--- TODO: I think we actually want a Prism here: there are 0 or 1 of these at
--- the tree's toplevel.
-treeCases :: Traversal' TraceEvent (SnocList (SnocList TraceEvent))
-treeCases = _TraceEnforceTree.located._2
-
-caseEvents :: Traversal' (SnocList (SnocList TraceEvent)) TraceEvent
-caseEvents = traverse.traverse

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -43,12 +43,13 @@ data TraceEvent
   | TraceWrite (Located (TagId, Schema))
   | TraceEnforce (Located TagId)
   | TraceBind (Located (VarId, Text, EType))
-  | TracePathStart TagId
+  | TraceSubpathStart TagId
   deriving (Show)
 
 data ExecutionGraph
   = ExecutionGraph
     { _egInitialVertex :: Vertex
+    , _egRootPath      :: TagId
     , _egGraph         :: Alga.Graph Vertex
     , _egEdgeEvents    :: Map Edge [TraceEvent]
     , _egPathEdges     :: Map TagId [Edge]

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -9,7 +9,8 @@
 module Pact.Analyze.Types.Model where
 
 import qualified Algebra.Graph             as Alga
-import           Control.Lens              (makeLenses, makePrisms)
+import           Control.Lens              (Traversal', _2, makeLenses,
+                                            makePrisms)
 import           Data.Map.Strict           (Map)
 import           Data.SBV                  (SBV)
 import           Data.Text                 (Text)
@@ -19,6 +20,7 @@ import           Prelude                   hiding (Float)
 import qualified Pact.Types.Typecheck      as TC
 
 import           Pact.Analyze.Types.Shared
+import           Pact.Analyze.Util         (SnocList)
 
 -- | An argument to a function
 data Arg = Arg
@@ -41,6 +43,7 @@ newtype Vertex
 data TraceEvent
   = TraceRead (Located (TagId, Schema))
   | TraceWrite (Located (TagId, Schema))
+  | TraceEnforceTree (Located (TagId, SnocList (SnocList TraceEvent)))
   | TraceAssert (Located TagId)
   | TraceAuth (Located TagId)
   | TraceBind (Located (VarId, Text, EType))
@@ -63,20 +66,22 @@ data Concreteness
 
 data ModelTags (c :: Concreteness)
   = ModelTags
-    { _mtVars    :: Map VarId (Located (Text, TVal))
+    { _mtVars         :: Map VarId (Located (Text, TVal))
     -- ^ each intermediate variable binding
-    , _mtReads   :: Map TagId (Located (S RowKey, Object))
-    -- ^ one per each read, in traversal order
-    , _mtWrites  :: Map TagId (Located (S RowKey, Object))
-    -- ^ one per each write, in traversal order
-    , _mtAsserts :: Map TagId (Located (SBV Bool))
+    , _mtReads        :: Map TagId (Located (S RowKey, Object))
+    -- ^ one per each read
+    , _mtWrites       :: Map TagId (Located (S RowKey, Object))
+    -- ^ one per each write
+    , _mtEnforceTrees :: Map TagId (Located (SBV Bool))
+    -- ^ one per enforce-one
+    , _mtAsserts      :: Map TagId (Located (SBV Bool))
     -- ^ one per non-keyset enforcement
-    , _mtAuths   :: Map TagId (Located (S KeySet, SBV Bool))
-    -- ^ one per each enforce/auth check, in traversal order. note that this
-    -- includes all (enforce ks) and (enforce-keyset "ks") calls.
-    , _mtResult  :: Located TVal
+    , _mtAuths        :: Map TagId (Located (S KeySet, SBV Bool))
+    -- ^ one per each enforce/auth check. note that this includes all
+    -- @(enforce ks)@ and @(enforce-keyset "ks")@ calls.
+    , _mtResult       :: Located TVal
     -- ^ return value of the function being checked
-    , _mtPaths   :: Map TagId (SBV Bool)
+    , _mtPaths        :: Map TagId (SBV Bool)
     -- ^ one at the start of the program, and on either side of the branches of
     -- each conditional. after a conditional, the path from before the
     -- conditional is resumed.
@@ -114,3 +119,11 @@ makePrisms ''TraceEvent
 makeLenses ''ExecutionGraph
 makeLenses ''ModelTags
 makeLenses ''Model
+
+-- TODO: I think we actually want a Prism here: there are 0 or 1 of these at
+-- the tree's toplevel.
+treeCases :: Traversal' TraceEvent (SnocList (SnocList TraceEvent))
+treeCases = _TraceEnforceTree.located._2
+
+caseEvents :: Traversal' (SnocList (SnocList TraceEvent)) TraceEvent
+caseEvents = traverse.traverse

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -44,7 +44,7 @@ data TraceEvent
   | TraceEnforce (Located TagId)
   | TraceBind (Located (VarId, Text, EType))
   | TraceSubpathStart TagId
-  deriving (Show)
+  deriving (Eq, Show)
 
 data ExecutionGraph
   = ExecutionGraph
@@ -54,6 +54,7 @@ data ExecutionGraph
     , _egEdgeEvents    :: Map Edge [TraceEvent]
     , _egPathEdges     :: Map TagId [Edge]
     }
+  deriving (Eq, Show)
 
 data Concreteness
   = Concrete
@@ -81,13 +82,16 @@ data ModelTags (c :: Concreteness)
 
 data Model (c :: Concreteness)
   = Model
-    { _modelArgs    :: Map VarId (Located (Text, TVal))
+    { _modelArgs           :: Map VarId (Located (Text, TVal))
     -- ^ one free value per input the function; allocatd post-translation.
-    , _modelTags    :: ModelTags c
+    , _modelTags           :: ModelTags c
     -- ^ free values to be constrained to equal values during analysis;
     -- allocated post-translation.
-    , _modelKsProvs :: Map TagId Provenance
+    , _modelKsProvs        :: Map TagId Provenance
     -- ^ keyset 'Provenance's from analysis
+    , _modelExecutionGraph :: ExecutionGraph
+    -- ^ execution graph corresponding to the program for reporting linearized
+    -- traces
     }
   deriving (Eq, Show)
 

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TemplateHaskell            #-}
 
@@ -52,7 +54,11 @@ data ExecutionGraph
     , _egPathEdges     :: Map TagId [Edge]
     }
 
-data ModelTags
+data Concreteness
+  = Concrete
+  | Symbolic
+
+data ModelTags (c :: Concreteness)
   = ModelTags
     { _mtVars   :: Map VarId (Located (Text, TVal))
     -- ^ each intermediate variable binding
@@ -72,11 +78,11 @@ data ModelTags
     }
   deriving (Eq, Show)
 
-data Model
+data Model (c :: Concreteness)
   = Model
     { _modelArgs    :: Map VarId (Located (Text, TVal))
     -- ^ one free value per input the function; allocatd post-translation.
-    , _modelTags    :: ModelTags
+    , _modelTags    :: ModelTags c
     -- ^ free values to be constrained to equal values during analysis;
     -- allocated post-translation.
     , _modelKsProvs :: Map TagId Provenance

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -54,17 +54,20 @@ data ExecutionGraph
 
 data ModelTags
   = ModelTags
-    { _mtVars   :: Map VarId (Located (Text, TVal))
+    { _mtVars        :: Map VarId (Located (Text, TVal))
     -- ^ each intermediate variable binding
-    , _mtReads  :: Map TagId (Located (S RowKey, Object))
+    , _mtReads       :: Map TagId (Located (S RowKey, Object))
     -- ^ one per each read, in traversal order
-    , _mtWrites :: Map TagId (Located (S RowKey, Object))
+    , _mtWrites      :: Map TagId (Located (S RowKey, Object))
     -- ^ one per each write, in traversal order
-    , _mtAuths  :: Map TagId (Located (SBV Bool))
+    , _mtAuths       :: Map TagId (Located (SBV Bool))
     -- ^ one per each enforce/auth check, in traversal order. note that this
     -- includes all (enforce ks) and (enforce-keyset "ks") calls.
-    , _mtResult :: Located TVal
+    , _mtResult      :: Located TVal
     -- ^ return value of the function being checked
+    , _mtCheckpoints :: Map TagId (SBV Bool)
+    -- ^ one at the start of the program, on either side of the branches of a
+    -- conditional, and after the branches of a conditional rejoin one another.
     }
   deriving (Eq, Show)
 

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -95,6 +95,12 @@ data Model (c :: Concreteness)
     }
   deriving (Eq, Show)
 
+data ExecutionTrace
+  = ExecutionTrace
+    { _etEvents :: [TraceEvent]
+    , _etResult :: Maybe TVal   -- successful result or tx abort
+    }
+
 data Goal
   = Satisfaction -- ^ Find satisfying model
   | Validation   -- ^ Prove no invalidating model exists

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -41,6 +41,7 @@ newtype Vertex
 data TraceEvent
   = TraceRead (Located (TagId, Schema))
   | TraceWrite (Located (TagId, Schema))
+  | TraceAssert (Located TagId)
   | TraceAuth (Located TagId)
   | TraceBind (Located (VarId, Text, EType))
   | TraceSubpathStart TagId
@@ -62,18 +63,20 @@ data Concreteness
 
 data ModelTags (c :: Concreteness)
   = ModelTags
-    { _mtVars   :: Map VarId (Located (Text, TVal))
+    { _mtVars    :: Map VarId (Located (Text, TVal))
     -- ^ each intermediate variable binding
-    , _mtReads  :: Map TagId (Located (S RowKey, Object))
+    , _mtReads   :: Map TagId (Located (S RowKey, Object))
     -- ^ one per each read, in traversal order
-    , _mtWrites :: Map TagId (Located (S RowKey, Object))
+    , _mtWrites  :: Map TagId (Located (S RowKey, Object))
     -- ^ one per each write, in traversal order
-    , _mtAuths  :: Map TagId (Located (SBV Bool))
+    , _mtAsserts :: Map TagId (Located (SBV Bool))
+    -- ^ one per non-keyset enforcement
+    , _mtAuths   :: Map TagId (Located (SBV Bool))
     -- ^ one per each enforce/auth check, in traversal order. note that this
     -- includes all (enforce ks) and (enforce-keyset "ks") calls.
-    , _mtResult :: Located TVal
+    , _mtResult  :: Located TVal
     -- ^ return value of the function being checked
-    , _mtPaths  :: Map TagId (SBV Bool)
+    , _mtPaths   :: Map TagId (SBV Bool)
     -- ^ one at the start of the program, and on either side of the branches of
     -- each conditional. after a conditional, the path from before the
     -- conditional is resumed.

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -29,6 +29,10 @@ newtype TagId
   = TagId Natural
   deriving (Num, Show, Ord, Eq)
 
+newtype Vertex
+  = Vertex Natural
+  deriving (Num, Enum, Show, Ord, Eq)
+
 data TagAllocation
   = AllocReadTag (Located (TagId, Schema))
   | AllocWriteTag (Located (TagId, Schema))

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -41,33 +41,34 @@ data TraceEvent
   | TraceWrite (Located (TagId, Schema))
   | TraceEnforce (Located TagId)
   | TraceBind (Located (VarId, Text, EType))
-  | TraceCheckpoint TagId
+  | TracePathStart TagId
   deriving (Show)
 
 data ExecutionGraph
   = ExecutionGraph
-    { _egInitialVertex     :: Vertex
-    , _egGraph             :: Alga.Graph Vertex
-    , _egEdgeEvents        :: Map Edge [TraceEvent]
-    , _egCheckpointEdges   :: Map TagId [Edge]
+    { _egInitialVertex :: Vertex
+    , _egGraph         :: Alga.Graph Vertex
+    , _egEdgeEvents    :: Map Edge [TraceEvent]
+    , _egPathEdges     :: Map TagId [Edge]
     }
 
 data ModelTags
   = ModelTags
-    { _mtVars        :: Map VarId (Located (Text, TVal))
+    { _mtVars   :: Map VarId (Located (Text, TVal))
     -- ^ each intermediate variable binding
-    , _mtReads       :: Map TagId (Located (S RowKey, Object))
+    , _mtReads  :: Map TagId (Located (S RowKey, Object))
     -- ^ one per each read, in traversal order
-    , _mtWrites      :: Map TagId (Located (S RowKey, Object))
+    , _mtWrites :: Map TagId (Located (S RowKey, Object))
     -- ^ one per each write, in traversal order
-    , _mtAuths       :: Map TagId (Located (SBV Bool))
+    , _mtAuths  :: Map TagId (Located (SBV Bool))
     -- ^ one per each enforce/auth check, in traversal order. note that this
     -- includes all (enforce ks) and (enforce-keyset "ks") calls.
-    , _mtResult      :: Located TVal
+    , _mtResult :: Located TVal
     -- ^ return value of the function being checked
-    , _mtCheckpoints :: Map TagId (SBV Bool)
-    -- ^ one at the start of the program, on either side of the branches of a
-    -- conditional, and after the branches of a conditional rejoin one another.
+    , _mtPaths  :: Map TagId (SBV Bool)
+    -- ^ one at the start of the program, and on either side of the branches of
+    -- each conditional. after a conditional, the path from before the
+    -- conditional is resumed.
     }
   deriving (Eq, Show)
 

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -35,20 +35,13 @@ newtype Vertex
   = Vertex Natural
   deriving (Num, Enum, Show, Ord, Eq)
 
-data TraceStatement
-  = TraceBinding
-  | TraceEnforce
-  | TraceEnforceKeySet
-  | TraceRead
-  | TraceWrite
+data TraceEvent
+  = TraceRead (Located (TagId, Schema))
+  | TraceWrite (Located (TagId, Schema))
+  | TraceEnforce (Located TagId)
+  | TraceBind (Located (VarId, Text, EType))
   deriving (Show)
 
-data TagAllocation
-  = AllocReadTag (Located (TagId, Schema))
-  | AllocWriteTag (Located (TagId, Schema))
-  | AllocAuthTag (Located TagId)
-  | AllocVarTag (Located (VarId, Text, EType))
-  deriving (Show)
 
 data ModelTags
   = ModelTags
@@ -84,6 +77,6 @@ data Goal
 
 deriving instance Eq Goal
 
-makePrisms ''TagAllocation
+makePrisms ''TraceEvent
 makeLenses ''ModelTags
 makeLenses ''Model

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -71,7 +71,7 @@ data ModelTags (c :: Concreteness)
     -- ^ one per each write, in traversal order
     , _mtAsserts :: Map TagId (Located (SBV Bool))
     -- ^ one per non-keyset enforcement
-    , _mtAuths   :: Map TagId (Located (SBV Bool))
+    , _mtAuths   :: Map TagId (Located (S KeySet, SBV Bool))
     -- ^ one per each enforce/auth check, in traversal order. note that this
     -- includes all (enforce ks) and (enforce-keyset "ks") calls.
     , _mtResult  :: Located TVal

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -40,7 +40,7 @@ newtype Vertex
   deriving (Num, Enum, Show, Ord, Eq)
 
 data Recoverability
-  -- The path upon which to resume inclusion of events. An alternative here
+  -- | The path upon which to resume inclusion of events. An alternative here
   -- would be to have more edges in the subgraphs formed by @enforce-one@ --
   -- have vertices not just for each case, but additionally one after each
   -- recoverable assert/auth as well, to connect from right after the
@@ -74,6 +74,11 @@ data TraceEvent
   | TraceSubpathStart TagId
   deriving (Eq, Show)
 
+-- | An @ExecutionGraph@ is produced by translation, and contains all
+-- information about where 'TraceEvent's occur in the program. From a
+-- @Model 'Concrete@ (which contains this type), we can produce a linear trace
+-- of events for a concrete execution, in the form of 'ExecutionTrace'. For
+-- more information about how this graph is constructed, see 'TranslateState'.
 data ExecutionGraph
   = ExecutionGraph
     { _egInitialVertex :: Vertex
@@ -99,8 +104,8 @@ data ModelTags (c :: Concreteness)
     , _mtAsserts :: Map TagId (Located (SBV Bool))
     -- ^ one per non-keyset enforcement
     , _mtAuths   :: Map TagId (Located (S KeySet, SBV Bool))
-    -- ^ one per each enforce/auth check. note that this includes all
-    -- @(enforce ks)@ and @(enforce-keyset "ks")@ calls.
+    -- ^ one per each authorization check. note that this includes uses of
+    -- @(enforce-keyset ks)@ and @(enforce-keyset "ks")@ calls.
     , _mtResult  :: Located TVal
     -- ^ return value of the function being checked
     , _mtPaths   :: Map TagId (SBV Bool)
@@ -126,6 +131,8 @@ data Model (c :: Concreteness)
     }
   deriving (Eq, Show)
 
+-- | A linearized trace of 'TraceEvent's, derived from a @Model 'Concrete@.
+-- This is used for presentation purposes.
 data ExecutionTrace
   = ExecutionTrace
     { _etEvents :: [TraceEvent]

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -29,6 +29,8 @@ newtype TagId
   = TagId Natural
   deriving (Num, Show, Ord, Eq)
 
+type Edge = (Vertex, Vertex)
+
 newtype Vertex
   = Vertex Natural
   deriving (Num, Enum, Show, Ord, Eq)

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -6,6 +6,7 @@
 
 module Pact.Analyze.Types.Model where
 
+import qualified Algebra.Graph             as Alga
 import           Control.Lens              (makeLenses, makePrisms)
 import           Data.Map.Strict           (Map)
 import           Data.SBV                  (SBV)
@@ -27,7 +28,7 @@ data Arg = Arg
 
 newtype TagId
   = TagId Natural
-  deriving (Num, Show, Ord, Eq)
+  deriving (Num, Enum, Show, Ord, Eq)
 
 type Edge = (Vertex, Vertex)
 
@@ -40,8 +41,16 @@ data TraceEvent
   | TraceWrite (Located (TagId, Schema))
   | TraceEnforce (Located TagId)
   | TraceBind (Located (VarId, Text, EType))
+  | TraceCheckpoint TagId
   deriving (Show)
 
+data ExecutionGraph
+  = ExecutionGraph
+    { _egInitialVertex     :: Vertex
+    , _egGraph             :: Alga.Graph Vertex
+    , _egEdgeEvents        :: Map Edge [TraceEvent]
+    , _egCheckpointEdges   :: Map TagId [Edge]
+    }
 
 data ModelTags
   = ModelTags
@@ -78,5 +87,6 @@ data Goal
 deriving instance Eq Goal
 
 makePrisms ''TraceEvent
+makeLenses ''ExecutionGraph
 makeLenses ''ModelTags
 makeLenses ''Model

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -41,7 +41,7 @@ newtype Vertex
 data TraceEvent
   = TraceRead (Located (TagId, Schema))
   | TraceWrite (Located (TagId, Schema))
-  | TraceEnforce (Located TagId)
+  | TraceAuth (Located TagId)
   | TraceBind (Located (VarId, Text, EType))
   | TraceSubpathStart TagId
   deriving (Eq, Show)

--- a/src/Pact/Analyze/Util.hs
+++ b/src/Pact/Analyze/Util.hs
@@ -78,9 +78,6 @@ pattern ConsList :: [a] -> SnocList a
 pattern ConsList xs <- SnocList (reverse -> xs)
   where ConsList xs = SnocList $ reverse xs
 
-consList :: SnocList a -> [a]
-consList = Foldable.toList
-
 instance Functor SnocList where
   fmap f (SnocList revXs) = SnocList $ fmap f revXs
 

--- a/src/Pact/Analyze/Util.hs
+++ b/src/Pact/Analyze/Util.hs
@@ -59,25 +59,26 @@ dummyInfo = Default.def
 vacuousMatch :: String -> a
 vacuousMatch msg = error $ "vacuous match: " ++ msg
 
--- * ReversedList
+-- * SnocList
 
-newtype ReversedList a
-  = ReversedList { _reversedList :: [a] }
+newtype SnocList a
+  = SnocList { _snocList :: [a] }
   deriving (Eq, Ord, Show)
 
-instance Monoid (ReversedList a) where
-  mempty = ReversedList []
-  ReversedList xs `mappend` ReversedList ys = ReversedList $ ys ++ xs
+instance Monoid (SnocList a) where
+  mempty = SnocList []
+  SnocList xs `mappend` SnocList ys = SnocList $ ys ++ xs
 
-pattern UnreversedList :: [a] -> ReversedList a
-pattern UnreversedList xs <- ReversedList (reverse -> xs)
+pattern ConsList :: [a] -> SnocList a
+pattern ConsList xs <- SnocList (reverse -> xs)
+  where ConsList xs = SnocList $ reverse xs
 
-makeLenses ''ReversedList
+makeLenses ''SnocList
 
-instance Snoc (ReversedList a) (ReversedList b) a b where
+instance Snoc (SnocList a) (SnocList b) a b where
   _Snoc = prism
-    (\(ReversedList as,a) -> ReversedList (a:as))
-    (\(ReversedList aas) ->
+    (\(SnocList as,a) -> SnocList (a:as))
+    (\(SnocList aas) ->
       case aas of
-        (a:as) -> Right (ReversedList as, a)
-        []     -> Left  (ReversedList []))
+        (a:as) -> Right (SnocList as, a)
+        []     -> Left  (SnocList []))

--- a/src/Pact/Analyze/Util.hs
+++ b/src/Pact/Analyze/Util.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms  #-}
+{-# LANGUAGE ViewPatterns     #-}
 
 module Pact.Analyze.Util where
 
@@ -52,3 +54,15 @@ dummyInfo = Default.def
 
 vacuousMatch :: String -> a
 vacuousMatch msg = error $ "vacuous match: " ++ msg
+
+-- * ReversedList
+
+newtype ReversedList a
+  = ReversedList [a]
+
+instance Monoid (ReversedList a) where
+  mempty = ReversedList []
+  ReversedList xs `mappend` ReversedList ys = ReversedList $ ys ++ xs
+
+pattern UnreversedList :: [a] -> ReversedList a
+pattern UnreversedList xs <- ReversedList (reverse -> xs)

--- a/src/Pact/Analyze/Util.hs
+++ b/src/Pact/Analyze/Util.hs
@@ -62,7 +62,7 @@ vacuousMatch msg = error $ "vacuous match: " ++ msg
 -- * SnocList
 
 newtype SnocList a
-  = SnocList { _snocList :: [a] }
+  = SnocList { _reversed :: [a] }
   deriving (Eq, Ord, Show)
 
 instance Monoid (SnocList a) where

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,6 +20,7 @@ packages:
 extra-deps:
   - bound-2
   - ed25519-donna-0.1.1
+  - algebraic-graphs-0.1.1.1
 
 flags: {}
 

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -969,7 +969,7 @@ spec = describe "analyze" $ do
 
             [CheckFailure _ (SmtFailure (Invalid model))] <- pure $
               invariantResults ^.. ix "test" . ix "accounts" . ix 0 . _Left
-            let (Model args (ModelTags _ _ writes _ _ _ _) ksProvs _) = model
+            let (Model args (ModelTags _ _ writes _ _ _ _ _) ksProvs _) = model
 
             it "should have a negative amount" $ do
               Just (Located _ (_, (_, AVal _prov amount))) <- pure $

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -548,7 +548,8 @@ spec = describe "analyze" $ do
              (enforce true)]))
           |]
 
-    expectPass code $ Valid $ Inj Success
+    expectPass code $ Valid Success'
+    expectPass code $ Valid Result'
 
   describe "enforce-one.3" $ do
     let code =
@@ -559,7 +560,7 @@ spec = describe "analyze" $ do
              (enforce false)]))
           |]
 
-    expectPass code $ Valid $ PNot $ Inj Success
+    expectPass code $ Valid $ PNot Success'
 
   describe "enforce-one.4" $ do
     let code =
@@ -571,7 +572,8 @@ spec = describe "analyze" $ do
                   (enforce false))]))
           |]
 
-    expectPass code $ Valid $ Inj Success
+    expectPass code $ Valid Success'
+    expectPass code $ Valid Result'
 
   -- This one is a little subtle. Even though the `or` would evaluate to
   -- `true`, one of its `enforce`s threw, so it fails.
@@ -584,11 +586,11 @@ spec = describe "analyze" $ do
                  (enforce true))]))
           |]
 
-    expectPass code $ Valid $ PNot $ Inj Success
+    expectPass code $ Valid $ PNot Success'
 
   -- This one is also subtle. `or` short-circuits so the second `enforce` never
   -- throws.
-  describe "enforce-one.5" $ do
+  describe "enforce-one.6" $ do
     let code =
           [text|
         (defun test:bool ()
@@ -597,7 +599,24 @@ spec = describe "analyze" $ do
                  (enforce false))]))
           |]
 
-    expectPass code $ Valid $ Inj Success
+    expectPass code $ Valid Success'
+    expectPass code $ Valid Result'
+
+  describe "enforce-one.7" $ do
+    let code =
+          [text|
+            (defun test:bool ()
+              (enforce-one ""
+                [(enforce false)
+                 (enforce-one "" ; nested enforce-one
+                   [(enforce false)
+                    (enforce true)
+                    (enforce false)])
+                 (enforce false)]))
+          |]
+
+    expectPass code $ Valid Success'
+    expectPass code $ Valid Result'
 
   describe "logical short-circuiting" $ do
     describe "and" $ do

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -8,7 +8,8 @@
 
 module AnalyzeSpec (spec) where
 
-import           Control.Lens                 (at, findOf, ix, (^.), (^..), _Left, _2)
+import           Control.Lens                 (at, findOf, ix, (^.), (^..), _2,
+                                               _Left)
 import           Control.Monad.Except         (runExceptT)
 import           Control.Monad.State.Strict   (runStateT)
 import           Data.Either                  (isLeft)
@@ -17,13 +18,16 @@ import qualified Data.HashMap.Strict          as HM
 import           Data.Map                     (Map)
 import qualified Data.Map                     as Map
 import           Data.Maybe                   (isJust, isNothing)
-import           Data.SBV                     (Boolean (bnot, true, (&&&), (==>)), isConcretely)
-import           Data.SBV.Internals           (SBV(SBV))
+import           Data.SBV                     (Boolean (bnot, true, (&&&), (==>)),
+                                               isConcretely)
+import           Data.SBV.Internals           (SBV (SBV))
 import           Data.Text                    (Text)
 import qualified Data.Text                    as T
 import           NeatInterpolation            (text)
-import           Test.Hspec                   (Spec, describe, expectationFailure, it, runIO,
-                                               shouldBe, shouldSatisfy, pendingWith)
+import           Test.Hspec                   (Spec, describe,
+                                               expectationFailure, it,
+                                               pendingWith, runIO, shouldBe,
+                                               shouldSatisfy)
 import qualified Test.HUnit                   as HUnit
 
 import           Pact.Parse                   (parseExprs)
@@ -33,8 +37,8 @@ import           Pact.Types.Runtime           (ModuleData, eeRefStore,
                                                rsModules)
 
 import           Pact.Analyze.Check
-import           Pact.Analyze.Parse           (TableEnv, expToProp, inferProp,
-                                               PreProp(..))
+import           Pact.Analyze.Parse           (PreProp (..), TableEnv,
+                                               expToProp, inferProp)
 import           Pact.Analyze.PrenexNormalize (prenexConvert)
 import           Pact.Analyze.Types
 import           Pact.Analyze.Util            ((...))
@@ -969,7 +973,7 @@ spec = describe "analyze" $ do
 
             [CheckFailure _ (SmtFailure (Invalid model))] <- pure $
               invariantResults ^.. ix "test" . ix "accounts" . ix 0 . _Left
-            let (Model args (ModelTags _ _ writes _ _ _ _ _) ksProvs _) = model
+            let (Model args (ModelTags _ _ writes _ _ _ _) ksProvs _) = model
 
             it "should have a negative amount" $ do
               Just (Located _ (_, (_, AVal _prov amount))) <- pure $

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -618,6 +618,17 @@ spec = describe "analyze" $ do
     expectPass code $ Valid Success'
     expectPass code $ Valid Result'
 
+  describe "enforce-one.8" $ do
+    let code =
+          [text|
+            (defun test:bool ()
+              (enforce-one ""
+                [(enforce false) false (enforce false)]))
+          |]
+
+    expectPass code $ Valid Success'
+    expectPass code $ Valid $ PNot Result'
+
   describe "logical short-circuiting" $ do
     describe "and" $ do
       let code =

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -939,7 +939,7 @@ spec = describe "analyze" $ do
 
             [CheckFailure _ (SmtFailure (Invalid model))] <- pure $
               invariantResults ^.. ix "test" . ix "accounts" . ix 0 . _Left
-            let (Model args (ModelTags _ _ writes _ _ _) ksProvs _) = model
+            let (Model args (ModelTags _ _ writes _ _ _ _) ksProvs _) = model
 
             it "should have a negative amount" $ do
               Just (Located _ (_, (_, AVal _prov amount))) <- pure $

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -633,6 +633,15 @@ spec = describe "analyze" $ do
     expectPass code $ Valid Success'
     expectPass code $ Valid $ PNot Result'
 
+  describe "enforce-one.9" $ do
+    let code =
+          [text|
+            (defun test:bool ()
+              (enforce-one "" []))
+          |]
+
+    expectPass code $ Valid $ bnot Success'
+
   describe "logical short-circuiting" $ do
     describe "and" $ do
       let code =

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -925,7 +925,7 @@ spec = describe "analyze" $ do
 
             [CheckFailure _ (SmtFailure (Invalid model))] <- pure $
               invariantResults ^.. ix "test" . ix "accounts" . ix 0 . _Left
-            let (Model args (ModelTags _ _ writes _ _ _) ksProvs) = model
+            let (Model args (ModelTags _ _ writes _ _ _) ksProvs _) = model
 
             it "should have a negative amount" $ do
               Just (Located _ (_, (_, AVal _prov amount))) <- pure $

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -925,7 +925,7 @@ spec = describe "analyze" $ do
 
             [CheckFailure _ (SmtFailure (Invalid model))] <- pure $
               invariantResults ^.. ix "test" . ix "accounts" . ix 0 . _Left
-            let (Model args (ModelTags _ _ writes _ _) ksProvs) = model
+            let (Model args (ModelTags _ _ writes _ _ _) ksProvs) = model
 
             it "should have a negative amount" $ do
               Just (Located _ (_, (_, AVal _prov amount))) <- pure $


### PR DESCRIPTION
This builds an execution graph during translation to `Term`, and tags each edge with a symbolic boolean to be assigned during evaluation depending on whether that edge "is executed". We emit events and associate them with each edge to track reads, writes, "asserts" (uses of `enforce` over boolean expressions), "auths" (uses of `enforce` over keyset objects, and uses of `enforce-keyset`), and variable bindings. Each of these events are also tagged for surfacing relevant information in model reports.

Upon encountering a falsified model, we now construct a linear execution trace of these events by appealing to those edges in the graph which are tagged as having been executed. This is important because for our existing model reports, we previously had no notion of execution order.

Now, when testing whether the following function conserves mass:

```lisp
(defun test:string (from:string to:string amount:integer)
  "Transfer money between accounts"
  (let ((from-bal (at 'balance (read accounts from)))
        (to-bal   (at 'balance (read accounts to))))
    (enforce (> amount 0)         "Non-positive amount")
    (enforce (>= from-bal amount) "Insufficient Funds")
    ; (enforce (!= from to)         "Sender is the recipient")     <----- DISABLED
    (update accounts from { "balance": (- from-bal amount) })
    (update accounts to   { "balance": (+ to-bal amount) })))
```

when we used to have a model report like:

```
       <interactive>:0:0:Warning: Invalidating model found:
         Arguments:
           from := ""
           to := ""
           amount := 1

         Variables:
           from-bal := 2
           to-bal := 2

         Reads:
           "" => { balance: 2 }
           "" => { balance: 2 }

         Writes:
           "" => { balance: 1 }
           "" => { balance: 3 }

         Keysets:


         Result:
           "Write succeeded"
```

the new model report shows a trace of all "events" that occur in order:

```
       <interactive>:0:0:Warning: Invalidating model found:
         Arguments:
           from := ""
           to := ""
           amount := 1

         Program trace:
           read { balance: 2 } for key ""
           from-bal := 2
           read { balance: 2 } for key ""
           to-bal := 2
           satisfied assertion: (> amount 0)
           satisfied assertion: (>= from-bal amount)
           write { balance: 1 } to key ""
           write { balance: 3 } to key ""

         Result:
           Return value: "Write succeeded"
```

Additionally, in our previous model reports, we would include _all_ tags, even those from code paths that would never have been run during concrete execution (due to `enforce`, `enforce-one`, `enforce-keyset`, or `if`). For example, consider the following function which has an unreachable write to the DB:

```lisp
(defschema token-row balance:integer)
(deftable tokens:{token-row})

(defun test:string ()
  (if false
    (insert tokens "stu" {"balance": 5}) ; impossible
    "didn't write"))
```

Our previous model reports would include this write which does not actually occur due to the conditional:

```
       <interactive>:0:0:Warning: Invalidating model found:
         Arguments:


         Variables:


         Reads:


         Writes:
           "" => { balance: 0 }

         Keysets:


         Result:
           "didn't write"
```

In situations like this, we now omit the events which would never actually occur in the concrete execution of the program:

```
       <interactive>:0:0:Warning: Invalidating model found:
         Arguments:


         Program trace:


         Result:
           Return value: "didn't write"
```

From this current implementation, it will now be easy for us to further improve these error messages with information like line numbers -- we have all information available.

Additionally after adding the new dependency on `algebraic-graphs`, I verified that the nix build still works.