### PR TITLE
Revamp decimal arithmetic.

### DIFF
--- a/src/Pact/Analyze/Eval/Core.hs
+++ b/src/Pact/Analyze/Eval/Core.hs
@@ -18,8 +18,8 @@ import qualified Data.Text                   as T
 
 import           Pact.Analyze.Errors
 import           Pact.Analyze.Eval.Numerical
-import           Pact.Analyze.Types.Eval
 import           Pact.Analyze.Types
+import           Pact.Analyze.Types.Eval
 import           Pact.Analyze.Util
 
 
@@ -65,7 +65,7 @@ evalDecAddTime timeT secsT = do
   if isConcreteS secs
   -- Convert seconds to milliseconds /before/ conversion to Integer (see note
   -- [Time Representation]).
-  then pure $ time + fromIntegralS (banker'sMethod (secs * 1000000))
+  then pure $ time + fromIntegralS (banker'sMethod (secs .* fromIntegerD' 1000000))
   else throwErrorNoLoc $ PossibleRoundoff
     "A time being added is not concrete, so we can't guarantee that roundoff won't happen when it's converted to an integer."
 

--- a/src/Pact/Analyze/Eval/Core.hs
+++ b/src/Pact/Analyze/Eval/Core.hs
@@ -65,7 +65,7 @@ evalDecAddTime timeT secsT = do
   if isConcreteS secs
   -- Convert seconds to milliseconds /before/ conversion to Integer (see note
   -- [Time Representation]).
-  then pure $ time + fromIntegralS (banker'sMethod (secs .* fromIntegerD' 1000000))
+  then pure $ time + fromIntegralS (banker'sMethod (secs * fromInteger' 1000000))
   else throwErrorNoLoc $ PossibleRoundoff
     "A time being added is not concrete, so we can't guarantee that roundoff won't happen when it's converted to an integer."
 

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -195,7 +195,7 @@ tagVarBinding vid av = do
     Just tagAv -> addConstraint $ sansProv $ av .== tagAv
 
 symKsName :: S String -> S KeySetName
-symKsName = coerceS
+symKsName = unsafeCoerceS
 
 ksAuthorized :: S KeySet -> Analyze (S Bool)
 ksAuthorized sKs = do
@@ -382,14 +382,17 @@ evalTerm = \case
 
       case aval' of
         AVal mProv sVal -> do
-          let writeDelta :: forall t
-                          . (Num t, SymWord t)
-                         => (TableName -> ColumnName -> S RowKey -> S Bool -> Lens' AnalyzeState (S t))
-                         -> (TableName -> ColumnName -> S RowKey ->           Lens' AnalyzeState (S t))
-                         -> (TableName -> ColumnName ->                       Lens' AnalyzeState (S t))
-                         -> Analyze ()
-              writeDelta mkCellL mkCellDeltaL mkColDeltaL = do
-                let cell :: Lens' AnalyzeState (S t)
+          -- Note: writeDeltaI and writeDeltaD are exactly the same, except
+          -- that they use integer addition and decimal addition (also
+          -- subtraction) respectively. This is necessary because `Decimal` is
+          -- not an instance of `Num`. For why see note [SymbolicDecimal].
+          let writeDeltaI
+                :: (TableName -> ColumnName -> S RowKey -> S Bool -> Lens' AnalyzeState (S Integer))
+                -> (TableName -> ColumnName -> S RowKey ->           Lens' AnalyzeState (S Integer))
+                -> (TableName -> ColumnName ->                       Lens' AnalyzeState (S Integer))
+                -> Analyze ()
+              writeDeltaI mkCellL mkCellDeltaL mkColDeltaL = do
+                let cell :: Lens' AnalyzeState (S Integer)
                     cell = mkCellL tn cn sRk true
                 let next = mkS mProv sVal
                 prev <- use cell
@@ -398,10 +401,25 @@ evalTerm = \case
                 mkCellDeltaL tn cn sRk += diff
                 mkColDeltaL  tn cn     += diff
 
+          let writeDeltaD
+                :: (TableName -> ColumnName -> S RowKey -> S Bool -> Lens' AnalyzeState (S Decimal))
+                -> (TableName -> ColumnName -> S RowKey ->           Lens' AnalyzeState (S Decimal))
+                -> (TableName -> ColumnName ->                       Lens' AnalyzeState (S Decimal))
+                -> Analyze ()
+              writeDeltaD mkCellL mkCellDeltaL mkColDeltaL = do
+                let cell :: Lens' AnalyzeState (S Decimal)
+                    cell = mkCellL tn cn sRk true
+                let next = mkS mProv sVal
+                prev <- use cell
+                cell .= next
+                let diff = next .- prev
+                mkCellDeltaL tn cn sRk %= (.+ diff)
+                mkColDeltaL  tn cn     %= (.+ diff)
+
           case fieldType of
-            EType TInt     -> writeDelta intCell intCellDelta intColumnDelta
+            EType TInt     -> writeDeltaI intCell intCellDelta intColumnDelta
             EType TBool    -> boolCell    tn cn sRk true .= mkS mProv sVal
-            EType TDecimal -> writeDelta decimalCell decCellDelta decColumnDelta
+            EType TDecimal -> writeDeltaD decimalCell decCellDelta decColumnDelta
             EType TTime    -> timeCell    tn cn sRk true .= mkS mProv sVal
             EType TStr     -> stringCell  tn cn sRk true .= mkS mProv sVal
             EType TKeySet  -> ksCell      tn cn sRk true .= mkS mProv sVal

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -382,40 +382,30 @@ evalTerm = \case
 
       case aval' of
         AVal mProv sVal -> do
-          let writeDeltaI
-                :: (TableName -> ColumnName -> S RowKey -> S Bool -> Lens' AnalyzeState (S Integer))
-                -> (TableName -> ColumnName -> S RowKey ->           Lens' AnalyzeState (S Integer))
-                -> (TableName -> ColumnName ->                       Lens' AnalyzeState (S Integer))
+          -- Note: The reason for taking `plus` and `minus` as arguments is to
+          -- avoid overlapping instances. GHC is willing to pick `+` and `-`
+          -- for each of the two instantiations of this function.
+          let writeDelta
+                :: forall t
+                 . (S t -> S t -> S t) -> (S t -> S t -> S t)
+                -> (TableName -> ColumnName -> S RowKey -> S Bool -> Lens' AnalyzeState (S t))
+                -> (TableName -> ColumnName -> S RowKey ->           Lens' AnalyzeState (S t))
+                -> (TableName -> ColumnName ->                       Lens' AnalyzeState (S t))
                 -> Analyze ()
-              writeDeltaI mkCellL mkCellDeltaL mkColDeltaL = do
-                let cell :: Lens' AnalyzeState (S Integer)
+              writeDelta plus minus mkCellL mkCellDeltaL mkColDeltaL = do
+                let cell :: Lens' AnalyzeState (S t)
                     cell = mkCellL tn cn sRk true
                 let next = mkS mProv sVal
                 prev <- use cell
                 cell .= next
-                let diff = next - prev
-                mkCellDeltaL tn cn sRk += diff
-                mkColDeltaL  tn cn     += diff
-
-          let writeDeltaD
-                :: (TableName -> ColumnName -> S RowKey -> S Bool -> Lens' AnalyzeState (S Decimal))
-                -> (TableName -> ColumnName -> S RowKey ->           Lens' AnalyzeState (S Decimal))
-                -> (TableName -> ColumnName ->                       Lens' AnalyzeState (S Decimal))
-                -> Analyze ()
-              writeDeltaD mkCellL mkCellDeltaL mkColDeltaL = do
-                let cell :: Lens' AnalyzeState (S Decimal)
-                    cell = mkCellL tn cn sRk true
-                let next = mkS mProv sVal
-                prev <- use cell
-                cell .= next
-                let diff = next - prev
-                mkCellDeltaL tn cn sRk += diff
-                mkColDeltaL  tn cn     += diff
+                let diff = next `minus` prev
+                mkCellDeltaL tn cn sRk %= plus diff
+                mkColDeltaL  tn cn     %= plus diff
 
           case fieldType of
-            EType TInt     -> writeDeltaI intCell intCellDelta intColumnDelta
+            EType TInt     -> writeDelta (+) (-) intCell intCellDelta intColumnDelta
             EType TBool    -> boolCell   tn cn sRk true .= mkS mProv sVal
-            EType TDecimal -> writeDeltaD decimalCell decCellDelta decColumnDelta
+            EType TDecimal -> writeDelta (+) (-) decimalCell decCellDelta decColumnDelta
             EType TTime    -> timeCell   tn cn sRk true .= mkS mProv sVal
             EType TStr     -> stringCell tn cn sRk true .= mkS mProv sVal
             EType TKeySet  -> ksCell     tn cn sRk true .= mkS mProv sVal

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -382,10 +382,6 @@ evalTerm = \case
 
       case aval' of
         AVal mProv sVal -> do
-          -- Note: writeDeltaI and writeDeltaD are exactly the same, except
-          -- that they use integer addition and decimal addition (also
-          -- subtraction) respectively. This is necessary because `Decimal` is
-          -- not an instance of `Num`. For why see note [SymbolicDecimal].
           let writeDeltaI
                 :: (TableName -> ColumnName -> S RowKey -> S Bool -> Lens' AnalyzeState (S Integer))
                 -> (TableName -> ColumnName -> S RowKey ->           Lens' AnalyzeState (S Integer))
@@ -412,17 +408,17 @@ evalTerm = \case
                 let next = mkS mProv sVal
                 prev <- use cell
                 cell .= next
-                let diff = next .- prev
-                mkCellDeltaL tn cn sRk %= (.+ diff)
-                mkColDeltaL  tn cn     %= (.+ diff)
+                let diff = next - prev
+                mkCellDeltaL tn cn sRk += diff
+                mkColDeltaL  tn cn     += diff
 
           case fieldType of
             EType TInt     -> writeDeltaI intCell intCellDelta intColumnDelta
-            EType TBool    -> boolCell    tn cn sRk true .= mkS mProv sVal
+            EType TBool    -> boolCell   tn cn sRk true .= mkS mProv sVal
             EType TDecimal -> writeDeltaD decimalCell decCellDelta decColumnDelta
-            EType TTime    -> timeCell    tn cn sRk true .= mkS mProv sVal
-            EType TStr     -> stringCell  tn cn sRk true .= mkS mProv sVal
-            EType TKeySet  -> ksCell      tn cn sRk true .= mkS mProv sVal
+            EType TTime    -> timeCell   tn cn sRk true .= mkS mProv sVal
+            EType TStr     -> stringCell tn cn sRk true .= mkS mProv sVal
+            EType TKeySet  -> ksCell     tn cn sRk true .= mkS mProv sVal
             EType TAny     -> void $ throwErrorNoLoc OpaqueValEncountered
             EObjectTy _    -> void $ throwErrorNoLoc UnsupportedObjectInDbCell
 

--- a/src/Pact/Analyze/Model/Text.hs
+++ b/src/Pact/Analyze/Model/Text.hs
@@ -23,7 +23,6 @@ import qualified Data.Text                  as T
 import           GHC.Natural                (Natural)
 
 import qualified Pact.Types.Info            as Pact
-import           Pact.Types.Runtime         (tShow)
 
 import           Pact.Analyze.Model.Graph   (linearize)
 import           Pact.Analyze.Types
@@ -35,10 +34,10 @@ indent :: Natural -> Text -> Text
 indent 0     = id
 indent times = indent (pred times) . indent1
 
-showSbv :: (Show a, SymWord a) => SBV a -> Text
-showSbv sbv = maybe "[ERROR:symbolic]" tShow (SBV.unliteral sbv)
+showSbv :: (UserShow a, SymWord a) => SBV a -> Text
+showSbv sbv = maybe "[ERROR:symbolic]" userShow (SBV.unliteral sbv)
 
-showS :: (Show a, SymWord a) => S a -> Text
+showS :: (UserShow a, SymWord a) => S a -> Text
 showS = showSbv . _sSbv
 
 showTVal :: TVal -> Text

--- a/src/Pact/Analyze/Parse/Types.hs
+++ b/src/Pact/Analyze/Parse/Types.hs
@@ -62,7 +62,7 @@ instance UserShow PreProp where
   userShowsPrec prec = \case
     PreIntegerLit i -> tShow i
     PreStringLit t  -> tShow t
-    PreDecimalLit d -> tShow d
+    PreDecimalLit d -> userShow d
     PreTimeLit t    -> tShow (Pact.LTime (toPact timeIso t))
     PreBoolLit b    -> tShow (Pact.LBool b)
 

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -253,9 +253,9 @@ mkInitialAnalyzeState tables = AnalyzeState
     tableNames = map (TableName . T.unpack . view Types.tableName) tables
 
     intCellDeltas = mkTableColumnMap (== TyPrim TyInteger) (mkSFunArray (const 0))
-    decCellDeltas = mkTableColumnMap (== TyPrim TyDecimal) (mkSFunArray (const 0))
+    decCellDeltas = mkTableColumnMap (== TyPrim TyDecimal) (mkSFunArray (const (fromIntegerD 0)))
     intColumnDeltas = mkTableColumnMap (== TyPrim TyInteger) 0
-    decColumnDeltas = mkTableColumnMap (== TyPrim TyDecimal) 0
+    decColumnDeltas = mkTableColumnMap (== TyPrim TyDecimal) (fromIntegerD 0)
     cellsEnforced
       = mkTableColumnMap (== TyPrim TyKeySet) (mkSFunArray (const false))
     cellsWritten = mkTableColumnMap (const True) (mkSFunArray (const false))

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -253,9 +253,9 @@ mkInitialAnalyzeState tables = AnalyzeState
     tableNames = map (TableName . T.unpack . view Types.tableName) tables
 
     intCellDeltas = mkTableColumnMap (== TyPrim TyInteger) (mkSFunArray (const 0))
-    decCellDeltas = mkTableColumnMap (== TyPrim TyDecimal) (mkSFunArray (const (fromIntegerD 0)))
+    decCellDeltas = mkTableColumnMap (== TyPrim TyDecimal) (mkSFunArray (const (fromInteger 0)))
     intColumnDeltas = mkTableColumnMap (== TyPrim TyInteger) 0
-    decColumnDeltas = mkTableColumnMap (== TyPrim TyDecimal) (fromIntegerD 0)
+    decColumnDeltas = mkTableColumnMap (== TyPrim TyDecimal) (fromInteger 0)
     cellsEnforced
       = mkTableColumnMap (== TyPrim TyKeySet) (mkSFunArray (const false))
     cellsWritten = mkTableColumnMap (const True) (mkSFunArray (const false))

--- a/src/Pact/Analyze/Types/Numerical.hs
+++ b/src/Pact/Analyze/Types/Numerical.hs
@@ -1,19 +1,149 @@
-{-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE GADTs              #-}
-{-# LANGUAGE LambdaCase         #-}
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-} -- coerceSBV requires Coercible
 module Pact.Analyze.Types.Numerical where
 
-import           Control.Lens         (Prism')
-import           Data.SBV             (AlgReal)
-import           Data.Text            (Text)
+import           Control.Lens                (Prism')
+import           Data.Coerce                 (Coercible)
+import qualified Data.Decimal                as Decimal
+import           Data.SBV                    (HasKind (kindOf),
+                                              Kind (KUnbounded),
+                                              SDivisible (..), SymWord (..),
+                                              oneIf, (.>=), (.^))
+import           Data.SBV.Control            (SMTValue (sexprToVal))
+import           Data.SBV.Dynamic            (svPlus, svTimes, svUNeg)
+import           Data.SBV.Internals          (CW (..), CWVal (CWInteger),
+                                              SBV (SBV), SVal (SVal),
+                                              genMkSymVar, normCW)
+import qualified Data.SBV.Internals          as SBVI
+import           Data.Text                   (Text)
+import           GHC.Real                    ((%))
 
-import           Pact.Analyze.Feature
+import           Pact.Types.Util             (tShow)
+
+import           Pact.Analyze.Feature        hiding (dec)
 import           Pact.Analyze.Types.UserShow
 
--- Pact uses Data.Decimal which is arbitrary-precision
-type Decimal = AlgReal
+
+-- We model decimals as integers. The value of a decimal is the value of the
+-- integer, shifted right 255 decimal places.
+newtype Decimal = Decimal { unDecimal :: Integer }
+  deriving (Enum, Eq, Ord, Show)
+
+-- Note [SymbolicDecimal]:
+--
+-- Decimal used to be an instance of Num, and it almost still could be. The
+-- only problem is that sbv automatically builds an instance `instance (Ord a,
+-- Num a, SymWord a) => Num (SBV a)`, which ignores your own `Num` instance. In
+-- our case we need to do shifting aound multiplications and divisions so the
+-- default instance doesn't work.
+class SymbolicDecimal d where
+  type IntegerOf d :: *
+  negateD       ::                d -> d
+  (.+)          ::           d -> d -> d
+  (.-)          ::           d -> d -> d
+  (.*)          ::           d -> d -> d
+  (./)          ::           d -> d -> d
+  fromIntegerD  :: Integer          -> d
+  fromIntegerD' :: IntegerOf d      -> d
+  literalD      :: Decimal.Decimal  -> d
+  lShiftD       :: Int         -> d -> d
+  lShiftD'      :: IntegerOf d -> d -> d
+  rShiftD       :: Int         -> d -> d
+  rShiftD'      :: IntegerOf d -> d -> d
+  floorD        ::      d -> IntegerOf d
+
+instance SymbolicDecimal Decimal where
+  type IntegerOf Decimal = Integer
+  negateD (Decimal d)    = Decimal (negate d)
+  Decimal a .+ Decimal b = Decimal (a + b)
+  Decimal a .- Decimal b = Decimal (a - b)
+  Decimal a .* Decimal b = rShift255D (Decimal (a * b))
+  a         ./ Decimal b =
+    -- first make the numerator 10^255 times larger
+    let Decimal a'     = lShift255D a
+        -- now get the quotient and remainder
+        (divAb, modAb) = divMod a' b
+        -- if the remainder is more than half of the divisor, round up
+        adjustment     = if modAb * 2 >= b then 1 else 0
+    in Decimal $ divAb + adjustment
+  fromIntegerD i        = lShift255D (Decimal i)
+  fromIntegerD'         = fromIntegerD
+  literalD (Decimal.Decimal places mantissa)
+    = lShiftD (decimalPrecision - fromIntegral places) (Decimal mantissa)
+  lShiftD n (Decimal d) = Decimal (d * 10 ^ n)
+  lShiftD' n            = lShiftD (fromIntegral n)
+  rShiftD n (Decimal d) = Decimal (d `div` 10 ^ n)
+  rShiftD' n            = rShiftD (fromIntegral n)
+  floorD                = unDecimal . rShift255D
+
+instance SymbolicDecimal (SBV Decimal) where
+  type IntegerOf (SBV Decimal) = SBV Integer
+  negateD (SBVI.SBV a)         = SBVI.SBV (svUNeg a)
+  SBVI.SBV a .+ SBVI.SBV b     = SBVI.SBV (svPlus a b)
+  SBVI.SBV a .- SBVI.SBV b     = SBVI.SBV (svPlus a (svUNeg b))
+  SBVI.SBV a .* SBVI.SBV b     = rShift255D (SBVI.SBV (svTimes a b))
+
+  a ./ b =
+    let (divAb, modAb) = sDivMod
+          (coerceSBV @_ @Integer (lShift255D a))
+          (coerceSBV @_ @Integer b)
+        adjustment = oneIf $ coerceSBV modAb * 2 .>= coerceSBV @_ @Integer b
+    in coerceSBV $ divAb + adjustment
+
+  fromIntegerD  = literal . fromIntegerD
+  fromIntegerD' = lShift255D . coerceSBV
+  literalD      = literal . literalD
+
+  lShiftD  n = coerceSBV . (*       10  ^ n)  . coerceSBV @Decimal @Integer
+  lShiftD' n = coerceSBV . (*       10 .^ n)  . coerceSBV @Decimal @Integer
+  rShiftD  n = coerceSBV . (`sDiv` (10  ^ n)) . coerceSBV @Decimal @Integer
+  rShiftD' n = coerceSBV . (`sDiv` (10 .^ n)) . coerceSBV @Decimal @Integer
+  floorD     = coerceSBV . rShift255D
+
+decimalPrecision :: Int
+decimalPrecision = 255
+
+lShift255D :: SymbolicDecimal d => d -> d
+lShift255D = lShiftD decimalPrecision
+
+rShift255D :: SymbolicDecimal d => d -> d
+rShift255D = rShiftD decimalPrecision
+
+-- Note: we require a redundant `Coercible` constraint here. `a` and `b` are
+-- both phantom, so this is not actually required to do the conversion, but it
+-- seems right morally. We also provide the unsafe version for conversions like
+-- `Text` -> `String`.
+coerceSBV :: Coercible a b => SBV a -> SBV b
+coerceSBV = SBVI.SBV . SBVI.unSBV
+
+unsafeCoerceSBV :: SBV a -> SBV b
+unsafeCoerceSBV = SBVI.SBV . SBVI.unSBV
+
+instance HasKind Decimal where kindOf _ = KUnbounded
+instance SymWord Decimal where
+  mkSymWord  = genMkSymVar KUnbounded
+  literal a  = SBV . SVal KUnbounded . Left . normCW $ CW KUnbounded (CWInteger (unDecimal a))
+  fromCW (CW _ (CWInteger x)) = Decimal x
+  fromCW x = error $ "in instance SymWord Decimal: expected CWInteger, found: " ++ show x
+
+instance SMTValue Decimal where sexprToVal = fmap Decimal . sexprToVal
+
+instance UserShow Decimal where
+  userShowsPrec _ (Decimal dec) =
+    case Decimal.eitherFromRational (dec % (10 ^ decimalPrecision)) of
+      Left err                    -> error err
+      -- Make sure to show ".0":
+      Right (Decimal.Decimal 0 i) -> tShow $ Decimal.Decimal 1 (i * 10 :: Integer)
+      Right d                     -> tShow d
 
 -- Operations that apply to a pair of either integer or decimal, resulting in
 -- the same:

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -128,28 +128,16 @@ mkConcreteInteger = SBVI.SBV
 newtype PactIso a b = PactIso {unPactIso :: Iso' a b}
 
 decimalIso :: PactIso Decimal.Decimal Decimal
-decimalIso = PactIso $ iso literalD unMkDecimal
+decimalIso = PactIso $ iso mkDecimal unMkDecimal
   where
     unMkDecimal :: Decimal -> Decimal.Decimal
     unMkDecimal (Decimal dec) = case Decimal.eitherFromRational (dec % 10 ^ decimalPrecision) of
       Left err -> error err
       Right d  -> d
 
-instance SymbolicDecimal (S Decimal) where
-  type IntegerOf (S Decimal) = S Integer
-  negateD (S _ a)            = sansProv (negateD a)
-  S _ a .+ S _ b             = sansProv (a .+ b)
-  S _ a .- S _ b             = sansProv (a .- b)
-  S _ a .* S _ b             = sansProv (a .* b)
-  S _ a ./ S _ b             = sansProv (a ./ b)
-  fromIntegerD               = literalS . fromIntegerD
-  fromIntegerD' (S _ a)      = sansProv (fromIntegerD' a)
-  literalD                   = literalS . literalD
-  lShiftD  i       (S _ d)   = sansProv (lShiftD  i d)
-  lShiftD' (S _ i) (S _ d)   = sansProv (lShiftD' i d)
-  rShiftD  i       (S _ d)   = sansProv (rShiftD  i d)
-  rShiftD' (S _ i) (S _ d)   = sansProv (rShiftD' i d)
-  floorD (S _ d)             = sansProv (floorD d)
+    mkDecimal :: Decimal.Decimal -> Decimal
+    mkDecimal (Decimal.Decimal places mantissa)
+      = lShiftD (decimalPrecision - fromIntegral places) (Decimal mantissa)
 
 fromPact :: PactIso a b -> a -> b
 fromPact = view . unPactIso
@@ -336,6 +324,29 @@ instance Boolean (S Bool) where
 instance IsString (S String) where
   fromString = sansProv . fromString
 
+instance SymbolicDecimal (S Decimal) where
+  type IntegerOf (S Decimal) = S Integer
+  fromInteger' (S _ a)       = sansProv (fromInteger' a)
+  lShiftD  i       (S _ d)   = sansProv (lShiftD  i d)
+  lShiftD' (S _ i) (S _ d)   = sansProv (lShiftD' i d)
+  rShiftD  i       (S _ d)   = sansProv (rShiftD  i d)
+  rShiftD' (S _ i) (S _ d)   = sansProv (rShiftD' i d)
+  floorD (S _ d)             = sansProv (floorD d)
+
+-- Caution [OverlappingInstances]: Though it looks like this instance is
+-- exactly the same as the one below, do not be deceived, it is not. In this
+-- instance `*` resolves to `*` from `instance Num (SBV Decimal)`, which has an
+-- `rShift255D`. In the instance below, `*` resolves to `*` from `*` from
+-- `instance (Ord a, Num a, SymWord a) => Num (SBV a)`, included in sbv, which
+-- does to include the shift. *This instance must be selected for decimals*.
+instance {-# OVERLAPPING #-} Num (S Decimal) where
+  S _ x + S _ y  = sansProv $ x + y
+  S _ x * S _ y  = sansProv $ x * y
+  abs (S _ x)    = sansProv $ abs x
+  signum (S _ x) = sansProv $ signum x
+  fromInteger i  = sansProv $ fromInteger i
+  negate (S _ x) = sansProv $ negate x
+
 instance (Num a, SymWord a) => Num (S a) where
   S _ x + S _ y  = sansProv $ x + y
   S _ x * S _ y  = sansProv $ x * y
@@ -343,6 +354,12 @@ instance (Num a, SymWord a) => Num (S a) where
   signum (S _ x) = sansProv $ signum x
   fromInteger i  = sansProv $ fromInteger i
   negate (S _ x) = sansProv $ negate x
+
+-- Caution: see note [OverlappingInstances] *This instance must be selected for
+-- decimals*.
+instance {-# OVERLAPPING #-} Fractional (S Decimal) where
+  fromRational  = literalS . fromRational
+  S _ x / S _ y = sansProv $ x / y
 
 instance (Fractional a, SymWord a) => Fractional (S a) where
   fromRational = literalS . fromRational

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -208,37 +208,37 @@ spec = describe "analyze" $ do
     let unlit :: S Decimal -> Decimal
         unlit = fromJust . unliteralS
 
-    it "+"      $ unlit (literalD 1.1    .+ literalD 2.2   ) == literalD 3.3
-    it "* + +"  $ unlit (literalD 1.5    .* literalD 1.5   ) == literalD 2.25
-    it "* + -"  $ unlit (literalD 1.5    .* literalD (-1.5)) == literalD (-2.25)
-    it "* - +"  $ unlit (literalD (-1.5) .* literalD 1.5   ) == literalD (-2.25)
-    it "* - -"  $ unlit (literalD (-1.5) .* literalD (-1.5)) == literalD 2.25
+    it "+"      $ unlit (1.1  +   2.2)  == 3.3
+    it "* + +"  $ unlit (1.5  *   1.5)  == 2.25
+    it "* + -"  $ unlit (1.5  * (-1.5)) == -2.25
+    it "* - +"  $ unlit (-1.5 *   1.5)  == -2.25
+    it "* - -"  $ unlit (-1.5 * (-1.5)) == 2.25
 
-    it "negate" $ unlit (negateD (literalD 1.5))             == literalD (-1.5)
-    it "negate" $ unlit (negateD (literalD (-1.5)))          == literalD 1.5
+    it "negate" $ unlit (negate 1.5)    == -1.5
+    it "negate" $ unlit (negate (-1.5)) == 1.5
 
-    it "shifts" $ unlit (literalD 1.5    .* fromIntegerD 10) == literalD 15
-    it "shifts" $ unlit (literalD (-1.5) .* fromIntegerD 10) == literalD (-15)
-    it "shifts" $ lShift255D (rShift255D (literalD 1.5))     == literalD @Decimal 1
+    it "shifts" $ unlit ( 1.5 * fromInteger 10) == 15
+    it "shifts" $ unlit (-1.5 * fromInteger 10) == -15
+    it "shifts" $ lShift255D (rShift255D 1.5)   == (1 :: Decimal)
 
-    it "floor" $ floorD @Decimal (literalD 0)            == 0
-    it "floor" $ floorD @Decimal (literalD (1.5))        == 1
-    it "floor" $ floorD @Decimal (literalD (-1.5))       == -2
+    it "floor" $ floorD @Decimal 0      == 0
+    it "floor" $ floorD @Decimal 1.5    == 1
+    it "floor" $ floorD @Decimal (-1.5) == -2
 
   describe "decimal division" $ do
-    let unlit = fromJust . unliteralS
+    let unlit = fromJust . unliteralS @Decimal
 
-    it "can be one half" $ unlit (literalD 1 ./ literalD 2) == literalD @Decimal 0.5
+    it "can be one half" $ unlit (1 / 2) == 0.5
     it "handles the last decimal correctly" $
-      unlit (literalD 1581138830084.1918464 ./ literalD 1581138830084)
+      unlit (1581138830084.1918464 / 1581138830084)
       ==
-      literalD 1.000000000000121334316980759948431357013938975877803928214364623522650045615600621337146939720454311443026061056754776474139591383112306668111215913835129748371209820415844429729847990579481732664375546615468582277686924612859136684739968417878803629721864
+      1.000000000000121334316980759948431357013938975877803928214364623522650045615600621337146939720454311443026061056754776474139591383112306668111215913835129748371209820415844429729847990579481732664375546615468582277686924612859136684739968417878803629721864
 
   describe "banker's method" $ do
     let unlit = fromJust . unliteralS
 
-    it "rounds (_.5) to the nearest even" $ unlit (banker'sMethod (literalD 1.5)) == 2
-    it "rounds (_.5) to the nearest even" $ unlit (banker'sMethod (literalD 2.5)) == 2
+    it "rounds (_.5) to the nearest even" $ unlit (banker'sMethod (1.5)) == 2
+    it "rounds (_.5) to the nearest even" $ unlit (banker'sMethod (2.5)) == 2
 
   describe "result" $ do
     let code =
@@ -1057,10 +1057,10 @@ spec = describe "analyze" $ do
                 it "should have a negative amount" $ do
                   Just (Located _ (_, (_, AVal _prov amount))) <- pure $
                     find (\(Located _ (Unmunged nm, _)) -> nm == "amount") $ args ^.. traverse
-                  (SBV amount :: SBV Decimal) `shouldSatisfy` (`isConcretely` (< literalD 0))
+                  (SBV amount :: SBV Decimal) `shouldSatisfy` (`isConcretely` (< 0))
 
                 let negativeWrite (Object m) = case m Map.! "balance" of
-                      (_bal, AVal _ sval) -> (SBV sval :: SBV Decimal) `isConcretely` (< literalD 0)
+                      (_bal, AVal _ sval) -> (SBV sval :: SBV Decimal) `isConcretely` (< 0)
                       _                   -> False
 
                 balanceWrite <- pure $ find negativeWrite
@@ -1708,7 +1708,7 @@ spec = describe "analyze" $ do
 
       textToProp TDecimal "(+ 0.0 1.0)"
         `shouldBe`
-        Right (Inj (DecArithOp Add (PLit (literalD 0)) (PLit (literalD 1))))
+        Right (Inj (DecArithOp Add (PLit 0) (PLit 1)))
 
       textToProp TDecimal "(+ 0 1)"
         `shouldBe`
@@ -1830,7 +1830,7 @@ spec = describe "analyze" $ do
     it "renders literals how you would expect" $ do
       userShow (PreIntegerLit 1)            `shouldBe` "1"
       userShow (PreStringLit "foo")         `shouldBe` "\"foo\""
-      userShow (PreDecimalLit (literalD 1)) `shouldBe` "1.0"
+      userShow (PreDecimalLit 1) `shouldBe` "1.0"
       -- TODO: test rendering time literals
       -- userShow (PreTimeLit _) `shouldBe` _
       userShow (PreBoolLit True)            `shouldBe` "true"


### PR DESCRIPTION
This work was due to the fact that the `conserves-mass.decimal` test caused z3 to hang. By changing the representation of decimals from constrained algebraic reals to integers, we can get much more consistent performance.

This has the additional benefits:
1. The new representation of decimals is much closer to pact's own representation (a pair of `Integer` and `Word8`).
2. We no longer have to add constraints in `allocAVal` to rule out unrepresentable decimals. Now a decimal can be represented in pact iff it can be represented as `Decimal`.
3. This gave me an opportunity to clean up some other bits. I think the implementation of arithmetic is now a bit simpler in general.