### PR TITLE
Improve 'exp' with explicit commit

### DIFF
--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -111,7 +111,6 @@ term =
   <|> listLiteral
   <|> objectLiteral
 
-{-# INLINE specialForm #-}
 specialForm :: Compile (Term Name)
 specialForm = bareAtom >>= \AtomExp{..} -> case _atomAtom of
     "use" -> commit >> useForm
@@ -129,7 +128,6 @@ specialForm = bareAtom >>= \AtomExp{..} -> case _atomAtom of
     _ -> expected "special form"
 
 
-{-# INLINE app #-}
 app :: Compile (Term Name)
 app = do
   v <- varAtom
@@ -173,7 +171,6 @@ listLiteral = withList Brackets $ \ListExp{..} -> do
               _ -> TyAny
   pure $ TList ls lty _listInfo
 
-
 objectLiteral :: Compile (Term Name)
 objectLiteral = withList Braces $ \ListExp{..} -> do
   let pair = do
@@ -182,7 +179,6 @@ objectLiteral = withList Braces $ \ListExp{..} -> do
         return (key,val)
   ps <- pair `sepBy` sep Comma
   return $ TObject ps TyAny _listInfo
-
 
 literal :: Compile (Term Name)
 literal = lit >>= \LiteralExp{..} ->

--- a/src/Pact/Types/ExpParser.hs
+++ b/src/Pact/Types/ExpParser.hs
@@ -198,7 +198,6 @@ nes x = x :| []
 -- allowing for further tests on the result before committing.
 -- This is copypasta from Megaparsec's implementation of 'token' as
 -- of version 6.5.0, so this might break in future MP versions.
-{-# INLINE pTokenEpsilon #-}
 pTokenEpsilon :: forall e s m a. Stream s
   => (Token s -> Either ( Maybe (ErrorItem (Token s))
                         , S.Set (ErrorItem (Token s)) ) a)

--- a/src/Pact/Types/ExpParser.hs
+++ b/src/Pact/Types/ExpParser.hs
@@ -22,11 +22,29 @@
 --
 
 module Pact.Types.ExpParser
-  where
+  ( Cursor(..)
+  , ParseState(..), psCurrent, psUser
+  , MkInfo, mkEmptyInfo, mkStringInfo, mkTextInfo
+  , ExpParse
+  , runCompile
+  , tokenErr, tokenErr'
+  , syntaxError
+  , expected, unexpected'
+  , commit
+  , exp
+  , anyExp
+  , enter, exit, context, contextInfo
+  , current
+  , atom, bareAtom, symbol
+  , lit, lit', str
+  , list, list', withList, withList'
+  , sep
+    ) where
 
 import qualified Text.Trifecta.Delta as TF
 import Control.Applicative hiding (some,many)
 import Text.Megaparsec as MP
+import Text.Megaparsec.Internal (ParsecT(..))
 import Data.Proxy
 import Data.Void
 import Data.List.NonEmpty (NonEmpty(..),fromList,toList)
@@ -47,7 +65,7 @@ import Pact.Types.Exp
 import Pact.Types.Runtime (PactError(..),PactErrorType(..))
 import Pact.Types.Info
 
-
+-- | Exp stream type.
 data Cursor = Cursor
   { _cContext :: Maybe (Cursor,Exp Info)
   , _cStream :: [Exp Info]
@@ -55,7 +73,6 @@ data Cursor = Cursor
 instance Default Cursor where def = Cursor def def
 
 -- | adapted from Text.Megaparsec.Stream
-
 defaultAdvance1
   :: Pos               -- ^ Tab width (unused)
   -> SourcePos         -- ^ Current position
@@ -64,6 +81,8 @@ defaultAdvance1
 defaultAdvance1 _width (SourcePos n l c) _t = SourcePos n l (c <> pos1)
 {-# INLINE defaultAdvance1 #-}
 
+-- | Adapt Cursor to MP Stream, patterned after
+-- [Char] instance.
 instance Stream Cursor where
   type Token Cursor = Exp Info
   type Tokens Cursor = [Exp Info]
@@ -83,7 +102,7 @@ instance Stream Cursor where
     | otherwise = Just $ second (Cursor _cContext) $ splitAt n _cStream
   takeWhile_ f Cursor{..} = second (Cursor _cContext) $ span f _cStream
 
-
+-- | Capture last-parsed Exp, plus arbitrary state.
 data ParseState a = ParseState
   { _psCurrent :: (Exp Info)
   , _psUser :: a
@@ -109,7 +128,7 @@ mkTextInfo s d = Info (Just (Code $ T.take (_pLength d) $
 
 type ExpParse s a = StateT (ParseState s) (Parsec Void Cursor) a
 
-
+-- | Run a compile. TODO squint harder at MP errors for better output.
 {-# INLINE runCompile #-}
 runCompile :: ExpParse s a -> ParseState s -> Exp Info -> Either PactError a
 runCompile act cs a =
@@ -171,29 +190,64 @@ expected s = syntaxError $ "Expected: " ++ s
 unexpected' :: String -> ExpParse s a
 unexpected' s = syntaxError $ "Unexpected: " ++ s
 
+{-# INLINE nes #-}
+nes :: a -> NonEmpty a
+nes x = x :| []
 
+-- | Test a token in the stream for epsilon/"trivial" acceptance,
+-- allowing for further tests on the result before committing.
+-- This is copypasta from Megaparsec's implementation of 'token' as
+-- of version 6.5.0, so this might break in future MP versions.
+{-# INLINE pTokenEpsilon #-}
+pTokenEpsilon :: forall e s m a. Stream s
+  => (Token s -> Either ( Maybe (ErrorItem (Token s))
+                        , S.Set (ErrorItem (Token s)) ) a)
+  -> Maybe (Token s)
+  -> ParsecT e s m a
+pTokenEpsilon test mtoken = ParsecT $ \s@(State input (pos:|z) tp w) _ _ eok eerr ->
+  case take1_ input of
+    Nothing ->
+      let us = pure EndOfInput
+          ps = maybe S.empty (S.singleton . Tokens . nes) mtoken
+      in eerr (TrivialError (pos:|z) us ps) s
+    Just (c,cs) ->
+      case test c of
+        Left (us, ps) ->
+          let !apos = positionAt1 (Proxy :: Proxy s) pos c
+          in eerr (TrivialError (apos:|z) us ps)
+                  (State input (apos:|z) tp w)
+        Right x ->
+          let !npos = advance1 (Proxy :: Proxy s) w pos c
+              newstate = State cs (npos:|z) (tp + 1) w
+          in eok x newstate mempty -- this is the only change from 'token'
+
+-- | Call commit continuation with current state.
+pCommit :: forall e s m . Stream s => ParsecT e s m ()
+pCommit = ParsecT $ \s cok _ _ _ -> cok () s mempty
+
+-- | Commit any previous recognitions.
+commit :: ExpParse s ()
+commit = lift pCommit
+
+-- | Recognize a specific Exp sub-type, non-committing.
 {-# INLINE exp #-}
-exp :: String -> Prism' (Exp Info) a -> (a-> Either String b) -> ExpParse s (b,Exp Info)
-exp ty prism test2 = do
+exp :: String -> Prism' (Exp Info) a -> ExpParse s (a,Exp Info)
+exp ty prism = do
   let test i = case firstOf prism i of
-        Just a -> case test2 a of
-          Right b -> Right (b,i)
-          Left e -> err i e
+        Just a -> Right (a,i)
         Nothing -> err i ("Expected: " ++ ty)
       err i s = Left (pure (Tokens (i:|[])),
                       S.singleton (strErr s))
-  r <- context >>= token test
+  r <- context >>= (lift . pTokenEpsilon test)
   psCurrent .= snd r
   return r
 
-{-# INLINE exp' #-}
-exp' :: String -> Prism' (Exp Info) a -> ExpParse s a
-exp' t p = fst <$> exp t p Right
+-- | Recognize any Exp, committing.
+{-# INLINE anyExp #-}
+anyExp :: ExpParse s (Exp Info)
+anyExp = token Right Nothing
 
-{-# INLINE bareExp #-}
-bareExp :: ExpParse s (Exp Info)
-bareExp = token Right Nothing
-
+-- | Enter a list context, setting the token stream to its contents
 {-# INLINE enter #-}
 enter :: (ListExp Info,Exp Info) -> ExpParse s (ListExp Info)
 enter (l@ListExp{..},e) = do
@@ -201,6 +255,7 @@ enter (l@ListExp{..},e) = do
   setInput $ Cursor (Just (par,e)) _listList
   return l
 
+-- | Exit a list context, resuming a previous parent context.
 {-# INLINE exit #-}
 exit :: ExpParse s ()
 exit = do
@@ -209,59 +264,65 @@ exit = do
     Just (p,e) -> setInput p >> (psCurrent .= e)
     Nothing -> failure (Just EndOfInput) def
 
-{-# INLINE atom' #-}
-atom' :: (AtomExp Info -> Either String b) -> ExpParse s b
-atom' f = fst <$> exp "atom" _EAtom f
-
+-- | Recognize an atom, non-committing.
 {-# INLINE atom #-}
 atom :: ExpParse s (AtomExp Info)
-atom = exp' "atom" _EAtom
+atom = fst <$> exp "atom" _EAtom
 
+-- | Recognized a literal, non-committing.
 {-# INLINE lit #-}
 lit :: ExpParse s (LiteralExp Info)
-lit = exp' "literal" _ELiteral
+lit = fst <$> exp "literal" _ELiteral
 
+-- | Recognize a list, non-committing.
 {-# INLINE list #-}
 list :: ExpParse s (ListExp Info,Exp Info)
-list = exp "list" _EList Right
+list = exp "list" _EList
 
+-- | Recognize a separator, committing.
 {-# INLINE sep #-}
 sep :: Separator -> ExpParse s ()
-sep s = void $ exp "sep" _ESeparator $ \se@SeparatorExp{..} ->
-  if _sepSeparator == s then Right se else Left (show s)
+sep s = exp "sep" _ESeparator >>= \(SeparatorExp{..},_) ->
+  if _sepSeparator == s then commit else expected (show s)
 
+-- | Recognize a specific literal, non-committing.
 {-# INLINE lit' #-}
 lit' :: String -> Prism' Literal a -> ExpParse s a
 lit' ty prism = lit >>= \LiteralExp{..} -> case firstOf prism _litLiteral of
   Just l -> return l
   Nothing -> expected ty
 
+-- | Recognize a String literal, non-committing.
 {-# INLINE str #-}
 str :: ExpParse s Text
 str = lit' "string" _LString
 
+-- | Recognize a list with specified delimiter, committing.
 {-# INLINE list' #-}
 list' :: ListDelimiter -> ExpParse s (ListExp Info,Exp Info)
 list' d = list >>= \l@(ListExp{..},_) ->
-  if _listDelimiter == d then return l
+  if _listDelimiter == d then commit >> return l
   else expected $ enlist d (\(s,e)->unpack(s<>"list"<>e))
 
+-- | Recongize a list with specified delimiter and act on contents, committing.
 {-# INLINE withList #-}
 withList :: ListDelimiter -> (ListExp Info -> ExpParse s a) -> ExpParse s a
 withList d act = try $ list' d >>= enter >>= act >>= \a -> exit >> return a
 
+-- | 'withList' without providing ListExp arg to action, committing.
 {-# INLINE withList' #-}
 withList' :: ListDelimiter -> ExpParse s a -> ExpParse s a
 withList' d = withList d . const
 
+-- | Recognize an unqualified "bare" atom, non-committing.
 {-# INLINE bareAtom #-}
 bareAtom :: ExpParse s (AtomExp Info)
 bareAtom = atom >>= \a@AtomExp{..} -> case _atomQualifiers of
   (_:_) -> expected "unqualified atom"
   [] -> return a
 
+-- | Recognize a bare atom with expected text, committing.
 {-# INLINE symbol #-}
 symbol :: Text -> ExpParse s ()
-symbol s = void $ atom' $ \AtomExp{..} -> case _atomQualifiers of
-  [] | _atomAtom == s -> Right s
-  _ -> Left $ "Expected: " ++ unpack s
+symbol s = bareAtom >>= \AtomExp{..} ->
+  if _atomAtom == s then commit else expected $ unpack s


### PR DESCRIPTION
This cleans up `exp` by adapting megaparsec's `token` to defer the "committed" continuation, instead calling the epsilon continuation and providing explicit `commit`. Improvements include making it possible for `specialForm` to not be in a `try` block, but in general adapts MP for running multiple tests on a single capture.