### PR TITLE
Error on misspelled property definition.

### DIFF
--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -402,13 +402,14 @@ moduleTables modules (_mod, modRefs) = do
     invariants <- case schemas ^? ix schemaName.tMeta.mModel._Just of
       -- no model = no invariants
       Nothing    -> pure []
-      Just model -> liftEither $ do
-        let model'        = expToMapping model
-            expInvariants = model' ^? _Just . ix "invariants"
-            expInvariant  = model' ^? _Just . ix "invariant"
-        exps <- collectExps "invariants" expInvariants expInvariant
-        runExpParserOver exps $
-          flip runReaderT (varIdArgs _utFields) . expToInvariant TBool
+      Just model -> liftEither $ case expToMapping ["invariant", "invariants"] model of
+        Nothing -> throwError (model, "expected \"invariant\" or \"invariants\"")
+        Just model' -> do
+          let expInvariants = model' ^? ix "invariants"
+              expInvariant  = model' ^? ix "invariant"
+          exps <- collectExps "invariants" expInvariants expInvariant
+          runExpParserOver exps $
+            flip runReaderT (varIdArgs _utFields) . expToInvariant TBool
 
     pure $ Table tabName schema invariants
 
@@ -503,20 +504,25 @@ moduleFunChecks tables modTys propDefs = for modTys $ \case
     checks <- case defn ^? tMeta . mModel . _Just of
       -- no model = no properties
       Nothing    -> pure []
-      Just model -> withExcept ModuleParseFailure $ liftEither $ do
-        let model'        = expToMapping model
-            expProperties = model' ^? _Just . ix "properties"
-            expProperty   = model' ^? _Just . ix "property"
-        exps <- collectExps "properties" expProperties expProperty
-        runExpParserOver exps $
-          expToCheck tableEnv vidStart nameVids vidTys propDefs
+      Just model -> withExcept ModuleParseFailure $ liftEither $
+        case expToMapping ["property", "properties"] model of
+          Nothing -> throwError (model, "expected \"property\" or \"properties\"")
+          Just model' -> do
+            let expProperties = model' ^? ix "properties"
+                expProperty   = model' ^? ix "property"
+            exps <- collectExps "properties" expProperties expProperty
+            runExpParserOver exps $
+              expToCheck tableEnv vidStart nameVids vidTys propDefs
 
     pure (ref, Right checks)
 
--- | Given an exp like '(k v)', convert it to a singleton map
-expToMapping :: Exp Info -> Maybe (Map Text (Exp Info))
-expToMapping (ParenList [EAtom' k, v]) = Just $ Map.singleton k v
-expToMapping _                         = Nothing
+-- | Given an exp like '(k v)', and a set (list) of allowed keys, convert it to
+-- a singleton map
+expToMapping :: [Text] -> Exp Info -> Maybe (Map Text (Exp Info))
+expToMapping allowed = \case
+  ParenList [EAtom' k, v]
+    | k `elem` allowed -> Just $ Map.singleton k v
+  _                    -> Nothing
 
 -- | For both properties and invariants you're allowed to use either the
 -- singular ("property") or plural ("properties") name. This helper just


### PR DESCRIPTION
We allow "property" or "properties" / "invariant" or "invariants" in
their respective positions and error otherwise.

Tested by changing `@model (property conserves-mass)` to `@model
(propety conserves-mass)` in verified accounts. Saw this error message:

```
examples/verified-accounts/accounts.pact:48:11: could not parse (propety conserves-mass): expected "property" or "properties"
```

Fixes #141.