### PR TITLE
Change function inlining to use CBV semantics

### DIFF
--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -9,9 +9,9 @@ import           Data.Maybe           (isJust)
 import           Data.Text            (Text)
 
 import qualified Pact.Types.Lang      as Lang
-import           Pact.Types.Runtime   (BindType (BindLet, BindSchema),
-                                       Literal (LString))
-import           Pact.Types.Typecheck (AST (App, Binding, List, Object, Prim, Step, Table),
+import           Pact.Types.Runtime   (Literal (LString))
+import           Pact.Types.Typecheck (AstBindType (..),
+                                       AST (App, Binding, List, Object, Prim, Step, Table),
                                        Fun (FDefun, FNative), Named, Node,
                                        PrimValue (PrimLit), Special (SBinding))
 import qualified Pact.Types.Typecheck as TC
@@ -35,14 +35,33 @@ pattern NativeFunc f <- FNative _ f _ _
 
 -- compileNode's Patterns
 
+-- NOTE: For now, we don't handle an inlined App's synthetic (CBV) let bindings
+--       specially -- we'll let AST_Let handle these bindings until a refactor
+--       that will soon land (from the `trace-scopes` branch). At that point,
+--       we can get rid of 'letBindingType', the current version of
+--       'AST_InlinedApp', 'mkLet', and change 'AST_Let' to only match
+--       'AstBindLet' 'Binding's.
+
+-- pattern AST_InlinedApp :: [(Named a, AST a)] -> [AST a] -> AST a
+-- pattern AST_InlinedApp bindings body <-
+--   App _ (FDefun _ _ _ _ [Binding _ bindings body AstBindInlinedCallArgs]) _args
+
 pattern AST_InlinedApp :: [AST a] -> AST a
-pattern AST_InlinedApp body <- App _node (FDefun _ _ _ _ body) _args
+pattern AST_InlinedApp body <- App _ (FDefun _ _ _ _ body) _args
+
+letBindingType :: AstBindType n -> Bool
+letBindingType AstBindLet = True
+letBindingType AstBindInlinedCallArgs = True
+letBindingType (AstBindSchema _) = False
+
+mkLet :: a -> [(Named a, AST a)] -> [AST a] -> AST a
+mkLet node bindings body = Binding node bindings body AstBindLet
 
 pattern AST_Let :: forall a. a -> [(Named a, AST a)] -> [AST a] -> AST a
-pattern AST_Let node bindings body = Binding node bindings body BindLet
+pattern AST_Let node bindings body <- Binding node bindings body (letBindingType -> True)
 
 pattern AST_BindSchema :: forall a. a -> [(Named a, AST a)] -> a -> [AST a] -> AST a
-pattern AST_BindSchema node bindings schema body <- Binding node bindings body (BindSchema schema)
+pattern AST_BindSchema node bindings schema body <- Binding node bindings body (AstBindSchema schema)
 
 pattern AST_Var :: forall a. a -> AST a
 pattern AST_Var var <- TC.Var var

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -511,7 +511,7 @@ translateNode astNode = astContext astNode $ case astNode of
 
       tagVarBinding varInfo unmungedVarName varType vid
 
-      body' <- translateNode $ AST_Let node bindingsRest body
+      body' <- translateNode $ mkLet node bindingsRest body
       pure $ case body' of
         ESimple bodyTy bodyTm -> ESimple bodyTy (Let varName vid rhsETerm bodyTm)
         EObject bodyTy bodyTm -> EObject bodyTy (Let varName vid rhsETerm bodyTm)

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -534,6 +534,22 @@ spec = describe "analyze" $ do
       Inj (RowWrite "tokens" (PVar 1 "row")) ==>
         Inj (RowEnforced "tokens" "ks" (PVar 1 "row"))
 
+  describe "call-by-value semantics for inlining" $ do
+    let code =
+          [text|
+            (defun id:string (s:string)
+              s
+              s)
+
+            (defun test:string ()
+              @model (properties [ (my-column-delta 1) ])
+              (id
+                (write accounts "bob"
+                  {"balance": (+ 1 (at 'balance (read accounts "bob")))})
+                ))
+          |]
+    expectVerified code
+
   describe "enforce-one.1" $ do
     let code =
           [text|


### PR DESCRIPTION
- Fixes #203 
- Changes inlining to let-bind arguments to new variables, and then substitutes _those new variables_ (instead of substituting _argument expressions_) into the function body. This achieves call-by-value semantics, whereas previously inlining used call-by-name semantics. This means that we now handle effectful code properly during inlining.
- Introduces a new `BindType` (called `BindInlinedCallArgs`) so that we indicate in inlined code where this new synthetic let binding came from. At the moment in `Pact.Analyze`, we don't treat this new synthetic let binding differently from normal upstream lets, but we will shortly on the `trace-scopes` branch.

@slpopejoy: we talked about potentially re-working `toFun` at the same time as this change, but I determined that the solution here will likely change _very little_ once that is complete; I want to think a little more about that change, and have opened a new issue to track it: #208

Stu, since these are non-trivial typechecker changes, can you take a look at this? Thanks.