### PR TITLE
Share one manager between requests

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -229,6 +229,7 @@ test-suite hspec
       , async
       , ed25519-donna
       , crypto-api
+      , http-client
       , wreq
   other-modules:
                 Blake2Spec

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -263,10 +263,8 @@ mkInitialAnalyzeState tables = AnalyzeState
     cellsWritten = mkTableColumnMap (const True) (mkSFunArray (const false))
 
     mkTableColumnMap
-      -- | Include this column in the mapping?
-      :: (Pact.Type Pact.UserType -> Bool)
-      -- | Default value
-      -> a
+      :: (Pact.Type Pact.UserType -> Bool) -- ^ Include this column in the mapping?
+      -> a                                 -- ^ Default value
       -> TableMap (ColumnMap a)
     mkTableColumnMap f defValue = TableMap $ Map.fromList $
       tables <&> \Table { _tableName, _tableType } ->

--- a/tests/Utils/TestRunner.hs
+++ b/tests/Utils/TestRunner.hs
@@ -59,11 +59,11 @@ data ApiResultCheck = ApiResultCheck
   , _arcExpect :: Maybe Value
   } deriving (Show, Eq)
 
-runAll :: [Command T.Text] -> IO (HM.HashMap RequestKey ApiResult)
-runAll cmds = Exception.bracket
+runAll :: Options -> [Command T.Text] -> IO (HM.HashMap RequestKey ApiResult)
+runAll opts cmds = Exception.bracket
               (startServer _testConfigFilePath)
                stopServer
-              (const (run cmds))
+              (const (run opts cmds))
 
 startServer :: FilePath -> IO (Async (), Async (), Async ())
 startServer configFile = do
@@ -95,9 +95,9 @@ stopServer (asyncServer, asyncCmd, asyncHist) = do
                     "Thread " ++ show (asyncThreadId asy) ++ " could not be cancelled."
           _ -> return ()
 
-run :: [Command T.Text] -> IO (HM.HashMap RequestKey ApiResult)
-run cmds = do
-  sendResp <- doSend $ SubmitBatch cmds
+run :: Options -> [Command T.Text] -> IO (HM.HashMap RequestKey ApiResult)
+run opts cmds = do
+  sendResp <- doSend opts $ SubmitBatch cmds
   case sendResp of
     ApiFailure err -> Exception.evaluate (error err)
     ApiSuccess RequestKeys{..} -> do
@@ -107,27 +107,27 @@ run cmds = do
         Just res -> return res
 
   where helper reqKeys = do
-          pollResp <- doPoll $ Poll reqKeys
+          pollResp <- doPoll opts $ Poll reqKeys
           case pollResp of
             ApiFailure err -> Exception.evaluate (error err)
             ApiSuccess (PollResponses apiResults) ->
               if null apiResults then helper reqKeys
               else return apiResults
 
-doSend :: (ToJSON req) => req -> IO (ApiResponse RequestKeys)
-doSend req = view responseBody <$> doSend' req
+doSend :: (ToJSON req) => Options -> req -> IO (ApiResponse RequestKeys)
+doSend opts req = view responseBody <$> doSend' opts req
 
-doSend' :: (ToJSON req) => req -> IO (Response (ApiResponse RequestKeys))
-doSend' req = do
-  sendResp <- post (_serverPath ++ "send") (toJSON req)
+doSend' :: (ToJSON req) => Options -> req -> IO (Response (ApiResponse RequestKeys))
+doSend' opts req = do
+  sendResp <- postWith opts (_serverPath ++ "send") (toJSON req)
   asJSON sendResp
 
-doPoll :: (ToJSON req) => req -> IO (ApiResponse PollResponses)
-doPoll req = view responseBody <$> doPoll' req
+doPoll :: (ToJSON req) => Options -> req -> IO (ApiResponse PollResponses)
+doPoll opts req = view responseBody <$> doPoll' opts req
 
-doPoll' :: (ToJSON req) => req -> IO (Response (ApiResponse PollResponses))
-doPoll' req = do
-  pollResp <- post (_serverPath ++ "poll") (toJSON req)
+doPoll' :: (ToJSON req) => Options -> req -> IO (Response (ApiResponse PollResponses))
+doPoll' opts req = do
+  pollResp <- postWith opts (_serverPath ++ "poll") (toJSON req)
   asJSON pollResp
 
 


### PR DESCRIPTION
The default  `wreq` behaviour is to create a new manager each time, which is wasteful and takes longer.