### PR TITLE
Replace legacy `stack.yaml` syntax for source dependencies

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,19 +3,7 @@
 resolver: lts-8.15
 
 packages:
-- '.'
-- location:
-    git: https://github.com/slpopejoy/snap-cors.git
-    commit: cc88bab1fd3f62dc4d9f9ad81a231877a639c812
-  extra-dep: true
-- location:
-    git: https://github.com/kadena-io/thyme.git
-    commit: 6ee9fcb026ebdb49b810802a981d166680d867c9
-  extra-dep: true
-- location:
-    git: https://github.com/LeventErkok/sbv.git
-    commit: 3dc60340634c82f39f6c5dca2b3859d10925cfdf # with exposed registerKind
-  extra-dep: true
+  - '.'
 
 extra-deps:
   - bound-2
@@ -23,7 +11,9 @@ extra-deps:
   - megaparsec-6.5.0
   - parser-combinators-1.0.0
   - algebraic-graphs-0.1.1.1
-
-flags: {}
-
-extra-package-dbs: []
+  - git: https://github.com/slpopejoy/snap-cors.git
+    commit: cc88bab1fd3f62dc4d9f9ad81a231877a639c812
+  - git: https://github.com/kadena-io/thyme.git
+    commit: 6ee9fcb026ebdb49b810802a981d166680d867c9
+  - git: https://github.com/LeventErkok/sbv.git
+    commit: 3dc60340634c82f39f6c5dca2b3859d10925cfdf # with exposed registerKind


### PR DESCRIPTION
In preparing the Pact dependency graph for [this comment](https://github.com/kadena-io/pact/pull/195#issuecomment-420347793), I noticed that new versions of `stack` no longer parse the legacy source-dep syntax. This PR fixes the syntax, which is usable at least down to `stack 1.7.x`, the current stable release.

@mightybyte @slpopejoy 