### PR TITLE
Render execution graph DOT on analysis test failure

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -66,6 +66,7 @@ library
       Pact.Analyze.Feature
       Pact.Analyze.LegacySFunArray
       Pact.Analyze.Model
+      Pact.Analyze.Model.Dot
       Pact.Analyze.Orphans
       Pact.Analyze.Parse
       Pact.Analyze.Parse.Invariant

--- a/src/Pact/Analyze/Model/Dot.hs
+++ b/src/Pact/Analyze/Model/Dot.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+
+module Pact.Analyze.Model.Dot
+  ( compile
+  , render
+  ) where
+
+import qualified Algebra.Graph            as Alga
+import qualified Algebra.Graph.Export.Dot as Alga
+import           Algebra.Graph.Export.Dot (Style (..), Attribute ((:=)))
+import           Control.Lens             ((^.))
+import           Data.Map.Strict          (Map)
+import qualified Data.Map.Strict          as Map
+import           Data.Set                 (Set)
+import qualified Data.Set                 as Set
+import           Data.Text                (Text)
+import qualified Data.Text.IO             as Text
+
+import           Pact.Types.Util          (tShow)
+
+import qualified Pact.Analyze.Model       as Model
+import           Pact.Analyze.Types       (Concreteness (Concrete), Edge,
+                                           Model, TagId, Vertex,
+                                           modelExecutionGraph, egGraph,
+                                           egPathEdges)
+
+-- | Compile to DOT format
+compile :: Model 'Concrete -> Text
+compile m = Alga.export style graph
+  where
+    graph :: Alga.Graph Vertex
+    graph = m ^. modelExecutionGraph.egGraph
+
+    reachableEdges :: Set Edge
+    reachableEdges = Model.reachableEdges m
+
+    reachable :: Edge -> Bool
+    reachable = flip Set.member reachableEdges
+
+    edgePaths :: Map Edge TagId
+    edgePaths = Map.fromList $ do
+      (path, edges) <- Map.toList $ m ^. modelExecutionGraph.egPathEdges
+      (,path) <$> edges
+
+    style :: Alga.Style Vertex Text
+    style = Alga.Style
+      { graphName =
+          mempty
+      , preamble =
+          mempty
+      , graphAttributes =
+          []
+      , defaultVertexAttributes =
+          [ "shape" := "circle"
+          , "style" := "filled"
+          ]
+      , defaultEdgeAttributes =
+          []
+      , vertexName = \v ->
+          tShow $ fromEnum v
+      , vertexAttributes = \_v ->
+          []
+      , edgeAttributes = curry $ \e ->
+          [ "color" := "blue"
+          | reachable e
+          ] ++
+          [ "label" := tShow (fromEnum $ edgePaths Map.! e)
+          | True -- show path id on edge?
+          ]
+      }
+
+-- | Render to a DOT file
+render :: FilePath -> Model 'Concrete -> IO ()
+render fp m = Text.writeFile fp $ compile m


### PR DESCRIPTION
As a result of our new [linear execution traces](https://github.com/kadena-io/pact/pull/191) and the use of `algebraic-graphs`, it's quite easy for us to render DOTs/SVGs of execution traces for symbolically-executed code. I implemented this as an aid to help debug an issue, but also figured that it could serve as groundwork for potential future user analysis UI tooling.

At least for now, when we print out a falsifying model report for a failed analysis test, we'll point to a DOT file on disk (see the last line):

```
  /Users/bts/code/kadena/pact/tests/AnalyzeSpec.hs:162:
  1) enforce-one.7 Valid (CoreProp (Lit False))
       <interactive>:0:0:Warning: Invalidating model found:
         Arguments:


         Program trace:
           recovered from failure to satisfy assertion: false
           x := 5
           recovered from failure to satisfy assertion: false

         Result:
           Return value: True

       rendered execution graph to DOT: /tmp/execution-graph.dot
```

For this (manually induced!) test failure, we've used an `enforce-one` with a nested conditional:

```lisp
(defun test:bool ()
  (enforce-one ""
    [(enforce false)
     (let ((x 5)) (if (< x 6) (enforce false) (enforce true)))
     true
     (enforce false)
    ]))
```

here's the corresponding execution graph:

![screenshot 2018-08-30 15 43 54](https://user-images.githubusercontent.com/5743/44875218-85bc7a00-ac6b-11e8-8ed8-8acec8abe6cf.png)

This SVG was generated from the DOT file via graphviz: `dot -Tsvg /tmp/execution-graph.dot > /tmp/graph.svg`

The graphs are pretty minimal at the moment, but if we wanted, we could expand on this in the future and show different "events" like reads, writes, keyset authorizations, expression enforcements, variable bindings, function calls, etc.

For the curious, the numbers on the graph edges are "path identifiers". If we ever evolved this in the direction of user tooling, we likely wouldn't show these numbers (or the unique IDs on the vertices, either).

/cc @slpopejoy