### PR TITLE
Scope-aware linear analysis traces

### DIFF
--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -423,19 +423,19 @@ moduleFunChecks tables modTys propDefs = for modTys $ \case
           TypeTranslationFailure "couldn't translate argument type" ty
 
     resultTy' <- case maybeTranslateType resultTy of
-      Just ety -> pure ("result", 0, ety)
+      Just ety -> pure (0, "result", ety)
       Nothing  -> throwError $
         TypeTranslationFailure "couldn't translate result type" resultTy
 
-    let env :: [(Text, VarId, EType)]
+    let env :: [(VarId, Text, EType)]
         env = resultTy' :
-          ((\(vid, (text, ty)) -> (text, vid, ty)) <$> zip vids argTys')
+          ((\(vid, (nm, ty)) -> (vid, nm, ty)) <$> zip vids argTys')
 
         nameEnv :: Map Text VarId
-        nameEnv = Map.fromList $ fmap (\(name, vid, _) -> (name, vid)) env
+        nameEnv = Map.fromList $ fmap (\(vid, nm, _) -> (nm, vid)) env
 
         idEnv :: Map VarId EType
-        idEnv = Map.fromList $ fmap (\(_, vid, ty) -> (vid, ty)) env
+        idEnv = Map.fromList $ fmap (\(vid, _, ty) -> (vid, ty)) env
 
         vidStart = VarId (length env)
 

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -423,19 +423,19 @@ moduleFunChecks tables modTys propDefs = for modTys $ \case
           TypeTranslationFailure "couldn't translate argument type" ty
 
     resultTy' <- case maybeTranslateType resultTy of
-      Just ety -> pure (0, "result", ety)
+      Just ety -> pure $ Binding 0 "result" ety
       Nothing  -> throwError $
         TypeTranslationFailure "couldn't translate result type" resultTy
 
-    let env :: [(VarId, Text, EType)]
+    let env :: [Binding]
         env = resultTy' :
-          ((\(vid, (nm, ty)) -> (vid, nm, ty)) <$> zip vids argTys')
+          ((\(vid, (nm, ty)) -> Binding vid nm ty) <$> zip vids argTys')
 
         nameEnv :: Map Text VarId
-        nameEnv = Map.fromList $ fmap (\(vid, nm, _) -> (nm, vid)) env
+        nameEnv = Map.fromList $ fmap (\(Binding vid nm _) -> (nm, vid)) env
 
         idEnv :: Map VarId EType
-        idEnv = Map.fromList $ fmap (\(vid, _, ty) -> (vid, ty)) env
+        idEnv = Map.fromList $ fmap (\(Binding vid _ ty) -> (vid, ty)) env
 
         vidStart = VarId (length env)
 

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -240,7 +240,6 @@ evalTermO = \case
     rowReadCount tn sRk += 1
     tagAccessKey mtReads tid sRk
 
-
     aValFields <- iforM fields $ \fieldName fieldType -> do
       let cn = ColumnName $ T.unpack fieldName
       sDirty <- use $ cellWritten tn cn sRk

--- a/src/Pact/Analyze/Model/Text.hs
+++ b/src/Pact/Analyze/Model/Text.hs
@@ -130,6 +130,10 @@ showEvent ksProvs tags = \case
       [display mtVars vid showVar]
     TraceSubpathStart _ ->
       [] -- not shown to end-users
+    TracePushScope _ ->
+      []
+    TracePopScope _ ->
+      []
 
   where
     display

--- a/src/Pact/Analyze/Model/Text.hs
+++ b/src/Pact/Analyze/Model/Text.hs
@@ -144,7 +144,8 @@ showEvent ksProvs tags event = do
         pure [display mtAuths tid (showAuth recov $ tid `Map.lookup` ksProvs)]
       TraceSubpathStart _ ->
         pure [] -- not shown to end-users
-      TracePushScope _ scopeTy (fmap (view (located.bVid)) -> vids) -> do
+      TracePushScope _ scopeTy locatedBindings -> do
+        let vids = view (located.bVid) <$> locatedBindings
         modify succ
         let displayVids show' =
               (\vid -> indent1 $ display mtVars vid show') <$> vids

--- a/src/Pact/Analyze/Model/Text.hs
+++ b/src/Pact/Analyze/Model/Text.hs
@@ -149,9 +149,12 @@ showEvent ksProvs tags event = do
              ObjectScope      -> "destructuring object"
              FunctionScope nm -> "entering function " <> nm
           ) : ((\vid -> indent $ display mtVars vid showVar) <$> vids)
-      TracePopScope _ _ -> do
+      TracePopScope _ scopeTy tid _ -> do
         modify pred
-        pure []
+        pure $ case scopeTy of
+          LetScope -> []
+          ObjectScope -> []
+          FunctionScope _ -> ["returning with " <> display mtReturns tid showTVal]
 
   where
     display

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -35,12 +35,12 @@ pattern NativeFunc f <- FNative _ f _ _
 
 -- compileNode's Patterns
 
-pattern AST_InlinedApp :: [(Named a, AST a)] -> [AST a] -> AST a
-pattern AST_InlinedApp bindings body <-
-  App _ (FDefun _ _ _ _ [Binding _ bindings body AstBindInlinedCallArgs]) _args
+pattern AST_InlinedApp :: Text -> [(Named a, AST a)] -> [AST a] -> AST a
+pattern AST_InlinedApp funName bindings body <-
+  App _ (FDefun _ funName _ _ [Binding _ bindings body AstBindInlinedCallArgs]) _args
 
-pattern AST_Let :: forall a. a -> [(Named a, AST a)] -> [AST a] -> AST a
-pattern AST_Let node bindings body = Binding node bindings body AstBindLet
+pattern AST_Let :: forall a. [(Named a, AST a)] -> [AST a] -> AST a
+pattern AST_Let bindings body <- Binding _ bindings body AstBindLet
 
 pattern AST_BindSchema :: forall a. a -> [(Named a, AST a)] -> a -> [AST a] -> AST a
 pattern AST_BindSchema node bindings schema body <- Binding node bindings body (AstBindSchema schema)

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -35,30 +35,12 @@ pattern NativeFunc f <- FNative _ f _ _
 
 -- compileNode's Patterns
 
--- NOTE: For now, we don't handle an inlined App's synthetic (CBV) let bindings
---       specially -- we'll let AST_Let handle these bindings until a refactor
---       that will soon land (from the `trace-scopes` branch). At that point,
---       we can get rid of 'letBindingType', the current version of
---       'AST_InlinedApp', 'mkLet', and change 'AST_Let' to only match
---       'AstBindLet' 'Binding's.
-
--- pattern AST_InlinedApp :: [(Named a, AST a)] -> [AST a] -> AST a
--- pattern AST_InlinedApp bindings body <-
---   App _ (FDefun _ _ _ _ [Binding _ bindings body AstBindInlinedCallArgs]) _args
-
-pattern AST_InlinedApp :: [AST a] -> AST a
-pattern AST_InlinedApp body <- App _ (FDefun _ _ _ _ body) _args
-
-letBindingType :: AstBindType n -> Bool
-letBindingType AstBindLet = True
-letBindingType AstBindInlinedCallArgs = True
-letBindingType (AstBindSchema _) = False
-
-mkLet :: a -> [(Named a, AST a)] -> [AST a] -> AST a
-mkLet node bindings body = Binding node bindings body AstBindLet
+pattern AST_InlinedApp :: [(Named a, AST a)] -> [AST a] -> AST a
+pattern AST_InlinedApp bindings body <-
+  App _ (FDefun _ _ _ _ [Binding _ bindings body AstBindInlinedCallArgs]) _args
 
 pattern AST_Let :: forall a. a -> [(Named a, AST a)] -> [AST a] -> AST a
-pattern AST_Let node bindings body <- Binding node bindings body (letBindingType -> True)
+pattern AST_Let node bindings body = Binding node bindings body AstBindLet
 
 pattern AST_BindSchema :: forall a. a -> [(Named a, AST a)] -> a -> [AST a] -> AST a
 pattern AST_BindSchema node bindings schema body <- Binding node bindings body (AstBindSchema schema)

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -479,11 +479,7 @@ translateLet bindings body = withNewScope $ go bindings
         tagVarBinding varInfo unmungedVarName varType vid
 
         body' <- go bindingsRest
-        pure $ case body' of
-          ESimple bodyTy bodyTm ->
-            ESimple bodyTy (Let varName vid rhsETerm bodyTm)
-          EObject bodyTy bodyTm ->
-            EObject bodyTy (Let varName vid rhsETerm bodyTm)
+        pure $ mapExistential (Let varName vid rhsETerm) body'
 
 translateObjBinding
   :: [(Named Node, AST Node)]

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -404,7 +404,7 @@ data Term ret where
   IfThenElse      :: Term Bool -> (Path, Term a) -> (Path, Term a) -> Term a
 
   -- Variable binding
-  Let             :: Text -> VarId -> ETerm -> Term a -> Term a
+  Let             :: Text -> VarId -> TagId -> ETerm -> Term a -> Term a
 
   -- Control flow
   Sequence        :: ETerm     -> Term a ->           Term a

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -82,7 +82,7 @@ data TraceEvent
   | TraceAuth Recoverability (Located TagId)
   | TraceSubpathStart Path
   | TracePushScope Natural ScopeType [Located Binding]
-  | TracePopScope Natural ScopeType
+  | TracePopScope Natural ScopeType TagId EType
   deriving (Eq, Show)
 
 -- | An @ExecutionGraph@ is produced by translation, and contains all
@@ -138,6 +138,8 @@ data ModelTags (c :: Concreteness)
     -- each conditional. after a conditional, the path from before the
     -- conditional is resumed. we also split execution for each case of
     -- @enforce-one@.
+    , _mtReturns :: Map TagId TVal
+    -- ^ return values from function calls
     }
   deriving (Eq, Show)
 

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -76,6 +76,8 @@ data TraceEvent
   | TraceAuth Recoverability (Located TagId)
   | TraceBind (Located (VarId, Text, EType))
   | TraceSubpathStart Path
+  | TracePushScope Natural
+  | TracePopScope Natural
   deriving (Eq, Show)
 
 -- | An @ExecutionGraph@ is produced by translation, and contains all

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -482,6 +482,14 @@ newtype VarId
   = VarId Int
   deriving (Show, Eq, Enum, Num, Ord)
 
+data Binding
+  = Binding
+    { _bVid  :: VarId
+    , _bName :: Text
+    , _bType :: EType
+    }
+  deriving (Eq, Show)
+
 -- | The type of a pact data type we can't reason about -- see 'TAny'.
 data Any = Any
   deriving (Show, Read, Eq, Ord, Data)
@@ -615,6 +623,7 @@ makeLenses ''Object
 makeLenses ''OriginatingCell
 makePrisms ''Provenance
 makeLenses ''S
+makeLenses ''Binding
 makeLenses ''TableMap
 
 type instance Index (ColumnMap a) = ColumnName

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -211,7 +211,7 @@ data OriginatingCell
 data Provenance
   = FromCell    OriginatingCell
   | FromNamedKs (S KeySetName)
-  | FromInput   Text
+  | FromInput   Unmunged
   deriving (Eq, Show)
 
 -- Symbolic value carrying provenance, for tracking if values have come from a
@@ -482,11 +482,24 @@ newtype VarId
   = VarId Int
   deriving (Show, Eq, Enum, Num, Ord)
 
+-- | Identifier name that is guaranteed to be unique because it contains a
+-- unique identifier. These names are generated upstream in the typechecker
+-- (using 'freshId').
+newtype Munged
+  = Munged Text
+  deriving (Eq, Show)
+
+-- | A user-supplied (i.e. non-unique) identifer name.
+newtype Unmunged
+  = Unmunged Text
+  deriving (Eq, Show)
+
 data Binding
   = Binding
-    { _bVid  :: VarId
-    , _bName :: Text
-    , _bType :: EType
+    { _bVid   :: VarId
+    , _buName :: Unmunged
+    , _bmName :: Munged
+    , _bType  :: EType
     }
   deriving (Eq, Show)
 

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -1010,7 +1010,7 @@ spec = describe "analyze" $ do
 
             [CheckFailure _ (SmtFailure (Invalid model))] <- pure $
               invariantResults ^.. ix "test" . ix "accounts" . ix 0 . _Left
-            let (Model args (ModelTags _ _ writes _ _ _ _) ksProvs _) = model
+            let (Model args (ModelTags _ _ writes _ _ _ _ _) ksProvs _) = model
 
             it "should have a negative amount" $ do
               Just (Located _ (_, (_, AVal _prov amount))) <- pure $

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -1949,6 +1949,8 @@ spec = describe "analyze" $ do
         -- auth= isRight . matching _TraceAuth
         var    = isRight . matching _TraceBind
         path   = isRight . matching _TraceSubpathStart
+        push   = isRight . matching _TracePushScope
+        pop    = isRight . matching _TracePopScope
 
         match :: [a -> Bool] -> [a] -> Bool
         tests `match` items
@@ -1985,7 +1987,7 @@ spec = describe "analyze" $ do
             |]
 
       expectTrace code (bnot Success')
-        [read, var, read, var, assert, assert, write, write]
+        [push, read, var, read, var, assert, assert, write, write, pop]
 
     describe "doesn't include events excluded by a conditional" $ do
       let code =

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -1014,7 +1014,7 @@ spec = describe "analyze" $ do
 
             it "should have a negative amount" $ do
               Just (Located _ (_, (_, AVal _prov amount))) <- pure $
-                find (\(Located _ (nm, _)) -> nm == "amount") $ args ^.. traverse
+                find (\(Located _ (Unmunged nm, _)) -> nm == "amount") $ args ^.. traverse
               (SBV amount :: SBV Decimal) `shouldSatisfy` (`isConcretely` (< 0))
 
             let negativeWrite (Object m) = case m Map.! "balance" of
@@ -1942,12 +1942,11 @@ spec = describe "analyze" $ do
     expectFalsified code'
 
   describe "execution trace" $ do
-    let read, write, assert, {-auth,-} var :: TraceEvent -> Bool
+    let read, write, assert {-auth,-} :: TraceEvent -> Bool
         read   = isRight . matching _TraceRead
         write  = isRight . matching _TraceWrite
         assert = isRight . matching _TraceAssert
         -- auth= isRight . matching _TraceAuth
-        var    = isRight . matching _TraceBind
         path   = isRight . matching _TraceSubpathStart
         push   = isRight . matching _TracePushScope
         pop    = isRight . matching _TracePopScope
@@ -1987,7 +1986,7 @@ spec = describe "analyze" $ do
             |]
 
       expectTrace code (bnot Success')
-        [push, read, var, read, var, assert, assert, write, write, pop]
+        [read, read, push, assert, assert, write, write, pop]
 
     describe "doesn't include events excluded by a conditional" $ do
       let code =


### PR DESCRIPTION
Instead of emitting individual variable binding events, we now associate each binding with the (function, let, or object destructuring) scope in which it was defined.

With this information, we now indent analysis traces to make it clear when variables enter and exit scope, and when we enter and exit function calls.

For the following Pact code:

```lisp
(defun negate:integer (y:integer)
  (let ((res (- 0 y)))
    (enforce (= 0 0))
    res
    ))

(defun test:integer (x:integer)
  (let ((z
         (if (< x 0)
           0
           (negate (* x 2)))))
    z))
```

Where we used to display the following trace:

```
Invalidating model found:
  Arguments:
    x := 0

  Program trace:
    res := 0
    satisfied assertion: (= 0 0)
    z := 0

  Result:
    Return value: 0
```

We now display this new scope-aware trace:

```
Invalidating model found:
  Arguments:
    x := 0

  Program trace:
    entering function test.negate
      y := 0
      let
        res := 0
        satisfied assertion: (= 0 0)
      returning with 0
    let
      z := 0

  Result:
    Return value: 0
```