### PR TITLE
Warning Flags + Fixes

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -171,7 +171,7 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options:         -Wall -O2 -Werror
+  ghc-options:         -Widentities -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches
   ghc-prof-options:    -fprof-auto -fprof-auto-calls
 
 executable pact
@@ -180,7 +180,7 @@ executable pact
   build-depends:       base
                      , pact
   hs-source-dirs:      executables
-  ghc-options:         -Wall -threaded -rtsopts
+  ghc-options:         -Widentities -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches -threaded -rtsopts
   ghc-prof-options:    -fprof-auto -fprof-auto-calls
   default-language:    Haskell2010
 
@@ -189,15 +189,16 @@ executable bench
   build-depends:       base
                      , pact
   hs-source-dirs:      executables
-  ghc-options:         -Wall -threaded -rtsopts
+  ghc-options:         -Widentities -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches -threaded -rtsopts
   ghc-prof-options:    -fprof-auto -fprof-auto-calls
   default-language:    Haskell2010
 
 test-suite hspec
-  type: exitcode-stdio-1.0
-  main-is: hspec.hs
-  hs-source-dirs: tests
+  type:             exitcode-stdio-1.0
+  main-is:          hspec.hs
+  hs-source-dirs:   tests
   default-language: Haskell2010
+  ghc-options:      -Widentities -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches -O2 -threaded
   build-depends:
                 base
               , hspec

--- a/pact.cabal
+++ b/pact.cabal
@@ -172,7 +172,7 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options:          -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches
+  ghc-options:         -Wall -Werror -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   ghc-prof-options:    -fprof-auto -fprof-auto-calls
 
 executable pact
@@ -181,7 +181,7 @@ executable pact
   build-depends:       base
                      , pact
   hs-source-dirs:      executables
-  ghc-options:          -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches -threaded -rtsopts
+  ghc-options:         -Wall -threaded -rtsopts -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   ghc-prof-options:    -fprof-auto -fprof-auto-calls
   default-language:    Haskell2010
 
@@ -190,7 +190,7 @@ executable bench
   build-depends:       base
                      , pact
   hs-source-dirs:      executables
-  ghc-options:          -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches -threaded -rtsopts
+  ghc-options:         -Wall -threaded -rtsopts -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   ghc-prof-options:    -fprof-auto -fprof-auto-calls
   default-language:    Haskell2010
 
@@ -199,7 +199,7 @@ test-suite hspec
   main-is:          hspec.hs
   hs-source-dirs:   tests
   default-language: Haskell2010
-  ghc-options:       -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches -O2 -threaded
+  ghc-options:      -Wall -threaded -rtsopts -O2 -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
                 base
               , hspec

--- a/pact.cabal
+++ b/pact.cabal
@@ -172,7 +172,7 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options:         -Widentities -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches
+  ghc-options:          -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches
   ghc-prof-options:    -fprof-auto -fprof-auto-calls
 
 executable pact
@@ -181,7 +181,7 @@ executable pact
   build-depends:       base
                      , pact
   hs-source-dirs:      executables
-  ghc-options:         -Widentities -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches -threaded -rtsopts
+  ghc-options:          -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches -threaded -rtsopts
   ghc-prof-options:    -fprof-auto -fprof-auto-calls
   default-language:    Haskell2010
 
@@ -190,7 +190,7 @@ executable bench
   build-depends:       base
                      , pact
   hs-source-dirs:      executables
-  ghc-options:         -Widentities -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches -threaded -rtsopts
+  ghc-options:          -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches -threaded -rtsopts
   ghc-prof-options:    -fprof-auto -fprof-auto-calls
   default-language:    Haskell2010
 
@@ -199,7 +199,7 @@ test-suite hspec
   main-is:          hspec.hs
   hs-source-dirs:   tests
   default-language: Haskell2010
-  ghc-options:      -Widentities -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches -O2 -threaded
+  ghc-options:       -Wincomplete-patterns -Wincomplete-record-updates -Wincomplete-uni-patterns -Wname-shadowing -Wredundant-constraints -Wunused-binds -Wunused-imports -Wunused-matches -O2 -threaded
   build-depends:
                 base
               , hspec

--- a/pact.cabal
+++ b/pact.cabal
@@ -119,6 +119,7 @@ library
                      , bound >= 2 && < 2.1
                      , bytestring >=0.10.8.1 && < 0.11
                      , cereal >=0.5.4.0 && < 0.6
+                     , compactable >= 0.1 && < 0.2
                      , containers >= 0.5.7 && < 0.6
                      , data-default >= 0.7.1.1 && < 0.8
                      , deepseq >= 1.4.2.0 && < 1.5

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -24,7 +24,6 @@ import Data.Default
 import Pact.Types.Logger
 import System.CPUTime
 import Pact.MockDb
-import Data.String
 import qualified Data.Map.Strict as M
 import Pact.Persist.MockPersist
 import Pact.Persist
@@ -92,7 +91,7 @@ benchKeySet = KeySet [PublicKey "benchadmin"] (Name ">" def)
 acctRow :: Columns Persistable
 acctRow = Columns $ M.fromList [("balance",PLiteral (LDecimal 100.0))]
 
-benchRead :: (IsString k,FromJSON v) => Domain k v -> k -> Method () (Maybe v)
+benchRead :: Domain k v -> k -> Method () (Maybe v)
 benchRead KeySets _ = rc (Just benchKeySet)
 benchRead UserTables {} _ = rc (Just acctRow)
 benchRead _ _ = rc Nothing

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -137,6 +137,7 @@ data VerificationFailure
   = ModuleParseFailure ParseFailure
   | ModuleCheckFailure CheckFailure
   | TypeTranslationFailure Text (Pact.Type TC.UserType)
+  | InvalidRefType
   deriving Show
 
 describeCheckSuccess :: CheckSuccess -> Text
@@ -404,58 +405,60 @@ moduleFunChecks
   -> HM.HashMap Text (DefinedProperty (Exp Info))
   -> Except VerificationFailure
        (HM.HashMap Text (Ref, Either ParseFailure [Located Check]))
-moduleFunChecks tables modTys propDefs = for modTys $
-  \(ref@(Ref defn), Pact.FunType argTys resultTy) -> do
+moduleFunChecks tables modTys propDefs = for modTys $ \case
+  -- TODO How better to handle the type mismatch?
+  (Pact.Direct _, _) -> throwError InvalidRefType
+  (ref@(Ref defn), Pact.FunType argTys resultTy) -> do
 
-  let -- TODO: Ideally we wouldn't have any ad-hoc VID generation, but we're
-      --       not there yet:
-      vids = VarId <$> [1..]
+    -- TODO: Ideally we wouldn't have any ad-hoc VID generation, but we're
+    --       not there yet:
+    let vids = VarId <$> [1..]
 
-  -- TODO(joel): this relies on generating the same unique ids as
-  -- @checkFunction@. We need to more carefully enforce this is true!
-  argTys' <- for argTys $ \(Pact.Arg name ty _info) ->
-    case maybeTranslateType ty of
-      Just ety -> pure (name, ety)
+    -- TODO(joel): this relies on generating the same unique ids as
+    -- @checkFunction@. We need to more carefully enforce this is true!
+    argTys' <- for argTys $ \(Pact.Arg name ty _info) ->
+      case maybeTranslateType ty of
+        Just ety -> pure (name, ety)
+        Nothing  -> throwError $
+          TypeTranslationFailure "couldn't translate argument type" ty
+
+    resultTy' <- case maybeTranslateType resultTy of
+      Just ety -> pure ("result", 0, ety)
       Nothing  -> throwError $
-        TypeTranslationFailure "couldn't translate argument type" ty
+        TypeTranslationFailure "couldn't translate result type" resultTy
 
-  resultTy' <- case maybeTranslateType resultTy of
-    Just ety -> pure ("result", 0, ety)
-    Nothing  -> throwError $
-      TypeTranslationFailure "couldn't translate result type" resultTy
+    let env :: [(Text, VarId, EType)]
+        env = resultTy' :
+          ((\(vid, (text, ty)) -> (text, vid, ty)) <$> zip vids argTys')
 
-  let env :: [(Text, VarId, EType)]
-      env = resultTy' :
-        ((\(vid, (text, ty)) -> (text, vid, ty)) <$> zip vids argTys')
+        nameEnv :: Map Text VarId
+        nameEnv = Map.fromList $ fmap (\(name, vid, _) -> (name, vid)) env
 
-      nameEnv :: Map Text VarId
-      nameEnv = Map.fromList $ fmap (\(name, vid, _) -> (name, vid)) env
+        idEnv :: Map VarId EType
+        idEnv = Map.fromList $ fmap (\(_, vid, ty) -> (vid, ty)) env
 
-      idEnv :: Map VarId EType
-      idEnv = Map.fromList $ fmap (\(_, vid, ty) -> (vid, ty)) env
+        vidStart = VarId (length env)
 
-      vidStart = VarId (length env)
+        tableEnv = TableMap $ Map.fromList $
+          tables <&> \Table { _tableName, _tableType } ->
+                       let fields = _utFields _tableType
+                           colMap = ColumnMap $ Map.fromList $ flip mapMaybe fields $
+                             \(Pact.Arg argName ty _) ->
+                               (ColumnName (T.unpack argName),) <$> maybeTranslateType ty
+                       in (TableName (T.unpack _tableName), colMap)
 
-      tableEnv = TableMap $ Map.fromList $
-        tables <&> \Table { _tableName, _tableType } ->
-          let fields = _utFields _tableType
-              colMap = ColumnMap $ Map.fromList $ flip mapMaybe fields $
-                \(Pact.Arg argName ty _) ->
-                  (ColumnName (T.unpack argName),) <$> maybeTranslateType ty
-          in (TableName (T.unpack _tableName), colMap)
+    checks <- case defn ^? tMeta . mModel . _Just of
+      -- no model = no properties
+      Nothing    -> pure []
+      Just model -> withExcept ModuleParseFailure $ liftEither $ do
+        let model'        = expToMapping model
+            expProperties = model' ^? _Just . ix "properties"
+            expProperty   = model' ^? _Just . ix "property"
+        exps <- collectExps "properties" expProperties expProperty
+        runExpParserOver exps $
+          expToCheck tableEnv vidStart nameEnv idEnv propDefs
 
-  checks <- case defn ^? tMeta . mModel . _Just of
-    -- no model = no properties
-    Nothing    -> pure []
-    Just model -> withExcept ModuleParseFailure $ liftEither $ do
-      let model'        = expToMapping model
-          expProperties = model' ^? _Just . ix "properties"
-          expProperty   = model' ^? _Just . ix "property"
-      exps <- collectExps "properties" expProperties expProperty
-      runExpParserOver exps $
-        expToCheck tableEnv vidStart nameEnv idEnv propDefs
-
-  pure (ref, Right checks)
+    pure (ref, Right checks)
 
 -- | Given an exp like '(k v)', convert it to a singleton map
 expToMapping :: Exp Info -> Maybe (Map Text (Exp Info))

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -410,9 +410,9 @@ moduleFunChecks tables modTys propDefs = for modTys $ \case
   (Pact.Direct _, _) -> throwError InvalidRefType
   (ref@(Ref defn), Pact.FunType argTys resultTy) -> do
 
-    -- TODO: Ideally we wouldn't have any ad-hoc VID generation, but we're
-    --       not there yet:
-    let vids = VarId <$> [1..]
+    let -- TODO: Ideally we wouldn't have any ad-hoc VID generation, but we're
+        --       not there yet:
+        vids = VarId <$> [1..]
 
     -- TODO(joel): this relies on generating the same unique ids as
     -- @checkFunction@. We need to more carefully enforce this is true!
@@ -441,11 +441,11 @@ moduleFunChecks tables modTys propDefs = for modTys $ \case
 
         tableEnv = TableMap $ Map.fromList $
           tables <&> \Table { _tableName, _tableType } ->
-                       let fields = _utFields _tableType
-                           colMap = ColumnMap $ Map.fromList $ flip mapMaybe fields $
-                             \(Pact.Arg argName ty _) ->
-                               (ColumnName (T.unpack argName),) <$> maybeTranslateType ty
-                       in (TableName (T.unpack _tableName), colMap)
+            let fields = _utFields _tableType
+                colMap = ColumnMap $ Map.fromList $ flip mapMaybe fields $
+                  \(Pact.Arg argName ty _) ->
+                    (ColumnName (T.unpack argName),) <$> maybeTranslateType ty
+            in (TableName (T.unpack _tableName), colMap)
 
     checks <- case defn ^? tMeta . mModel . _Just of
       -- no model = no properties

--- a/src/Pact/Analyze/Eval/Numerical.hs
+++ b/src/Pact/Analyze/Eval/Numerical.hs
@@ -14,7 +14,7 @@ import           Pact.Analyze.Types.Eval
 import           Pact.Analyze.Types
 
 evalNumerical
-  :: (Analyzer m, S :<: TermOf m)
+  :: (Analyzer m)
   => Numerical (TermOf m) a -> m (S a)
 evalNumerical (DecArithOp op x y)      = evalDecArithOp op x y
 evalNumerical (IntArithOp op x y)      = evalIntArithOp op x y
@@ -160,7 +160,7 @@ banker'sMethod x =
 -- return: SReal        := -100.15
 evalRoundingLikeOp2
   :: forall m
-   . (Analyzer m, S :<: TermOf m)
+   . (Analyzer m)
   => RoundingLikeOp
   -> TermOf m Decimal
   -> TermOf m Integer

--- a/src/Pact/Analyze/Parse/Prop.hs
+++ b/src/Pact/Analyze/Parse/Prop.hs
@@ -429,8 +429,9 @@ inferPreProp preProp = case preProp of
       Just (DefinedProperty argTys body) -> do
         when (length args /= length argTys) $
           throwErrorIn preProp "wrong number of arguments"
-        propArgs <- for (zip args argTys) $ \(arg, (name, EType ty)) ->
-          (name,) . ESimple ty <$> checkPreProp ty arg
+        propArgs <- for (zip args argTys) $ \case
+          (arg, (name, EType ty)) -> (name,) . ESimple ty <$> checkPreProp ty arg
+          _ -> throwErrorIn preProp "Internal pattern match failure."
 
         -- inline the function, removing it from `definedProps` so it can't
         -- recursively call itself.

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -469,9 +469,8 @@ ksCell
 ksCell tn cn sRk sDirty = latticeState.lasTableCells.singular (ix tn).scKsValues.
   singular (ix cn).symArrayAt sRk.sbv2SFrom (fromCell tn cn sRk sDirty)
 
-symArrayAt
-  :: forall array k v
-   . (SymWord k, SymWord v, SymArray array)
+symArrayAt :: forall array k v
+   . (SymWord v, SymArray array)
   => S k -> Lens' (array k v) (SBV v)
 symArrayAt (S _ symKey) = lens getter setter
   where
@@ -482,14 +481,14 @@ symArrayAt (S _ symKey) = lens getter setter
     setter arr = writeArray arr symKey
 
 nameAuthorized
-  :: (MonadReader r m, HasAnalyzeEnv r, MonadError AnalyzeFailure m)
+  :: (MonadReader r m, HasAnalyzeEnv r)
   => S KeySetName
   -> m (S Bool)
 nameAuthorized sKsn = fmap sansProv $
   readArray <$> view ksAuths <*> (_sSbv <$> resolveKeySet sKsn)
 
 resolveKeySet
-  :: (MonadReader r m, HasAnalyzeEnv r, MonadError AnalyzeFailure m)
+  :: (MonadReader r m, HasAnalyzeEnv r)
   => S KeySetName
   -> m (S KeySet)
 resolveKeySet sKsn = fmap (withProv $ fromNamedKs sKsn) $
@@ -497,7 +496,7 @@ resolveKeySet sKsn = fmap (withProv $ fromNamedKs sKsn) $
 
 -- TODO: switch to lens
 resolveDecimal
-  :: (MonadReader r m, HasAnalyzeEnv r, MonadError AnalyzeFailure m)
+  :: (MonadReader r m, HasAnalyzeEnv r)
   => S String
   -> m (S Decimal)
 resolveDecimal sDn = fmap sansProv $

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -469,7 +469,8 @@ ksCell
 ksCell tn cn sRk sDirty = latticeState.lasTableCells.singular (ix tn).scKsValues.
   singular (ix cn).symArrayAt sRk.sbv2SFrom (fromCell tn cn sRk sDirty)
 
-symArrayAt :: forall array k v
+symArrayAt
+  :: forall array k v
    . (SymWord v, SymArray array)
   => S k -> Lens' (array k v) (SBV v)
 symArrayAt (S _ symKey) = lens getter setter

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -80,7 +80,7 @@ class sub :<: sup where
   inject  :: sub a -> sup a
   project :: sup a -> Maybe (sub a)
 
-instance Functor f => f :<: f where
+instance f :<: f where
   inject  = id
   project = Just
 

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -404,11 +404,7 @@ coerceS (S mProv a) = S mProv $ coerceSBV a
 iteS :: Mergeable a => S Bool -> a -> a -> a
 iteS sbool = ite (_sSbv sbool)
 
-fromIntegralS
-  :: forall a b
-  .  (Integral a, HasKind a, Num a, SymWord a, HasKind b, Num b, SymWord b)
-  => S a
-  -> S b
+fromIntegralS :: (Integral a, SymWord a, Num b, SymWord b) => S a -> S b
 fromIntegralS = over s2Sbv sFromIntegral
 
 realToIntegerS :: S Decimal -> S Integer

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -404,7 +404,11 @@ coerceS (S mProv a) = S mProv $ coerceSBV a
 iteS :: Mergeable a => S Bool -> a -> a -> a
 iteS sbool = ite (_sSbv sbool)
 
-fromIntegralS :: (Integral a, SymWord a, Num b, SymWord b) => S a -> S b
+fromIntegralS
+  :: forall a b
+  . (Integral a, SymWord a, Num b, SymWord b)
+  => S a
+  -> S b
 fromIntegralS = over s2Sbv sFromIntegral
 
 realToIntegerS :: S Decimal -> S Integer

--- a/src/Pact/Docgen.hs
+++ b/src/Pact/Docgen.hs
@@ -3,6 +3,11 @@
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE ViewPatterns      #-}
 
+-- TODO This is to silence a warning caused by usage of the `Feature` pattern.
+-- The pattern only seems to be used in one place, and could probably be
+-- factored out. When done, remove this pragma.
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+
 -- |
 -- Module      :  Pact.Docgen
 -- Copyright   :  (C) 2016 Stuart Popejoy

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -8,6 +8,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
+
+-- TODO This is to hide a warning involving `enforceKeySet`, which has a typeclass
+-- constraint unused in the function itself, but is critical for preventing misuse
+-- by a caller. There is probably a better way to enforce this restriction,
+-- allowing us to remove this warning suppression.
+-- See: https://github.com/kadena-io/pact/pull/206/files#r215468087
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+
 -- |
 -- Module      :  Pact.Eval
 -- Copyright   :  (C) 2016 Stuart Popejoy
@@ -81,7 +89,8 @@ enforceKeySetName mi mksn = do
 {-# INLINE enforceKeySetName #-}
 
 -- | Enforce keyset against environment
-enforceKeySet :: Info -> Maybe KeySetName -> KeySet -> Eval e ()
+enforceKeySet :: PureNoDb e => Info ->
+  Maybe KeySetName -> KeySet -> Eval e ()
 enforceKeySet i ksn KeySet{..} = do
   sigs <- view eeMsgSigs
   let count = length _ksKeys

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -81,8 +81,7 @@ enforceKeySetName mi mksn = do
 {-# INLINE enforceKeySetName #-}
 
 -- | Enforce keyset against environment
-enforceKeySet :: PureNoDb e => Info ->
-             Maybe KeySetName -> KeySet -> Eval e ()
+enforceKeySet :: Info -> Maybe KeySetName -> KeySet -> Eval e ()
 enforceKeySet i ksn KeySet{..} = do
   sigs <- view eeMsgSigs
   let count = length _ksKeys

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -90,7 +90,7 @@ enforceKeySetName mi mksn = do
 
 -- | Enforce keyset against environment
 enforceKeySet :: PureNoDb e => Info ->
-  Maybe KeySetName -> KeySet -> Eval e ()
+             Maybe KeySetName -> KeySet -> Eval e ()
 enforceKeySet i ksn KeySet{..} = do
   sigs <- view eeMsgSigs
   let count = length _ksKeys

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -393,7 +393,7 @@ enforceOne i as@[msg,TList conds _ _] = runPureSys (_faInfo i) $ gasUnreduced i 
 enforceOne i as = argsError' i as
 
 
-enforce' :: PureNoDb e => RNativeFun e
+enforce' :: RNativeFun e
 enforce' i [TLiteral (LBool b) _,TLitString msg]
     | b = return $ TLiteral (LBool True) def
     | otherwise = failTx (_faInfo i) $ unpack msg

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -6,6 +6,13 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TupleSections #-}
 
+-- TODO This is to hide a warning involving `enforce'`, which has a typeclass
+-- constraint unused in the function itself, but is critical for preventing misuse
+-- by a caller. There is probably a better way to enforce this restriction,
+-- allowing us to remove this warning suppression.
+-- See: https://github.com/kadena-io/pact/pull/206/files#r215468087
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+
 -- |
 -- Module      :  Pact.Native
 -- Copyright   :  (C) 2016 Stuart Popejoy
@@ -393,7 +400,7 @@ enforceOne i as@[msg,TList conds _ _] = runPureSys (_faInfo i) $ gasUnreduced i 
 enforceOne i as = argsError' i as
 
 
-enforce' :: RNativeFun e
+enforce' :: PureNoDb e => RNativeFun e
 enforce' i [TLiteral (LBool b) _,TLitString msg]
     | b = return $ TLiteral (LBool True) def
     | otherwise = failTx (_faInfo i) $ unpack msg

--- a/src/Pact/Parse.hs
+++ b/src/Pact/Parse.hs
@@ -17,26 +17,29 @@
 --
 
 module Pact.Parse
-  ( exprs, exprsOnly
-  , parseExprs
-  , number
-  , PactParser(unPactParser)
-  ) where
+    (
+     exprs, exprsOnly
+    ,parseExprs
+    ,number
+    ,PactParser(unPactParser)
+    )
 
-import           Control.Applicative
-import           Control.Monad
+where
+
+import Text.Trifecta as TF
+import Text.Trifecta.Delta as TF
+import Control.Applicative
+import Data.List
+import Control.Monad
+import Prelude
+import Data.Decimal
 import qualified Data.Attoparsec.Text as AP
-import           Data.Char (digitToInt)
-import           Data.Decimal
-import           Data.List
-import           Data.Text (Text)
-import           Prelude
-import           Text.Trifecta as TF
-import           Text.Trifecta.Delta as TF
+import Data.Char (digitToInt)
+import Data.Text (Text)
 
-import           Pact.Types.Exp
-import           Pact.Types.Parser
-import           Pact.Types.Info
+import Pact.Types.Exp
+import Pact.Types.Parser
+import Pact.Types.Info
 
 ---
 
@@ -64,7 +67,8 @@ expr = do
     ]
 {-# INLINE expr #-}
 
--- TODO Consider: http://hackage.haskell.org/package/megaparsec-7.0.0/docs/Text-Megaparsec-Char-Lexer.html#v:float
+-- TODO As number parsing is a solved problem, consider something like:
+-- http://hackage.haskell.org/package/megaparsec-7.0.0/docs/Text-Megaparsec-Char-Lexer.html#v:float
 number :: (Monad m, TokenParsing m, DeltaParsing m) => PactParser m Literal
 number = do
   -- Tricky: note that we use `char :: CharParsing m => Char -> m Char` rather

--- a/src/Pact/Parse.hs
+++ b/src/Pact/Parse.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
-
 -- |
 -- Module      :  Pact.Compile
 -- Copyright   :  (C) 2016 Stuart Popejoy
@@ -41,7 +40,6 @@ import Pact.Types.Exp
 import Pact.Types.Parser
 import Pact.Types.Info
 
----
 
 -- | Main parser for Pact expressions.
 expr :: (Monad m, TokenParsing m, DeltaParsing m) => PactParser m (Exp Parsed)

--- a/src/Pact/Persist.hs
+++ b/src/Pact/Persist.hs
@@ -31,9 +31,12 @@ type Persist s a = s -> IO (s,a)
 
 newtype DataKey = DataKey Text
   deriving (Eq,Ord,IsString,AsString,Hashable)
+
 instance Show DataKey where show (DataKey k) = show k
+
 newtype TxKey = TxKey Integer
   deriving (Eq,Ord,Num,Enum,Real,Integral,Hashable)
+
 instance Show TxKey where show (TxKey k) = show k
 
 type DataTable = Table DataKey

--- a/src/Pact/Persist.hs
+++ b/src/Pact/Persist.hs
@@ -31,12 +31,9 @@ type Persist s a = s -> IO (s,a)
 
 newtype DataKey = DataKey Text
   deriving (Eq,Ord,IsString,AsString,Hashable)
-
 instance Show DataKey where show (DataKey k) = show k
-
 newtype TxKey = TxKey Integer
   deriving (Eq,Ord,Num,Enum,Real,Integral,Hashable)
-
 instance Show TxKey where show (TxKey k) = show k
 
 type DataTable = Table DataKey

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -188,7 +188,7 @@ viewLibState f = modifyLibState (id &&& f)
 setop :: LibOp -> Eval LibState ()
 setop v = setLibState $ set rlsOp v
 
-setenv :: Show a => Setter' (EvalEnv LibState) a -> a -> Eval LibState ()
+setenv :: Setter' (EvalEnv LibState) a -> a -> Eval LibState ()
 setenv l v = setop $ UpdateEnv $ Endo (set l v)
 
 

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -365,6 +365,8 @@ verify i as = case as of
             [Text.unpack $ describeCheckFailure checkFailure]
           Left (TypeTranslationFailure msg ty) -> setop $ TcErrors
             [Text.unpack $ msg <> ": " <> tShow ty]
+          Left (InvalidRefType) -> setop $ TcErrors
+            ["Invalid reference type given to typechecker."]
           Right (ModuleChecks propResults invariantResults warnings) -> setop $ TcErrors $
             let propResults'      = propResults      ^.. traverse . each
                 invariantResults' = invariantResults ^.. traverse . traverse . each

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -546,8 +546,8 @@ unifyTypes l r = case (l,r) of
         (TypeVar {},TyVar SchemaVar {}) -> Nothing
         (TypeVar {},TyUser {}) -> Nothing
         (TypeVar _ ac,TyVar sv@(TypeVar _ bc)) -> case unifyConstraints ac bc of
-          Just (Left uc)  -> Just . vWrap . TyVar $ (v  & tvConstraint .~ uc)
-          Just (Right uc) -> Just . sWrap . TyVar $ (sv & tvConstraint .~ uc)
+          Just (Left uc)  -> Just . vWrap . TyVar $ set tvConstraint uc v
+          Just (Right uc) -> Just . sWrap . TyVar $ set tvConstraint uc sv
           Nothing -> Nothing
         (TypeVar _ ac,_) | checkConstraints s ac -> Just useS
         _ -> Nothing

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -57,7 +57,6 @@ import Pact.Types.Typecheck
 import Pact.Types.Runtime
 import Pact.Types.Native
 
-
 die :: MonadThrow m => Info -> String -> m a
 die i s = throwM $ CheckerException i s
 

--- a/src/Pact/Types/ExpParser.hs
+++ b/src/Pact/Types/ExpParser.hs
@@ -221,7 +221,7 @@ pTokenEpsilon test mtoken = ParsecT $ \s@(State input (pos:|z) tp w) _ _ eok eer
           in eok x newstate mempty -- this is the only change from 'token'
 
 -- | Call commit continuation with current state.
-pCommit :: forall e s m . Stream s => ParsecT e s m ()
+pCommit :: forall e s m. ParsecT e s m ()
 pCommit = ParsecT $ \s cok _ _ _ -> cok () s mempty
 
 -- | Commit any previous recognitions.

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,6 +19,7 @@ packages:
 
 extra-deps:
   - bound-2
+  - compactable-0.1.2.2
   - ed25519-donna-0.1.1
   - megaparsec-6.5.0
   - parser-combinators-1.0.0

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -10,7 +10,7 @@
 module AnalyzeSpec (spec) where
 
 import           Control.Lens                 (at, findOf, ix, matching, (&),
-                                               (.~), (^.), (^..), _2, _Left)
+                                               (.~), (^.), (^..), _Left)
 import           Control.Monad                (unless)
 import           Control.Monad.Except         (runExceptT)
 import           Control.Monad.State.Strict   (runStateT)

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -1001,9 +1001,10 @@ spec = describe "analyze" $ do
                 find (\(Located _ (nm, _)) -> nm == "amount") $ args ^.. traverse
               (SBV amount :: SBV Decimal) `shouldSatisfy` (`isConcretely` (< 0))
 
-            let negativeWrite (Object m) =
-                  let (_bal, AVal _ sval) = m Map.! "balance"
-                  in (SBV sval :: SBV Decimal) `isConcretely` (< 0)
+            let negativeWrite (Object m) = case m Map.! "balance" of
+                  (_bal, AVal _ sval) -> (SBV sval :: SBV Decimal) `isConcretely` (< 0)
+                  _ -> False
+
             balanceWrite <- pure $ find negativeWrite
               $ writes ^.. traverse . located . accObject
 

--- a/tests/Blake2Spec.hs
+++ b/tests/Blake2Spec.hs
@@ -24,11 +24,8 @@ blake2b_res = pack [
     ]
 
 -- parameter sets
-b2b_md_len :: [Int]
-b2b_md_len = [ 20, 32, 48, 64 ]
-
-b2b_in_len :: [Int]
-b2b_in_len = [ 0, 3, 128, 129, 255, 1024 ]
+b2b_md_len :: [Int]; b2b_md_len = [ 20, 32, 48, 64 ];
+b2b_in_len :: [Int]; b2b_in_len = [ 0, 3, 128, 129, 255, 1024 ];
 
 
 selftest_seq :: Int -> Word32 -> ByteString
@@ -67,11 +64,8 @@ blake2s_res = pack [
     ];
 
 -- Parameter sets.
-b2s_md_len :: [Int]
-b2s_md_len = [ 16, 20, 28, 32 ]
-
-b2s_in_len :: [Int]
-b2s_in_len = [ 0,  3,  64, 65, 255, 1024 ]
+b2s_md_len :: [Int]; b2s_md_len = [ 16, 20, 28, 32 ];
+b2s_in_len :: [Int]; b2s_in_len = [ 0,  3,  64, 65, 255, 1024 ];
 
 blake2s_selftest :: Spec
 blake2s_selftest = either fail p hashing


### PR DESCRIPTION
### TODO 
- [x] Pact library
- [x] Benchmarks
- [x] Tests

### Motivation
Ironically, `-Wall` leaves out a number of useful warning flags. This PR turns those on, and fixes the issues they reveal (mostly redundant typeclass constraints and pattern-match exhaustiveness). 