### PR TITLE
ReadTheDocs: English Corrections

### DIFF
--- a/docs/pact-functions.md
+++ b/docs/pact-functions.md
@@ -100,7 +100,7 @@ pact> (drop ['name] { 'name: "Vlad", 'active: false})
 *test*&nbsp;`bool` *msg*&nbsp;`string` *&rarr;*&nbsp;`bool`
 
 
-Fail transaction with MSG if value TEST is false. Otherwise, returns true. 
+Fail transaction with MSG if pure expression TEST is false. Otherwise, returns true. 
 ```lisp
 pact> (enforce (!= (+ 2 2) 4) "Chaos reigns")
 <interactive>:0:0: Chaos reigns
@@ -323,7 +323,7 @@ Parse KEY string or number value from top level of message data body as integer.
 *key*&nbsp;`string` *&rarr;*&nbsp;`<a>`
 
 
-Read KEY from top level of message data body, or data body itself if not provided. Coerces value to their corresponding pact type: String -> string, Number -> integer, Boolean -> bool, List -> list, Object -> object. 
+Read KEY from top level of message data body, or data body itself if not provided. Coerces value to their corresponding pact type: String -> string, Number -> integer, Boolean -> bool, List -> list, Object -> object. However, top-level values are provided as a 'value' JSON type. 
 ```lisp
 (defun exec ()
    (transfer (read-msg "from") (read-msg "to") (read-decimal "amount")))
@@ -355,7 +355,7 @@ Special form binds to a yielded object value from the prior step execution in a 
 *list*&nbsp;`[<a>]` *&rarr;*&nbsp;`[<a>]`
 
 
-Reverse a list. 
+Reverse LIST. 
 ```lisp
 pact> (reverse [1 2 3])
 [3 2 1]
@@ -1398,7 +1398,7 @@ Inspect state from previous pact execution. Returns object with fields 'yield': 
 *value*&nbsp;`<a>` *&rarr;*&nbsp;`string`
 
 
-Print a string, to format newlines correctly.
+Output VALUE to terminal as unquoted, unescaped text.
 
 
 ### rollback-tx {#rollback-tx}

--- a/docs/pact-functions.md
+++ b/docs/pact-functions.md
@@ -1193,7 +1193,7 @@ Read KEY from message data body as keyset ({ "keys": KEYLIST, "pred": PREDFUN })
 
 ## REPL-only functions {#repl-lib}
 
-The following functions are loaded magically in the interactive REPL, or in script files with a `.repl` extension. They are not available for blockchain-based execution.
+The following functions are loaded automatically into the interactive REPL, or within script files with a `.repl` extension. They are not available for blockchain-based execution.
 
 
 ### begin-tx {#begin-tx}
@@ -1264,7 +1264,7 @@ Set environment confidential ENTITY id, or unset with no argument. Clears any pr
 *gas*&nbsp;`integer` *&rarr;*&nbsp;`string`
 
 
-Query gas state, or set it to GAS
+Query gas state, or set it to GAS.
 
 
 ### env-gaslimit {#env-gaslimit}
@@ -1272,7 +1272,7 @@ Query gas state, or set it to GAS
 *limit*&nbsp;`integer` *&rarr;*&nbsp;`string`
 
 
-Set environment gas limit to LIMIT
+Set environment gas limit to LIMIT.
 
 
 ### env-gasprice {#env-gasprice}
@@ -1280,7 +1280,7 @@ Set environment gas limit to LIMIT
 *price*&nbsp;`decimal` *&rarr;*&nbsp;`string`
 
 
-Set environment gas price to PRICE
+Set environment gas price to PRICE.
 
 
 ### env-gasrate {#env-gasrate}
@@ -1288,7 +1288,7 @@ Set environment gas price to PRICE
 *rate*&nbsp;`integer` *&rarr;*&nbsp;`string`
 
 
-Update gas model to charge constant RATE
+Update gas model to charge constant RATE.
 
 
 ### env-hash {#env-hash}
@@ -1376,7 +1376,7 @@ pact> (json [{ "name": "joe", "age": 10 } {"name": "mary", "age": 25 }])
 *file*&nbsp;`string` *reset*&nbsp;`bool` *&rarr;*&nbsp;`string`
 
 
-Load and evaluate FILE, resetting repl state beforehand if optional NO-RESET is true. 
+Load and evaluate FILE, resetting repl state beforehand if optional RESET is true. 
 ```lisp
 (load "accounts.repl")
 ```
@@ -1398,7 +1398,7 @@ Inspect state from previous pact execution. Returns object with fields 'yield': 
 *value*&nbsp;`<a>` *&rarr;*&nbsp;`string`
 
 
-Print a string, mainly to format newlines correctly
+Print a string, to format newlines correctly.
 
 
 ### rollback-tx {#rollback-tx}
@@ -1417,7 +1417,7 @@ Rollback transaction.
  *&rarr;*&nbsp;`keyset`
 
 
-Convenience to build a keyset from keys present in message signatures, using 'keys-all' as the predicate.
+Convenience function to build a keyset from keys present in message signatures, using 'keys-all' as the predicate.
 
 
 ### typecheck {#typecheck}

--- a/docs/pact-functions.md
+++ b/docs/pact-functions.md
@@ -323,7 +323,7 @@ Parse KEY string or number value from top level of message data body as integer.
 *key*&nbsp;`string` *&rarr;*&nbsp;`<a>`
 
 
-Read KEY from top level of message data body, or data body itself if not provided. Coerces value to pact type: String -> string, Number -> integer, Boolean -> bool, List -> value, Object -> value. NB value types are not introspectable in pact. 
+Read KEY from top level of message data body, or data body itself if not provided. Coerces value to their corresponding pact type: String -> string, Number -> integer, Boolean -> bool, List -> list, Object -> object. 
 ```lisp
 (defun exec ()
    (transfer (read-msg "from") (read-msg "to") (read-decimal "amount")))

--- a/docs/pact-functions.md
+++ b/docs/pact-functions.md
@@ -50,7 +50,7 @@ pact> (filter (compose (length) (< 2)) ["my" "dog" "has" "fleas"])
 *value*&nbsp;`<a>` *ignore1*&nbsp;`<b>` *ignore2*&nbsp;`<c>` *ignore3*&nbsp;`<d>` *&rarr;*&nbsp;`<a>`
 
 
-Ignore (lazily) arguments IGNORE* and return VALUE. 
+Lazily ignore arguments IGNORE* and return VALUE. 
 ```lisp
 pact> (filter (constantly true) [1 2 3])
 [1 2 3]
@@ -100,7 +100,7 @@ pact> (drop ['name] { 'name: "Vlad", 'active: false})
 *test*&nbsp;`bool` *msg*&nbsp;`string` *&rarr;*&nbsp;`bool`
 
 
-Fail transaction with MSG if pure function TEST fails, or returns true. 
+Fail transaction with MSG if value TEST is false. Otherwise, returns true. 
 ```lisp
 pact> (enforce (!= (+ 2 2) 4) "Chaos reigns")
 <interactive>:0:0: Chaos reigns
@@ -140,7 +140,7 @@ Top level only: this function will fail if used in module code.
 *app*&nbsp;`(x:<a> -> bool)` *list*&nbsp;`[<a>]` *&rarr;*&nbsp;`[<a>]`
 
 
-Filter LIST by applying APP to each element to get a boolean determining inclusion.
+Filter LIST by applying APP to each element. For each true result, the original value is kept.
 ```lisp
 pact> (filter (compose (length) (< 2)) ["my" "dog" "has" "fleas"])
 ["dog" "has" "fleas"]
@@ -202,7 +202,7 @@ pact> (map (identity) [1 2 3])
 *cond*&nbsp;`bool` *then*&nbsp;`<a>` *else*&nbsp;`<a>` *&rarr;*&nbsp;`<a>`
 
 
-Test COND, if true evaluate THEN, otherwise evaluate ELSE. 
+Test COND. If true, evaluate THEN. Otherwise, evaluate ELSE. 
 ```lisp
 pact> (if (= (+ 2 2) 4) "Sanity prevails" "Chaos reigns")
 "Sanity prevails"
@@ -264,7 +264,7 @@ pact> (make-list 5 true)
 *app*&nbsp;`(x:<b> -> <a>)` *list*&nbsp;`[<b>]` *&rarr;*&nbsp;`[<a>]`
 
 
-Apply elements in LIST as last arg to APP, returning list of results. 
+Apply APP to each element in LIST, returning a new list of results. 
 ```lisp
 pact> (map (+ 1) [1 2 3])
 [2 3 4]
@@ -352,7 +352,7 @@ Special form binds to a yielded object value from the prior step execution in a 
 
 ### reverse {#reverse}
 
-*l*&nbsp;`[<a>]` *&rarr;*&nbsp;`[<a>]`
+*list*&nbsp;`[<a>]` *&rarr;*&nbsp;`[<a>]`
 
 
 Reverse a list. 
@@ -369,7 +369,7 @@ pact> (reverse [1 2 3])
 *fields*&nbsp;`[string]` *values*&nbsp;`[object:<{o}>]` *&rarr;*&nbsp;`[object:<{o}>]`
 
 
-Sort monotyped list of primitive VALUES, or objects using supplied FIELDS list. 
+Sort a homogeneous list of primitive VALUES, or objects using supplied FIELDS list. 
 ```lisp
 pact> (sort [3 1 2])
 [1 2 3]
@@ -453,7 +453,7 @@ pact> (filter (where 'age (> 20)) [{'name: "Mary",'age: 30} {'name: "Juan",'age:
 *OBJECT*&nbsp;`object:<{y}>` *&rarr;*&nbsp;`object:<{y}>`
 
 
-Yield OBJECT for use with 'resume' in following pact step. The object is similar to database row objects, in that only the top level can be binded to in 'resume'; nested objects are converted to opaque JSON values. 
+Yield OBJECT for use with 'resume' in following pact step. The object is similar to database row objects, in that only the top level can be bound to in 'resume'; nested objects are converted to opaque JSON values. 
 ```lisp
 (yield { "amount": 100.0 })
 ```
@@ -478,7 +478,7 @@ Top level only: this function will fail if used in module code.
 *keyset*&nbsp;`string` *&rarr;*&nbsp;`value`
 
 
-Get metadata for KEYSET
+Get metadata for KEYSET.
 
 Top level only: this function will fail if used in module code.
 
@@ -516,7 +516,7 @@ Top level only: this function will fail if used in module code.
 
 Write entry in TABLE for KEY of OBJECT column data, failing if data already exists for KEY.
 ```lisp
-(insert 'accounts { "balance": 0.0, "note": "Created account." })
+(insert accounts { "balance": 0.0, "note": "Created account." })
 ```
 
 
@@ -527,7 +527,7 @@ Write entry in TABLE for KEY of OBJECT column data, failing if data already exis
 
 Return updates to TABLE for a KEY in transactions at or after TXID, in a list of objects indexed by txid. 
 ```lisp
-(keylog 'accounts "Alice" 123485945)
+(keylog accounts "Alice" 123485945)
 ```
 
 
@@ -538,7 +538,7 @@ Return updates to TABLE for a KEY in transactions at or after TXID, in a list of
 
 Return all keys in TABLE. 
 ```lisp
-(keys 'accounts)
+(keys accounts)
 ```
 
 
@@ -549,9 +549,9 @@ Return all keys in TABLE.
 *table*&nbsp;`table:<{row}>` *key*&nbsp;`string` *columns*&nbsp;`[string]` *&rarr;*&nbsp;`object:<{row}>`
 
 
-Read row from TABLE for KEY returning database record object, or just COLUMNS if specified. 
+Read row from TABLE for KEY, returning database record object, or just COLUMNS if specified. 
 ```lisp
-(read 'accounts id ['balance 'ccy])
+(read accounts id ['balance 'ccy])
 ```
 
 
@@ -587,7 +587,7 @@ Return all txid values greater than or equal to TXID in TABLE.
 
 Return all updates to TABLE performed in transaction TXID. 
 ```lisp
-(txlog 'accounts 123485945)
+(txlog accounts 123485945)
 ```
 
 
@@ -598,7 +598,7 @@ Return all updates to TABLE performed in transaction TXID.
 
 Write entry in TABLE for KEY of OBJECT column data, failing if data does not exist for KEY.
 ```lisp
-(update 'accounts { "balance": (+ bal amount), "change": amount, "note": "credit" })
+(update accounts { "balance": (+ bal amount), "change": amount, "note": "credit" })
 ```
 
 
@@ -609,7 +609,7 @@ Write entry in TABLE for KEY of OBJECT column data, failing if data does not exi
 
 Special form to read row from TABLE for KEY and bind columns per BINDINGS over subsequent body statements. If row not found, read columns from DEFAULTS, an object with matching key names. 
 ```lisp
-(with-default-read 'accounts id { "balance": 0, "ccy": "USD" } { "balance":= bal, "ccy":= ccy }
+(with-default-read accounts id { "balance": 0, "ccy": "USD" } { "balance":= bal, "ccy":= ccy }
    (format "Balance for {} is {} {}" [id bal ccy]))
 ```
 
@@ -621,7 +621,7 @@ Special form to read row from TABLE for KEY and bind columns per BINDINGS over s
 
 Special form to read row from TABLE for KEY and bind columns per BINDINGS over subsequent body statements.
 ```lisp
-(with-read 'accounts id { "balance":= bal, "ccy":= ccy }
+(with-read accounts id { "balance":= bal, "ccy":= ccy }
    (format "Balance for {} is {} {}" [id bal ccy]))
 ```
 
@@ -633,7 +633,7 @@ Special form to read row from TABLE for KEY and bind columns per BINDINGS over s
 
 Write entry in TABLE for KEY of OBJECT column data.
 ```lisp
-(write 'accounts { "balance": 100.0 })
+(write accounts { "balance": 100.0 })
 ```
 
 ## Time {#Time}
@@ -683,7 +683,7 @@ pact> (diff-time (parse-time "%T" "16:00:00") (parse-time "%T" "09:30:00"))
 *format*&nbsp;`string` *time*&nbsp;`time` *&rarr;*&nbsp;`string`
 
 
-Format TIME using FORMAT. See ["Time Formats" docs](#time-formats) for supported formats.
+Format TIME using FORMAT. See ["Time Formats" docs](pact-reference.html#time-formats) for supported formats.
 ```lisp
 pact> (format-time "%F" (time "2016-07-22T12:00:00Z"))
 "2016-07-22"
@@ -723,7 +723,7 @@ pact> (add-time (time "2016-07-22T12:00:00Z") (minutes 1))
 *format*&nbsp;`string` *utcval*&nbsp;`string` *&rarr;*&nbsp;`time`
 
 
-Construct time from UTCVAL using FORMAT. See ["Time Formats" docs](#time-formats) for supported formats.
+Construct time from UTCVAL using FORMAT. See ["Time Formats" docs](pact-reference.html#time-formats) for supported formats.
 ```lisp
 pact> (parse-time "%F" "2016-09-12")
 "2016-09-12T00:00:00Z"
@@ -982,7 +982,7 @@ pact> (ceiling 100.15234 2)
 *x*&nbsp;`<a[integer,decimal]>` *&rarr;*&nbsp;`<a[integer,decimal]>`
 
 
-Exp of X 
+Exp of X. 
 ```lisp
 pact> (round (exp 3) 6)
 20.085537

--- a/docs/pact-functions.rst
+++ b/docs/pact-functions.rst
@@ -1322,9 +1322,9 @@ PREDFUN }). PREDFUN should resolve to a keys predicate.
 REPL-only functions
 -------------------
 
-The following functions are loaded magically in the interactive REPL, or
-in script files with a ``.repl`` extension. They are not available for
-blockchain-based execution.
+The following functions are loaded automatically into the interactive
+REPL, or within script files with a ``.repl`` extension. They are not
+available for blockchain-based execution.
 
 begin-tx
 ~~~~~~~~
@@ -1397,28 +1397,28 @@ env-gas
 
 *gas* ``integer`` *→* ``string``
 
-Query gas state, or set it to GAS
+Query gas state, or set it to GAS.
 
 env-gaslimit
 ~~~~~~~~~~~~
 
 *limit* ``integer`` *→* ``string``
 
-Set environment gas limit to LIMIT
+Set environment gas limit to LIMIT.
 
 env-gasprice
 ~~~~~~~~~~~~
 
 *price* ``decimal`` *→* ``string``
 
-Set environment gas price to PRICE
+Set environment gas price to PRICE.
 
 env-gasrate
 ~~~~~~~~~~~
 
 *rate* ``integer`` *→* ``string``
 
-Update gas model to charge constant RATE
+Update gas model to charge constant RATE.
 
 env-hash
 ~~~~~~~~
@@ -1512,7 +1512,7 @@ load
 *file* ``string`` *reset* ``bool`` *→* ``string``
 
 Load and evaluate FILE, resetting repl state beforehand if optional
-NO-RESET is true.
+RESET is true.
 
 .. code:: lisp
 
@@ -1536,7 +1536,7 @@ print
 
 *value* ``<a>`` *→* ``string``
 
-Print a string, mainly to format newlines correctly
+Print a string, to format newlines correctly.
 
 rollback-tx
 ~~~~~~~~~~~
@@ -1554,8 +1554,8 @@ sig-keyset
 
 *→* ``keyset``
 
-Convenience to build a keyset from keys present in message signatures,
-using ‘keys-all’ as the predicate.
+Convenience function to build a keyset from keys present in message
+signatures, using ‘keys-all’ as the predicate.
 
 typecheck
 ~~~~~~~~~

--- a/docs/pact-functions.rst
+++ b/docs/pact-functions.rst
@@ -347,9 +347,9 @@ read-msg
 *key* ``string`` *→* ``<a>``
 
 Read KEY from top level of message data body, or data body itself if not
-provided. Coerces value to pact type: String -> string, Number ->
-integer, Boolean -> bool, List -> value, Object -> value. NB value types
-are not introspectable in pact.
+provided. Coerces value to their corresponding pact type: String ->
+string, Number -> integer, Boolean -> bool, List -> list, Object ->
+object.
 
 .. code:: lisp
 

--- a/docs/pact-functions.rst
+++ b/docs/pact-functions.rst
@@ -113,8 +113,8 @@ enforce
 
 *test* ``bool`` *msg* ``string`` *→* ``bool``
 
-Fail transaction with MSG if value TEST is false. Otherwise, returns
-true.
+Fail transaction with MSG if pure expression TEST is false. Otherwise,
+returns true.
 
 .. code:: lisp
 
@@ -349,7 +349,7 @@ read-msg
 Read KEY from top level of message data body, or data body itself if not
 provided. Coerces value to their corresponding pact type: String ->
 string, Number -> integer, Boolean -> bool, List -> list, Object ->
-object.
+object. However, top-level values are provided as a ‘value’ JSON type.
 
 .. code:: lisp
 
@@ -381,7 +381,7 @@ reverse
 
 *list* ``[<a>]`` *→* ``[<a>]``
 
-Reverse a list.
+Reverse LIST.
 
 .. code:: lisp
 
@@ -1536,7 +1536,7 @@ print
 
 *value* ``<a>`` *→* ``string``
 
-Print a string, to format newlines correctly.
+Output VALUE to terminal as unquoted, unescaped text.
 
 rollback-tx
 ~~~~~~~~~~~

--- a/docs/pact-functions.rst
+++ b/docs/pact-functions.rst
@@ -61,7 +61,7 @@ constantly
 *value* ``<a>`` *ignore1* ``<b>`` *ignore2* ``<c>`` *ignore3* ``<d>``
 *→* ``<a>``
 
-Ignore (lazily) arguments IGNORE\* and return VALUE.
+Lazily ignore arguments IGNORE\* and return VALUE.
 
 .. code:: lisp
 
@@ -113,7 +113,8 @@ enforce
 
 *test* ``bool`` *msg* ``string`` *→* ``bool``
 
-Fail transaction with MSG if pure function TEST fails, or returns true.
+Fail transaction with MSG if value TEST is false. Otherwise, returns
+true.
 
 .. code:: lisp
 
@@ -150,13 +151,15 @@ from the left, such that ‘2’, ‘2.2’, and ‘2.2.3’ would all allow
    pact> (enforce-pact-version "2.3")
    true
 
+Top level only: this function will fail if used in module code.
+
 filter
 ~~~~~~
 
 *app* ``(x:<a> -> bool)`` *list* ``[<a>]`` *→* ``[<a>]``
 
-Filter LIST by applying APP to each element to get a boolean determining
-inclusion.
+Filter LIST by applying APP to each element. For each true result, the
+original value is kept.
 
 .. code:: lisp
 
@@ -221,7 +224,7 @@ if
 
 *cond* ``bool`` *then* ``<a>`` *else* ``<a>`` *→* ``<a>``
 
-Test COND, if true evaluate THEN, otherwise evaluate ELSE.
+Test COND. If true, evaluate THEN. Otherwise, evaluate ELSE.
 
 .. code:: lisp
 
@@ -264,6 +267,8 @@ list-modules
 
 List modules available for loading.
 
+Top level only: this function will fail if used in module code.
+
 make-list
 ~~~~~~~~~
 
@@ -281,7 +286,7 @@ map
 
 *app* ``(x:<b> -> <a>)`` *list* ``[<b>]`` *→* ``[<a>]``
 
-Apply elements in LIST as last arg to APP, returning list of results.
+Apply APP to each element in LIST, returning a new list of results.
 
 .. code:: lisp
 
@@ -306,6 +311,8 @@ Obtain current pact build version.
 
    pact> (pact-version)
    "2.5.0"
+
+Top level only: this function will fail if used in module code.
 
 read-decimal
 ~~~~~~~~~~~~
@@ -372,7 +379,7 @@ execution in a pact.
 reverse
 ~~~~~~~
 
-*l* ``[<a>]`` *→* ``[<a>]``
+*list* ``[<a>]`` *→* ``[<a>]``
 
 Reverse a list.
 
@@ -388,7 +395,7 @@ sort
 
 *fields* ``[string]`` *values* ``[object:<{o}>]`` *→* ``[object:<{o}>]``
 
-Sort monotyped list of primitive VALUES, or objects using supplied
+Sort a homogeneous list of primitive VALUES, or objects using supplied
 FIELDS list.
 
 .. code:: lisp
@@ -397,6 +404,24 @@ FIELDS list.
    [1 2 3]
    pact> (sort ['age] [{'name: "Lin",'age: 30} {'name: "Val",'age: 25}])
    [{"name": "Val", "age": 25} {"name": "Lin", "age": 30}]
+
+str-to-int
+~~~~~~~~~~
+
+*str-val* ``string`` *→* ``integer``
+
+*base* ``integer`` *str-val* ``string`` *→* ``integer``
+
+Compute the integer value of STR-VAL in base 10, or in BASE if
+specified. STR-VAL must be <= 128 chars in length and BASE must be
+between 2 and 16.
+
+.. code:: lisp
+
+   pact> (str-to-int 16 "123456")
+   1193046
+   pact> (str-to-int "abcdef123456")
+   1123455123456
 
 take
 ~~~~
@@ -461,9 +486,8 @@ yield
 *OBJECT* ``object:<{y}>`` *→* ``object:<{y}>``
 
 Yield OBJECT for use with ‘resume’ in following pact step. The object is
-similar to database row objects, in that only the top level can be
-binded to in ‘resume’; nested objects are converted to opaque JSON
-values.
+similar to database row objects, in that only the top level can be bound
+to in ‘resume’; nested objects are converted to opaque JSON values.
 
 .. code:: lisp
 
@@ -485,12 +509,16 @@ Create table TABLE.
 
    (create-table accounts)
 
+Top level only: this function will fail if used in module code.
+
 describe-keyset
 ~~~~~~~~~~~~~~~
 
 *keyset* ``string`` *→* ``value``
 
-Get metadata for KEYSET
+Get metadata for KEYSET.
+
+Top level only: this function will fail if used in module code.
 
 describe-module
 ~~~~~~~~~~~~~~~
@@ -504,6 +532,8 @@ Get metadata for MODULE. Returns an object with ‘name’, ‘hash’,
 
    (describe-module 'my-module)
 
+Top level only: this function will fail if used in module code.
+
 describe-table
 ~~~~~~~~~~~~~~
 
@@ -516,6 +546,8 @@ Get metadata for TABLE. Returns an object with ‘name’, ‘hash’,
 
    (describe-table accounts)
 
+Top level only: this function will fail if used in module code.
+
 insert
 ~~~~~~
 
@@ -527,7 +559,7 @@ already exists for KEY.
 
 .. code:: lisp
 
-   (insert 'accounts { "balance": 0.0, "note": "Created account." })
+   (insert accounts { "balance": 0.0, "note": "Created account." })
 
 keylog
 ~~~~~~
@@ -540,7 +572,7 @@ list of objects indexed by txid.
 
 .. code:: lisp
 
-   (keylog 'accounts "Alice" 123485945)
+   (keylog accounts "Alice" 123485945)
 
 keys
 ~~~~
@@ -551,7 +583,7 @@ Return all keys in TABLE.
 
 .. code:: lisp
 
-   (keys 'accounts)
+   (keys accounts)
 
 read
 ~~~~
@@ -561,12 +593,12 @@ read
 *table* ``table:<{row}>`` *key* ``string`` *columns* ``[string]``
 *→* ``object:<{row}>``
 
-Read row from TABLE for KEY returning database record object, or just
+Read row from TABLE for KEY, returning database record object, or just
 COLUMNS if specified.
 
 .. code:: lisp
 
-   (read 'accounts id ['balance 'ccy])
+   (read accounts id ['balance 'ccy])
 
 select
 ~~~~~~
@@ -605,7 +637,7 @@ Return all updates to TABLE performed in transaction TXID.
 
 .. code:: lisp
 
-   (txlog 'accounts 123485945)
+   (txlog accounts 123485945)
 
 update
 ~~~~~~
@@ -618,7 +650,7 @@ not exist for KEY.
 
 .. code:: lisp
 
-   (update 'accounts { "balance": (+ bal amount), "change": amount, "note": "credit" })
+   (update accounts { "balance": (+ bal amount), "change": amount, "note": "credit" })
 
 with-default-read
 ~~~~~~~~~~~~~~~~~
@@ -632,7 +664,7 @@ from DEFAULTS, an object with matching key names.
 
 .. code:: lisp
 
-   (with-default-read 'accounts id { "balance": 0, "ccy": "USD" } { "balance":= bal, "ccy":= ccy }
+   (with-default-read accounts id { "balance": 0, "ccy": "USD" } { "balance":= bal, "ccy":= ccy }
       (format "Balance for {} is {} {}" [id bal ccy]))
 
 with-read
@@ -646,7 +678,7 @@ BINDINGS over subsequent body statements.
 
 .. code:: lisp
 
-   (with-read 'accounts id { "balance":= bal, "ccy":= ccy }
+   (with-read accounts id { "balance":= bal, "ccy":= ccy }
       (format "Balance for {} is {} {}" [id bal ccy]))
 
 write
@@ -659,7 +691,7 @@ Write entry in TABLE for KEY of OBJECT column data.
 
 .. code:: lisp
 
-   (write 'accounts { "balance": 100.0 })
+   (write accounts { "balance": 100.0 })
 
 .. _Time:
 
@@ -711,8 +743,8 @@ format-time
 
 *format* ``string`` *time* ``time`` *→* ``string``
 
-Format TIME using FORMAT. See `“Time Formats” docs <#time-formats>`__
-for supported formats.
+Format TIME using FORMAT. See `“Time Formats”
+docs <pact-reference.html#time-formats>`__ for supported formats.
 
 .. code:: lisp
 
@@ -753,7 +785,7 @@ parse-time
 *format* ``string`` *utcval* ``string`` *→* ``time``
 
 Construct time from UTCVAL using FORMAT. See `“Time Formats”
-docs <#time-formats>`__ for supported formats.
+docs <pact-reference.html#time-formats>`__ for supported formats.
 
 .. code:: lisp
 
@@ -1061,7 +1093,7 @@ exp
 
 *x* ``<a[integer,decimal]>`` *→* ``<a[integer,decimal]>``
 
-Exp of X
+Exp of X.
 
 .. code:: lisp
 
@@ -1220,6 +1252,8 @@ will be enforced before updating to new value.
 .. code:: lisp
 
    (define-keyset 'admin-keyset (read-keyset "keyset"))
+
+Top level only: this function will fail if used in module code.
 
 enforce-keyset
 ~~~~~~~~~~~~~~

--- a/docs/pact-properties.md
+++ b/docs/pact-properties.md
@@ -1,6 +1,6 @@
 ![](img/kadena-logo-210px.png)
 
-The Pact property checking system
+The Pact Property Checking System
 ===
 
 ## What is it?
@@ -24,7 +24,7 @@ property _statically_, before any code is deployed to the blockchain.
 Compared with conventional unit testing, wherein the behavior of a program is
 validated for a single combination of inputs and the author hopes this case
 generalizes to all inputs, the Pact property checking system _automatically_
-checks the code under test against all possible inputs, and therefore all
+checks the code against all possible inputs, and therefore all
 possible execution paths.
 
 Pact does this by allowing authors to specify _schema invariants_ about columns
@@ -48,9 +48,9 @@ sophisticated properties about their smart contracts over time.
 
 Here's an example of Pact's properties in action -- we declare a property
 alongside the docstring of the function to which it corresponds. Note that the
-function farms out its implementation of keyset enforcement to another
-function, `enforce-admin`, and we don't have to be concerned about how that
-happens to be implemented. Our property states that if the transaction
+function delegates its implementation of keyset enforcement to another
+function, `enforce-admin`, and we don't need to be concerned about its
+internal details. Our property states that if the transaction
 submitted to the blockchain runs successfully, it must be the case that the
 transaction has the proper signatures to satisfy the keyset named `admins`:
 

--- a/docs/pact-properties.md
+++ b/docs/pact-properties.md
@@ -171,7 +171,7 @@ properties at once:
 ### Transaction abort and success
 
 By default, every property is predicated on the successful completion of the
-transaction which would contain an invocation of the function under test. This
+transaction which would contain an invocation of the function being tested. This
 means that properties like the following:
 
 ```lisp
@@ -296,7 +296,7 @@ For an example using this property, see "A simple balance transfer example"
 below.
 
 It turns out that `conserves-mass` is actually just a trivial application of
-another property called `column-delta`, which returns an numeric value of the
+another property called `column-delta`, which returns a numeric value of the
 sum of all changes to the column during the transaction. So
 `(conserves-mass 'accounts 'balance)` is actually just the same as:
 
@@ -326,8 +326,8 @@ change. So here `1` means an increase of `1` to the column's total sum.
 In examples like `(row-enforced 'accounts 'ks key)` or
 `(row-written 'accounts key)` above, we've so far only referred to function
 arguments by the use of the variable named `key`. But what if we wanted to
-talk about all possible rows that will be written, if function doesn't simply
-update a single row keyed by an input to the function?
+talk about all possible rows that will be written, if a function doesn't simply
+update a single row?
 
 In such a situation we could use universal quantification to talk about _any_
 such row:

--- a/docs/pact-properties.rst
+++ b/docs/pact-properties.rst
@@ -186,8 +186,8 @@ Transaction abort and success
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, every property is predicated on the successful completion of
-the transaction which would contain an invocation of the function under
-test. This means that properties like the following:
+the transaction which would contain an invocation of the function being
+tested. This means that properties like the following:
 
 .. code:: lisp
 
@@ -322,8 +322,8 @@ For an example using this property, see “A simple balance transfer
 example” below.
 
 It turns out that ``conserves-mass`` is actually just a trivial
-application of another property called ``column-delta``, which returns
-an numeric value of the sum of all changes to the column during the
+application of another property called ``column-delta``, which returns a
+numeric value of the sum of all changes to the column during the
 transaction. So ``(conserves-mass 'accounts 'balance)`` is actually just
 the same as:
 
@@ -355,9 +355,8 @@ Universal and existential quantification
 In examples like ``(row-enforced 'accounts 'ks key)`` or
 ``(row-written 'accounts key)`` above, we’ve so far only referred to
 function arguments by the use of the variable named ``key``. But what if
-we wanted to talk about all possible rows that will be written, if
-function doesn’t simply update a single row keyed by an input to the
-function?
+we wanted to talk about all possible rows that will be written, if a
+function doesn’t simply update a single row?
 
 In such a situation we could use universal quantification to talk about
 *any* such row:

--- a/docs/pact-properties.rst
+++ b/docs/pact-properties.rst
@@ -1,6 +1,6 @@
 |image0|
 
-The Pact property checking system
+The Pact Property Checking System
 =================================
 
 What is it?
@@ -27,8 +27,8 @@ blockchain.
 Compared with conventional unit testing, wherein the behavior of a
 program is validated for a single combination of inputs and the author
 hopes this case generalizes to all inputs, the Pact property checking
-system *automatically* checks the code under test against all possible
-inputs, and therefore all possible execution paths.
+system *automatically* checks the code against all possible inputs, and
+therefore all possible execution paths.
 
 Pact does this by allowing authors to specify *schema invariants* about
 columns in database tables, and to state and prove *properties* about
@@ -53,12 +53,12 @@ What do properties and schema invariants look like?
 
 Here’s an example of Pact’s properties in action – we declare a property
 alongside the docstring of the function to which it corresponds. Note
-that the function farms out its implementation of keyset enforcement to
-another function, ``enforce-admin``, and we don’t have to be concerned
-about how that happens to be implemented. Our property states that if
-the transaction submitted to the blockchain runs successfully, it must
-be the case that the transaction has the proper signatures to satisfy
-the keyset named ``admins``:
+that the function delegates its implementation of keyset enforcement to
+another function, ``enforce-admin``, and we don’t need to be concerned
+about its internal details. Our property states that if the transaction
+submitted to the blockchain runs successfully, it must be the case that
+the transaction has the proper signatures to satisfy the keyset named
+``admins``:
 
 .. code:: lisp
 

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -972,7 +972,7 @@ Strings also support multiline by putting a backslash before and after whitespac
 Symbols are string literals representing some unique item in the runtime, like a function or a table name.
 Their representation internally is simply a string literal so their usage is idiomatic.
 
-Symbols are created with a preceding tick, thus they do no support whitespace or multiline.
+Symbols are created with a preceding tick, thus they do not support whitespaces or multilines.
 
 ```
 pact> 'a-symbol
@@ -981,21 +981,24 @@ pact> 'a-symbol
 
 ### Integers {#integers}
 
-Integer literals are unbounded positive naturals. For negative numbers use the unary [-](#-) function.
+Integer literals are unbounded, and can be positive or negative.
 
 ```
 pact> 12345
 12345
+pact> -922337203685477580712387461234
+-922337203685477580712387461234
 ```
 
 ### Decimals {#decimals}
 
-Decimal literals are positive decimals to exact expressed precision.
+Decimal literals have potentially unlimited precision.
+
 ```
 pact> 100.25
 100.25
-pact> 356452.23451872
-356452.23451872
+pact> -356452.234518728287461023856582382983746
+-356452.234518728287461023856582382983746
 ```
 
 ### Booleans {#booleans}
@@ -1108,18 +1111,18 @@ in the following form:
 
 ```lisp
 (defun foo (bar)
-  "Do the thing with BAR"
+  "Do something with BAR"
   ...)
 ```
 
 However, in this position an optional _metadata section_ can specify docs and
 metadata, where metadata can be tagged with any key desired.
-The following code provides a docstring of "does the thing with BAR" and specifies metadata of type
+The following code provides a docstring of "does something with BAR" and specifies metadata of type
 `property` and `example`:
 
 ```lisp
 (defun foo (bar)
-  ("does the thing with BAR"
+  ("does something with BAR"
     (property [(when something abort)])
     (example (foo "my house")))
   ...)

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -675,7 +675,7 @@ Some tips for fast execution are:
 Design transactions so they can be executed with a single function call.
 
 #### Call with references instead of `use` {#usereferences}
-When calling module functions in transactions, use [reference syntax](#reference) instead of importing
+When calling module functions in transactions, use [reference syntax](#references) instead of importing
 the module with [use](#use). When defining modules that reference other module functions, `use` is
 fine, as those references will be inlined at module definition time.
 

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -1105,33 +1105,31 @@ Tables and objects can only take a schema type literal.
 Special forms {#special-forms}
 ---
 
-### Docs and metadata
+### Docs and Metadata
 Many special forms like [defun](#defun) accept optional documentation strings,
 in the following form:
 
 ```lisp
-(defun foo (bar)
-  "Do something with BAR"
-  ...)
+(defun average (a b)
+  "take the average of a and b"
+  (/ (+ a b) 2))
 ```
 
-However, in this position an optional _metadata section_ can specify docs and
-metadata, where metadata can be tagged with any key desired.
-The following code provides a docstring of "does something with BAR" and specifies metadata of type
-`property` and `example`:
+However, in this position, optional metadata can also be specified.
+One such metadata field is `@model`, which represents a property that can
+be used by Pact tooling to verify the correctness of the implementation:
 
 ```lisp
-(defun foo (bar)
-  ("does something with BAR"
-    (property [(when something abort)])
-    (example (foo "my house")))
-  ...)
+(defun average (a b)
+  @doc   "take the average of a and b"
+  @model (property (= (+ a b) (* 2 result)))
+  (/ (+ a b) 2))
 ```
 
-Thus, the metadata form is DOC PAIR*, where a PAIR is (ATOM EXPR). The Pact
-language lexer/compiler ignores all EXPR forms, to be lexed/compiled at some later stage
-by whatever tool recognizes ATOM.
+Indeed, a bare docstring like `"foo"` is actually just a short form for `@doc "foo"`.
+More metadata types are expected to be added in future.
 
+Specific information on *Properties* can be found in [The Pact Property Checking System](pact-properties.html).
 
 ### bless {#bless}
 ```

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -1115,9 +1115,9 @@ in the following form:
   (/ (+ a b) 2))
 ```
 
-However, in this position, extra metadata fields can also be specified.
-One such metadata field is `@model`, which represents a *property* that can
-be used by Pact tooling to verify the correctness of the implementation:
+Alternately, users can specify metadata using a special `@`-prefix syntax.
+Supported metadata fields are `@doc` to provide a documentation string, and `@model`
+that can be used by Pact tooling to verify the correctness of the implementation:
 
 ```lisp
 (defun average (a b)
@@ -1127,7 +1127,6 @@ be used by Pact tooling to verify the correctness of the implementation:
 ```
 
 Indeed, a bare docstring like `"foo"` is actually just a short form for `@doc "foo"`.
-More metadata types are expected to be added in future.
 
 Specific information on *Properties* can be found in [The Pact Property Checking System](pact-properties.html).
 

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -972,7 +972,7 @@ Strings also support multiline by putting a backslash before and after whitespac
 Symbols are string literals representing some unique item in the runtime, like a function or a table name.
 Their representation internally is simply a string literal so their usage is idiomatic.
 
-Symbols are created with a preceding tick, thus they do not support whitespaces or multilines.
+Symbols are created with a preceding tick, thus they do not support whitespace nor multiline syntax.
 
 ```
 pact> 'a-symbol
@@ -1184,7 +1184,9 @@ Define NAME as VALUE, with option DOC-OR-META. Value is evaluated upon module lo
 (defpact NAME ARGLIST [DOC-OR-META] STEPS...)
 ```
 
-Define NAME as a _pact_, a multistep transaction computation.
+
+Define NAME as a _pact_, a computation comprised of multiple steps that occur
+in distinct transactions.
 Identical to [defun](#defun) except body must be comprised of [steps](#step) to be
 executed in strict sequential order. Steps must uniformly be "public" (no entity indicator)
 or "private" (with entity indicator). With private steps, failures result in a reverse-sequence
@@ -1292,7 +1294,7 @@ ROLLBACK-EXPR functions as a "cancel function" to be explicitly executed by a pa
 ```
 
 Import an existing MODULE into a namespace. Can only be issued at the top-level, or within a module
-declaration. MODULE can be a string, symbol or bare atom. With HASH, validate that the remote module's
+declaration. MODULE can be a string, symbol or bare atom. With HASH, validate that the imported module's
 hash matches HASH, failing if not. Use [describe-module](#describe-module) to query for the
 hash of a loaded module on the chain.
 
@@ -1355,7 +1357,7 @@ runtime error.
 
 ### References {#references}
 
-References are two atoms joined by a dot `.` that directly resolve to definitions found
+References are multiple atoms joined by a dot `.` that directly resolve to definitions found
 in other modules.
 
 ```

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -1500,7 +1500,7 @@ pact> (format-time "%a, %_d %b %Y %H:%M:%S %Z" (time "2016-07-23T13:30:45Z"))
 ### YYYY-MM-DD hh:mm:ss.000000
 
 ```
-> (format-time "%Y-%m-%d %H:%M:%S.%v" (add-time (time "2016-07-23T13:30:45Z") 0.001002))
+pact> (format-time "%Y-%m-%d %H:%M:%S.%v" (add-time (time "2016-07-23T13:30:45Z") 0.001002))
 "2016-07-23 13:30:45.001002"
 ```
 

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -738,7 +738,7 @@ arguments in order to serially execute the function.
 
 ```lisp
 (map (+ 2) [1 2 3])
-(fold (+) ["Concatenate" " " "me"]
+(fold (+) "" ["Concatenate" " " "me"]
 ```
 
 Pact also has [compose](#compose), which allows "chaining" applications in a functional style.
@@ -761,8 +761,8 @@ code to execute quickly.
 ### Message Data {#messagedata}
 
 Pact expects code to arrive in a message with a JSON payload and signatures. Message data
-is read using [read-msg](#read-msg) and related functions, while signatures are not directly
-readable or writable -- they are evaluated as part of [keyset predicate](#keysetpredicates)
+is read using [read-msg](#read-msg) and related functions. While signatures are not directly
+readable or writable, they are evaluated as part of [keyset predicate](#keysetpredicates)
 enforcement.
 
 #### JSON support {#json}
@@ -861,7 +861,7 @@ previous step as a new ROLLBACK transaction, completing when the first step is r
 ### Yield and Resume
 
 A step can yield values to the following step using [yield](#yield) and [resume](#resume). In public,
-this is an unforgeable value as it is maintained within the blockchain pact scope. In private this is
+this is an unforgeable value, as it is maintained within the blockchain pact scope. In private, this is
 simply a value sent with a RESUME message from the executed entity.
 
 ### Pact execution scope and `pact-id`

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -92,7 +92,7 @@ All endpoints are served from `api/v1`. Thus a `send` call would be sent to <htt
 
 ### /send
 
-Asynchronous submit of one or more *public* (unencrypted) commands to the blockchain.
+Asynchronous submission of one or more *public* (unencrypted) commands to the blockchain.
 See [cmd field format](#cmd-field-and-payloads) regarding the stringified JSON data.
 
 Request JSON:
@@ -131,8 +131,8 @@ Response JSON:
 
 ### /private
 
-Asynchronous submit of one or more *private* commands to the blockchain, using supplied address info
-to securely encrypt for only sending and receiving entities to read.
+Asynchronous submission of one or more *private* commands to the blockchain, using supplied address info
+to securely encrypt, in order only to send and receive entities for reading.
 See [cmd field format](#cmd-field-and-payloads) regarding the stringified JSON data.
 
 Request JSON:
@@ -524,14 +524,14 @@ encountered, the runtime enforces the type when the expression is evaluated.
 With the [typecheck](#typecheck) repl command, the Pact interpreter will analyze a module
 and attempt to infer types on every variable, function application or const definition.
 Using this in project repl scripts is helpful to aid the developer in adding "just enough types"
-to make the typecheck succeed. Fully successful typecheck is usually a matter of providing
+to make the typecheck succeed. Successful typechecking is usually a matter of providing
 schemas for all tables, and argument types for ancillary functions that call ambiguous or
 overloaded native functions.
 
 ### Formal Verification
 
-Pact's typechecker is designed to output a fully typechecked, inlined AST for use generating
-formal proofs in SMT-LIB2. If the typecheck does not fully succeed, the module is not
+Pact's typechecker is designed to output a fully typechecked and inlined AST for generating
+formal proofs in the SMT-LIB2 language. If the typecheck does not succeed, the module is not
 considered "provable".
 
 We see, then, that Pact code can move its way up a "safety" gradient, starting with no types,
@@ -573,18 +573,18 @@ Examples of valid keyset JSON productions:
 
 ### Keyset Predicates {#keyset-predicates}
 
-A keyset predicate references a function by its (optionally qualified) name which will compare the public keys in the keyset
+A keyset predicate references a function by its (optionally qualified) name, and will compare the public keys in the keyset
 to the key or keys used to sign the blockchain message. The function accepts two arguments,
 "count" and "matched", where "count" is the number of keys in the keyset and "matched" is how many
 keys on the message signature matched a keyset key.
 
 Support for multiple signatures is the responsibility of the blockchain layer, and is a powerful
-feature for Bitcoin-style "multisig" contracts (ie requiring at least two signatures to release funds).
+feature for Bitcoin-style "multisig" contracts (i.e. requiring at least two signatures to release funds).
 
 Pact comes with built-in keyset predicates: [keys-all](#keys-all), [keys-any](#keys-any), [keys-2](#keys-2).
 Module authors are free to define additional predicates.
 
-If a keyset predicate is not specified, it is defaulted to [keys-all](#keys-all).
+If a keyset predicate is not specified, [keys-all](#keys-all) is used by default.
 
 ### Key rotation {#keyrotation}
 
@@ -595,7 +595,7 @@ and predicate. Once authorized, the keyset can be easily [redefined](#define-key
 
 When [creating](#create-table) a table, a module name must also be specified. By this mechanism,
 tables are "guarded" or "encapsulated" by the module, such that direct access to the table
-via [data-access functions](#Database) is authorized by the module's admin keyset. However,
+via [data-access functions](#Database) is authorized only by the module's admin keyset. However,
 *within module functions*, table access is unconstrained. This gives contract authors great
 flexibility in designing data access, and is intended to enshrine the module as the main
 "user" data access API.
@@ -649,8 +649,6 @@ Module-global constant values can be declared with [defconst](#defconst).
 
 Pact code can be explicitly typed, and is always strongly-typed under the hood as the native
 functions perform strict type checking as indicated in their documented type signatures.
-language, but does use fixed type representations "under the hood"
-and does no coercion of types, so is strongly-typed nonetheless.
 
 Pact's supported types are:
 

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -869,7 +869,7 @@ simply a value sent with a RESUME message from the executed entity.
 Every time a pact is initiated, it is given a unique ID which is retrievable using the [pact-id](#pact-id)
 function, which will return the ID of the currently executing pact, or fail if not running within a pact
 scope. This mechanism can thus be used to guard access to resources, analogous to the use of keysets and
-signatures. The classic use of this is to create escrow accounts that can only be used within the context
+signatures. One typical use of this is to create escrow accounts that can only be used within the context
 of a given pact, eliminating the need for a trusted third party for many use-cases.
 
 ### Testing pacts
@@ -903,13 +903,13 @@ hash value into the module's hash.
 This allows a "dependency-only" upgrade to push the upgrade to the module version.
 
 ### Inlined Dependencies: "No Leftpad"
-Pact inlines all user-code references when a module is loaded, meaning that upstream definitions are
-injected into downstream code. At this point, upstream definitions are permanent: the only way to upgrade
-dependencies is to re-load the module code.
+When a module is loaded, all references to foreign modules are resolved, and their code is
+directly inlined. At this point, upstream definitions are permanent: the only way to upgrade
+dependencies is to reload the original module.
 
-This permanence is great for downstream/client code: the upstream provider cannot change what code
-gets executed in your module, once loaded. It creates a big problem
-for upstream/provider code, as providers cannot upgrade the downstream code to address an exploit, or to
+This permanence is great for user code: once a module is loaded, an upstream provider cannot change what code
+is executed within. However, this creates a big problem
+for upstream developers, as they cannot upgrade the downstream code themselves in order to address an exploit, or to
 introduce new features.
 
 ### Blessing hashes

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -1585,7 +1585,7 @@ Times are stored in a JSON object capturing a Modified Julian Day value and a da
 
 ```javascript
 { "_P_timed": 234 /* "modified julian day value */
-  "_P_timems": 32495874 /* microseconds, encoded using INTEGER format */
+, "_P_timems": 32495874 /* microseconds, encoded using INTEGER format */
 }
 ```
 

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -8,7 +8,7 @@ correct, transactional execution on a [high-performance blockchain](http://kaden
 background, please see the [white paper](http://kadena.io/docs/Kadena-PactWhitepaper.pdf)
 or the [pact home page](http://kadena.io/#pactModal).
 
-Copyright (c) 2016/2017, Stuart Popejoy. All Rights Reserved.
+Copyright (c) 2016 - 2018, Stuart Popejoy. All Rights Reserved.
 
 
 Rest API

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -738,7 +738,7 @@ arguments in order to serially execute the function.
 
 ```lisp
 (map (+ 2) [1 2 3])
-(fold (+) "" ["Concatenate" " " "me"]
+(fold (+) "" ["Concatenate" " " "me"])
 ```
 
 Pact also has [compose](#compose), which allows "chaining" applications in a functional style.

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -1527,7 +1527,7 @@ _Transparency_: JSON is a human-readable format which allows visual verification
 
 _Portability_: JSON enjoys strong support in nearly every database backend at time of writing (2018). The key-value
 structure allows using even non-RDBMS backends like RocksDB etc, and also keeps SQL DDL very straightforward,
-with simple primary key structure. Indexing is not supported or required.
+with simple primary key structure. Indexing is not supported nor required.
 
 ## Pact Datatype Codec
 

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -1630,7 +1630,7 @@ The data table supports CRUD-style access to the current table state.
 
 The transaction table logs all updates to the table.
 
-- **Naming**: `TX_[module]_[table]**`
+- **Naming**: `TX_[module]_[table]`
 - **Key Format**: Keys are integers, using backend-specific BIGINT values, reflecting the transaction ID being recorded.
 - **Value format**: JSON array of updates in a particular transaction.
 

--- a/docs/pact-reference.md
+++ b/docs/pact-reference.md
@@ -1115,8 +1115,8 @@ in the following form:
   (/ (+ a b) 2))
 ```
 
-However, in this position, optional metadata can also be specified.
-One such metadata field is `@model`, which represents a property that can
+However, in this position, extra metadata fields can also be specified.
+One such metadata field is `@model`, which represents a *property* that can
 be used by Pact tooling to verify the correctness of the implementation:
 
 ```lisp
@@ -1160,7 +1160,8 @@ Arguments are in scope for BODY, one or more expressions.
 ```lisp
 (defun add3 (a b c) (+ a (+ b c)))
 
-(defun scale3 (a b c s) "multiply sum of A B C times s"
+(defun scale3 (a b c s)
+  "multiply sum of A B C times s"
   (* s (add3 a b c)))
 ```
 
@@ -1183,7 +1184,7 @@ Define NAME as VALUE, with option DOC-OR-META. Value is evaluated upon module lo
 (defpact NAME ARGLIST [DOC-OR-META] STEPS...)
 ```
 
-Define NAME as a _pact_, a multistep computation intended for private transactions.
+Define NAME as a _pact_, a multistep transaction computation.
 Identical to [defun](#defun) except body must be comprised of [steps](#step) to be
 executed in strict sequential order. Steps must uniformly be "public" (no entity indicator)
 or "private" (with entity indicator). With private steps, failures result in a reverse-sequence
@@ -1246,12 +1247,12 @@ the same let binding; for this use [let\*](#letstar).
 ### let&#42; {#letstar}
 
 ```
-(let\* (BINDPAIR [BINDPAIR [...]]) BODY)
+(let* (BINDPAIR [BINDPAIR [...]]) BODY)
 ```
 
 Bind variables in BINDPAIRs to be in scope over BODY. Variables
 can reference previously declared BINDPAIRS in the same let.
-`let\*` is expanded at compile-time to nested `let` calls for
+`let*` is expanded at compile-time to nested `let` calls for
 each BINDPAIR; thus `let` is preferred where possible.
 
 ```lisp
@@ -1267,10 +1268,11 @@ each BINDPAIR; thus `let` is preferred where possible.
 (step ENTITY EXPR)
 ```
 
-Define a step within a [defpact](#defpact) such that any prior steps will be executed in prior transactions,
-and later steps in later transactions. With ENTITY, indicates that this step is intended for confidential transactions
-such that only ENTITY will execute the step, while other participants will "skip" the step.
-in order of execution specified in containing [defpact](#defpact).
+Define a step within a [defpact](#defpact), such that any prior steps will be
+executed in prior transactions, and later steps in later transactions.
+Including an ENTITY argument indicates that this step is intended for confidential
+transactions. Therefore, only the ENTITY would execute the step, and other
+participants would "skip" it.
 
 ### step-with-rollback {#step-with-rollback}
 ```
@@ -1289,8 +1291,8 @@ ROLLBACK-EXPR functions as a "cancel function" to be explicitly executed by a pa
 (use MODULE HASH)
 ```
 
-Import an existing MODULE into namespace. Can only be issued at top-level, or within a module
-declaration. MODULE can be a string, symbol or bare atom. With HASH, validate that module
+Import an existing MODULE into a namespace. Can only be issued at the top-level, or within a module
+declaration. MODULE can be a string, symbol or bare atom. With HASH, validate that the remote module's
 hash matches HASH, failing if not. Use [describe-module](#describe-module) to query for the
 hash of a loaded module on the chain.
 
@@ -1342,7 +1344,7 @@ or to symbols imported into the namespace with [use](#use).
 ### S-expressions {#sexp}
 
 S-expressions are formed with parentheses, with the first atom determining if
-the expression is a [special form](#special) or a function application, in
+the expression is a [special form](#special-forms) or a function application, in
 which case the first atom must refer to a definition.
 
 #### Partial application {#partialapplication}
@@ -1353,8 +1355,8 @@ runtime error.
 
 ### References {#references}
 
-References are two atoms joined by a dot `.` to directly resolve to module
-definitions.
+References are two atoms joined by a dot `.` that directly resolve to definitions found
+in other modules.
 
 ```
 pact> accounts.transfer
@@ -1370,8 +1372,8 @@ pact> transfer
 SRC to DEST\")"
 ```
 
-References are preferred to `use` for transactions, as references resolve faster.
-However in module definition, `use` is preferred for legibility.
+References are preferred over `use` for transactions, as references resolve faster.
+However, when defining a module, `use` is preferred for legibility.
 
 Time formats
 ===
@@ -1472,10 +1474,10 @@ Note: `%q` (picoseconds, zero-padded) does not work properly so not documented h
 
 ## Default format and JSON serialization
 
-The default format is a UTC ISO8601 date+time format: "%Y-%m-%dT%H:%M:%SZ", as accepted by the [time](#time)
+The default format is a UTC ISO8601 date+time format: "%Y-%m-%dT%H:%M:%SZ", as accepted by the [time](pact-functions.html#id4)
 function. While the time object internally supports up to microsecond resolution, values returned from the Pact
 interpreter as JSON will be serialized with the default format. When higher resolution is desired, explicitly format
-times with `%v` and related.
+times with `%v` and related codes.
 
 ## Examples
 

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -1417,9 +1417,10 @@ strings, in the following form:
      "take the average of a and b"
      (/ (+ a b) 2))
 
-However, in this position, optional metadata can also be specified. One
-such metadata field is ``@model``, which represents a property that can
-be used by Pact tooling to verify the correctness of the implementation:
+However, in this position, extra metadata fields can also be specified.
+One such metadata field is ``@model``, which represents a *property*
+that can be used by Pact tooling to verify the correctness of the
+implementation:
 
 .. code:: lisp
 
@@ -1469,7 +1470,8 @@ DOC-OR-META. Arguments are in scope for BODY, one or more expressions.
 
    (defun add3 (a b c) (+ a (+ b c)))
 
-   (defun scale3 (a b c s) "multiply sum of A B C times s"
+   (defun scale3 (a b c s)
+     "multiply sum of A B C times s"
      (* s (add3 a b c)))
 
 defconst
@@ -1495,12 +1497,12 @@ defpact
 
    (defpact NAME ARGLIST [DOC-OR-META] STEPS...)
 
-Define NAME as a *pact*, a multistep computation intended for private
-transactions. Identical to `defun <#defun>`__ except body must be
-comprised of `steps <#step>`__ to be executed in strict sequential
-order. Steps must uniformly be “public” (no entity indicator) or
-“private” (with entity indicator). With private steps, failures result
-in a reverse-sequence “rollback cascade”.
+Define NAME as a *pact*, a multistep transaction computation. Identical
+to `defun <#defun>`__ except body must be comprised of `steps <#step>`__
+to be executed in strict sequential order. Steps must uniformly be
+“public” (no entity indicator) or “private” (with entity indicator).
+With private steps, failures result in a reverse-sequence “rollback
+cascade”.
 
 .. code:: lisp
 
@@ -1566,10 +1568,10 @@ let\*
 
 ::
 
-   (let\* (BINDPAIR [BINDPAIR [...]]) BODY)
+   (let* (BINDPAIR [BINDPAIR [...]]) BODY)
 
 Bind variables in BINDPAIRs to be in scope over BODY. Variables can
-reference previously declared BINDPAIRS in the same let. ``let\*`` is
+reference previously declared BINDPAIRS in the same let. ``let*`` is
 expanded at compile-time to nested ``let`` calls for each BINDPAIR; thus
 ``let`` is preferred where possible.
 
@@ -1588,12 +1590,11 @@ step
    (step EXPR)
    (step ENTITY EXPR)
 
-Define a step within a `defpact <#defpact>`__ such that any prior steps
+Define a step within a `defpact <#defpact>`__, such that any prior steps
 will be executed in prior transactions, and later steps in later
-transactions. With ENTITY, indicates that this step is intended for
-confidential transactions such that only ENTITY will execute the step,
-while other participants will “skip” the step. in order of execution
-specified in containing `defpact <#defpact>`__.
+transactions. Including an ENTITY argument indicates that this step is
+intended for confidential transactions. Therefore, only the ENTITY would
+execute the step, and other participants would “skip” it.
 
 step-with-rollback
 ~~~~~~~~~~~~~~~~~~
@@ -1619,11 +1620,11 @@ use
    (use MODULE)
    (use MODULE HASH)
 
-Import an existing MODULE into namespace. Can only be issued at
+Import an existing MODULE into a namespace. Can only be issued at the
 top-level, or within a module declaration. MODULE can be a string,
-symbol or bare atom. With HASH, validate that module hash matches HASH,
-failing if not. Use `describe-module <#describe-module>`__ to query for
-the hash of a loaded module on the chain.
+symbol or bare atom. With HASH, validate that the remote module’s hash
+matches HASH, failing if not. Use `describe-module <#describe-module>`__
+to query for the hash of a loaded module on the chain.
 
 .. code:: lisp
 
@@ -1685,8 +1686,8 @@ S-expressions
 ~~~~~~~~~~~~~
 
 S-expressions are formed with parentheses, with the first atom
-determining if the expression is a `special form <#special>`__ or a
-function application, in which case the first atom must refer to a
+determining if the expression is a `special form <#special-forms>`__ or
+a function application, in which case the first atom must refer to a
 definition.
 
 .. _partialapplication:
@@ -1703,8 +1704,8 @@ runtime error.
 References
 ~~~~~~~~~~
 
-References are two atoms joined by a dot ``.`` to directly resolve to
-module definitions.
+References are two atoms joined by a dot ``.`` that directly resolve to
+definitions found in other modules.
 
 ::
 
@@ -1720,9 +1721,9 @@ module definitions.
    "(defun accounts.transfer (src,dest,amount,date) \"transfer AMOUNT from
    SRC to DEST\")"
 
-References are preferred to ``use`` for transactions, as references
-resolve faster. However in module definition, ``use`` is preferred for
-legibility.
+References are preferred over ``use`` for transactions, as references
+resolve faster. However, when defining a module, ``use`` is preferred
+for legibility.
 
 Time formats
 ============
@@ -1849,11 +1850,12 @@ Default format and JSON serialization
 -------------------------------------
 
 The default format is a UTC ISO8601 date+time format:
-“%Y-%m-%dT%H:%M:%SZ”, as accepted by the `time <#time>`__ function.
-While the time object internally supports up to microsecond resolution,
-values returned from the Pact interpreter as JSON will be serialized
-with the default format. When higher resolution is desired, explicitly
-format times with ``%v`` and related.
+“%Y-%m-%dT%H:%M:%SZ”, as accepted by the
+`time <pact-functions.html#id4>`__ function. While the time object
+internally supports up to microsecond resolution, values returned from
+the Pact interpreter as JSON will be serialized with the default format.
+When higher resolution is desired, explicitly format times with ``%v``
+and related codes.
 
 Examples
 --------

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -2039,7 +2039,7 @@ User Transaction Table
 
 The transaction table logs all updates to the table.
 
--  **Naming**: ``TX_[module]_[table]**``
+-  **Naming**: ``TX_[module]_[table]``
 -  **Key Format**: Keys are integers, using backend-specific BIGINT
    values, reflecting the transaction ID being recorded.
 -  **Value format**: JSON array of updates in a particular transaction.

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -9,7 +9,7 @@ blockchain <http://kadena.io>`__. For more background, please see the
 `white paper <http://kadena.io/docs/Kadena-PactWhitepaper.pdf>`__ or the
 `pact home page <http://kadena.io/#pactModal>`__.
 
-Copyright (c) 2016/2017, Stuart Popejoy. All Rights Reserved.
+Copyright (c) 2016 - 2018, Stuart Popejoy. All Rights Reserved.
 
 Rest API
 ========

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -1881,7 +1881,7 @@ YYYY-MM-DD hh:mm:ss.000000
 
 ::
 
-   > (format-time "%Y-%m-%d %H:%M:%S.%v" (add-time (time "2016-07-23T13:30:45Z") 0.001002))
+   pact> (format-time "%Y-%m-%d %H:%M:%S.%v" (add-time (time "2016-07-23T13:30:45Z") 0.001002))
    "2016-07-23 13:30:45.001002"
 
 Database Serialization Format

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -838,7 +838,7 @@ Call with references instead of ``use``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When calling module functions in transactions, use `reference
-syntax <#reference>`__ instead of importing the module with
+syntax <#references>`__ instead of importing the module with
 `use <#use>`__. When defining modules that reference other module
 functions, ``use`` is fine, as those references will be inlined at
 module definition time.

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -939,7 +939,7 @@ execute the function.
 .. code:: lisp
 
    (map (+ 2) [1 2 3])
-   (fold (+) "" ["Concatenate" " " "me"]
+   (fold (+) "" ["Concatenate" " " "me"])
 
 Pact also has `compose <#compose>`__, which allows “chaining”
 applications in a functional style.

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -1250,7 +1250,7 @@ runtime, like a function or a table name. Their representation
 internally is simply a string literal so their usage is idiomatic.
 
 Symbols are created with a preceding tick, thus they do not support
-whitespaces or multilines.
+whitespace nor multiline syntax.
 
 ::
 
@@ -1497,12 +1497,12 @@ defpact
 
    (defpact NAME ARGLIST [DOC-OR-META] STEPS...)
 
-Define NAME as a *pact*, a multistep transaction computation. Identical
-to `defun <#defun>`__ except body must be comprised of `steps <#step>`__
-to be executed in strict sequential order. Steps must uniformly be
-“public” (no entity indicator) or “private” (with entity indicator).
-With private steps, failures result in a reverse-sequence “rollback
-cascade”.
+Define NAME as a *pact*, a computation comprised of multiple steps that
+occur in distinct transactions. Identical to `defun <#defun>`__ except
+body must be comprised of `steps <#step>`__ to be executed in strict
+sequential order. Steps must uniformly be “public” (no entity indicator)
+or “private” (with entity indicator). With private steps, failures
+result in a reverse-sequence “rollback cascade”.
 
 .. code:: lisp
 
@@ -1622,7 +1622,7 @@ use
 
 Import an existing MODULE into a namespace. Can only be issued at the
 top-level, or within a module declaration. MODULE can be a string,
-symbol or bare atom. With HASH, validate that the remote module’s hash
+symbol or bare atom. With HASH, validate that the imported module’s hash
 matches HASH, failing if not. Use `describe-module <#describe-module>`__
 to query for the hash of a loaded module on the chain.
 
@@ -1704,8 +1704,8 @@ runtime error.
 References
 ~~~~~~~~~~
 
-References are two atoms joined by a dot ``.`` that directly resolve to
-definitions found in other modules.
+References are multiple atoms joined by a dot ``.`` that directly
+resolve to definitions found in other modules.
 
 ::
 

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -1249,8 +1249,8 @@ Symbols are string literals representing some unique item in the
 runtime, like a function or a table name. Their representation
 internally is simply a string literal so their usage is idiomatic.
 
-Symbols are created with a preceding tick, thus they do no support
-whitespace or multiline.
+Symbols are created with a preceding tick, thus they do not support
+whitespaces or multilines.
 
 ::
 
@@ -1260,25 +1260,26 @@ whitespace or multiline.
 Integers
 ~~~~~~~~
 
-Integer literals are unbounded positive naturals. For negative numbers
-use the unary `- <#->`__ function.
+Integer literals are unbounded, and can be positive or negative.
 
 ::
 
    pact> 12345
    12345
+   pact> -922337203685477580712387461234
+   -922337203685477580712387461234
 
 Decimals
 ~~~~~~~~
 
-Decimal literals are positive decimals to exact expressed precision.
+Decimal literals have potentially unlimited precision.
 
 ::
 
    pact> 100.25
    100.25
-   pact> 356452.23451872
-   356452.23451872
+   pact> -356452.234518728287461023856582382983746
+   -356452.234518728287461023856582382983746
 
 Booleans
 ~~~~~~~~
@@ -1413,18 +1414,18 @@ strings, in the following form:
 .. code:: lisp
 
    (defun foo (bar)
-     "Do the thing with BAR"
+     "Do something with BAR"
      ...)
 
 However, in this position an optional *metadata section* can specify
 docs and metadata, where metadata can be tagged with any key desired.
-The following code provides a docstring of “does the thing with BAR” and
+The following code provides a docstring of “does something with BAR” and
 specifies metadata of type ``property`` and ``example``:
 
 .. code:: lisp
 
    (defun foo (bar)
-     ("does the thing with BAR"
+     ("does something with BAR"
        (property [(when something abort)])
        (example (foo "my house")))
      ...)

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -1121,7 +1121,7 @@ Every time a pact is initiated, it is given a unique ID which is
 retrievable using the `pact-id <#pact-id>`__ function, which will return
 the ID of the currently executing pact, or fail if not running within a
 pact scope. This mechanism can thus be used to guard access to
-resources, analogous to the use of keysets and signatures. The classic
+resources, analogous to the use of keysets and signatures. One typical
 use of this is to create escrow accounts that can only be used within
 the context of a given pact, eliminating the need for a trusted third
 party for many use-cases.
@@ -1168,16 +1168,16 @@ module version.
 Inlined Dependencies: “No Leftpad”
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Pact inlines all user-code references when a module is loaded, meaning
-that upstream definitions are injected into downstream code. At this
-point, upstream definitions are permanent: the only way to upgrade
-dependencies is to re-load the module code.
+When a module is loaded, all references to foreign modules are resolved,
+and their code is directly inlined. At this point, upstream definitions
+are permanent: the only way to upgrade dependencies is to reload the
+original module.
 
-This permanence is great for downstream/client code: the upstream
-provider cannot change what code gets executed in your module, once
-loaded. It creates a big problem for upstream/provider code, as
-providers cannot upgrade the downstream code to address an exploit, or
-to introduce new features.
+This permanence is great for user code: once a module is loaded, an
+upstream provider cannot change what code is executed within. However,
+this creates a big problem for upstream developers, as they cannot
+upgrade the downstream code themselves in order to address an exploit,
+or to introduce new features.
 
 Blessing hashes
 ~~~~~~~~~~~~~~~

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -1918,7 +1918,7 @@ verification of values.
 backend at time of writing (2018). The key-value structure allows using
 even non-RDBMS backends like RocksDB etc, and also keeps SQL DDL very
 straightforward, with simple primary key structure. Indexing is not
-supported or required.
+supported nor required.
 
 Pact Datatype Codec
 -------------------

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -114,8 +114,8 @@ sent to http://localhost:8080/api/v1/send, if running on
 /send
 ~~~~~
 
-Asynchronous submit of one or more *public* (unencrypted) commands to
-the blockchain. See `cmd field format <#cmd-field-and-payloads>`__
+Asynchronous submission of one or more *public* (unencrypted) commands
+to the blockchain. See `cmd field format <#cmd-field-and-payloads>`__
 regarding the stringified JSON data.
 
 Request JSON:
@@ -155,9 +155,9 @@ Response JSON:
 /private
 ~~~~~~~~
 
-Asynchronous submit of one or more *private* commands to the blockchain,
-using supplied address info to securely encrypt for only sending and
-receiving entities to read. See `cmd field
+Asynchronous submission of one or more *private* commands to the
+blockchain, using supplied address info to securely encrypt, in order
+only to send and receive entities for reading. See `cmd field
 format <#cmd-field-and-payloads>`__ regarding the stringified JSON data.
 
 Request JSON:
@@ -633,16 +633,16 @@ With the `typecheck <#typecheck>`__ repl command, the Pact interpreter
 will analyze a module and attempt to infer types on every variable,
 function application or const definition. Using this in project repl
 scripts is helpful to aid the developer in adding “just enough types” to
-make the typecheck succeed. Fully successful typecheck is usually a
-matter of providing schemas for all tables, and argument types for
-ancillary functions that call ambiguous or overloaded native functions.
+make the typecheck succeed. Successful typechecking is usually a matter
+of providing schemas for all tables, and argument types for ancillary
+functions that call ambiguous or overloaded native functions.
 
 Formal Verification
 ~~~~~~~~~~~~~~~~~~~
 
-Pact’s typechecker is designed to output a fully typechecked, inlined
-AST for use generating formal proofs in SMT-LIB2. If the typecheck does
-not fully succeed, the module is not considered “provable”.
+Pact’s typechecker is designed to output a fully typechecked and inlined
+AST for generating formal proofs in the SMT-LIB2 language. If the
+typecheck does not succeed, the module is not considered “provable”.
 
 We see, then, that Pact code can move its way up a “safety” gradient,
 starting with no types, then with “enough” types, and lastly, with
@@ -688,7 +688,7 @@ Keyset Predicates
 ~~~~~~~~~~~~~~~~~
 
 A keyset predicate references a function by its (optionally qualified)
-name which will compare the public keys in the keyset to the key or keys
+name, and will compare the public keys in the keyset to the key or keys
 used to sign the blockchain message. The function accepts two arguments,
 “count” and “matched”, where “count” is the number of keys in the keyset
 and “matched” is how many keys on the message signature matched a keyset
@@ -696,14 +696,14 @@ key.
 
 Support for multiple signatures is the responsibility of the blockchain
 layer, and is a powerful feature for Bitcoin-style “multisig” contracts
-(ie requiring at least two signatures to release funds).
+(i.e. requiring at least two signatures to release funds).
 
 Pact comes with built-in keyset predicates: `keys-all <#keys-all>`__,
 `keys-any <#keys-any>`__, `keys-2 <#keys-2>`__. Module authors are free
 to define additional predicates.
 
-If a keyset predicate is not specified, it is defaulted to
-`keys-all <#keys-all>`__.
+If a keyset predicate is not specified, `keys-all <#keys-all>`__ is used
+by default.
 
 .. _keyrotation:
 
@@ -722,10 +722,11 @@ Module Table Guards
 When `creating <#create-table>`__ a table, a module name must also be
 specified. By this mechanism, tables are “guarded” or “encapsulated” by
 the module, such that direct access to the table via `data-access
-functions <#Database>`__ is authorized by the module’s admin keyset.
-However, *within module functions*, table access is unconstrained. This
-gives contract authors great flexibility in designing data access, and
-is intended to enshrine the module as the main “user” data access API.
+functions <#Database>`__ is authorized only by the module’s admin
+keyset. However, *within module functions*, table access is
+unconstrained. This gives contract authors great flexibility in
+designing data access, and is intended to enshrine the module as the
+main “user” data access API.
 
 .. _rowlevelkeysets:
 
@@ -800,9 +801,7 @@ Data Types
 
 Pact code can be explicitly typed, and is always strongly-typed under
 the hood as the native functions perform strict type checking as
-indicated in their documented type signatures. language, but does use
-fixed type representations “under the hood” and does no coercion of
-types, so is strongly-typed nonetheless.
+indicated in their documented type signatures.
 
 Pact’s supported types are:
 

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -939,7 +939,7 @@ execute the function.
 .. code:: lisp
 
    (map (+ 2) [1 2 3])
-   (fold (+) ["Concatenate" " " "me"]
+   (fold (+) "" ["Concatenate" " " "me"]
 
 Pact also has `compose <#compose>`__, which allows “chaining”
 applications in a functional style.
@@ -972,8 +972,8 @@ Message Data
 
 Pact expects code to arrive in a message with a JSON payload and
 signatures. Message data is read using `read-msg <#read-msg>`__ and
-related functions, while signatures are not directly readable or
-writable – they are evaluated as part of `keyset
+related functions. While signatures are not directly readable or
+writable, they are evaluated as part of `keyset
 predicate <#keysetpredicates>`__ enforcement.
 
 .. _json:
@@ -1110,8 +1110,8 @@ Yield and Resume
 ~~~~~~~~~~~~~~~~
 
 A step can yield values to the following step using `yield <#yield>`__
-and `resume <#resume>`__. In public, this is an unforgeable value as it
-is maintained within the blockchain pact scope. In private this is
+and `resume <#resume>`__. In public, this is an unforgeable value, as it
+is maintained within the blockchain pact scope. In private, this is
 simply a value sent with a RESUME message from the executed entity.
 
 Pact execution scope and ``pact-id``

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -1417,10 +1417,10 @@ strings, in the following form:
      "take the average of a and b"
      (/ (+ a b) 2))
 
-However, in this position, extra metadata fields can also be specified.
-One such metadata field is ``@model``, which represents a *property*
-that can be used by Pact tooling to verify the correctness of the
-implementation:
+Alternately, users can specify metadata using a special ``@``-prefix
+syntax. Supported metadata fields are ``@doc`` to provide a
+documentation string, and ``@model`` that can be used by Pact tooling to
+verify the correctness of the implementation:
 
 .. code:: lisp
 
@@ -1430,8 +1430,7 @@ implementation:
      (/ (+ a b) 2))
 
 Indeed, a bare docstring like ``"foo"`` is actually just a short form
-for ``@doc "foo"``. More metadata types are expected to be added in
-future.
+for ``@doc "foo"``.
 
 Specific information on *Properties* can be found in `The Pact Property
 Checking System <pact-properties.html>`__.

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -1985,7 +1985,7 @@ and a day-local microsecond value.
 .. code:: javascript
 
    { "_P_timed": 234 /* "modified julian day value */
-     "_P_timems": 32495874 /* microseconds, encoded using INTEGER format */
+   , "_P_timems": 32495874 /* microseconds, encoded using INTEGER format */
    }
 
 Suggestions for converting MJDs can be found

--- a/docs/pact-reference.rst
+++ b/docs/pact-reference.rst
@@ -1405,7 +1405,7 @@ Consts
 Special forms
 -------------
 
-Docs and metadata
+Docs and Metadata
 ~~~~~~~~~~~~~~~~~
 
 Many special forms like `defun <#defun>`__ accept optional documentation
@@ -1413,26 +1413,27 @@ strings, in the following form:
 
 .. code:: lisp
 
-   (defun foo (bar)
-     "Do something with BAR"
-     ...)
+   (defun average (a b)
+     "take the average of a and b"
+     (/ (+ a b) 2))
 
-However, in this position an optional *metadata section* can specify
-docs and metadata, where metadata can be tagged with any key desired.
-The following code provides a docstring of “does something with BAR” and
-specifies metadata of type ``property`` and ``example``:
+However, in this position, optional metadata can also be specified. One
+such metadata field is ``@model``, which represents a property that can
+be used by Pact tooling to verify the correctness of the implementation:
 
 .. code:: lisp
 
-   (defun foo (bar)
-     ("does something with BAR"
-       (property [(when something abort)])
-       (example (foo "my house")))
-     ...)
+   (defun average (a b)
+     @doc   "take the average of a and b"
+     @model (property (= (+ a b) (* 2 result)))
+     (/ (+ a b) 2))
 
-Thus, the metadata form is DOC PAIR*, where a PAIR is (ATOM EXPR). The
-Pact language lexer/compiler ignores all EXPR forms, to be
-lexed/compiled at some later stage by whatever tool recognizes ATOM.
+Indeed, a bare docstring like ``"foo"`` is actually just a short form
+for ``@doc "foo"``. More metadata types are expected to be added in
+future.
+
+Specific information on *Properties* can be found in `The Pact Property
+Checking System <pact-properties.html>`__.
 
 bless
 ~~~~~

--- a/src/Pact/Docgen.hs
+++ b/src/Pact/Docgen.hs
@@ -55,7 +55,7 @@ renderFunctions h = do
     renderSection ns
   hPutStrLn h "## REPL-only functions {#repl-lib}"
   hPutStrLn h ""
-  hPutStrLn h "The following functions are loaded magically in the interactive REPL, or in script files \
+  hPutStrLn h "The following functions are loaded automatically into the interactive REPL, or within script files \
                \with a `.repl` extension. They are not available for blockchain-based execution."
   hPutStrLn h ""
   renderSection (snd replDefs)

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -92,7 +92,7 @@ listA = mkTyVar "a" [TyList (mkTyVar "l" []),TyPrim TyString,TySchema TyObject (
 enforceDef :: NativeDef
 enforceDef = defNative "enforce" enforce
   (funType tTyBool [("test",tTyBool),("msg",tTyString)])
-  "Fail transaction with MSG if pure function TEST fails, or returns true. \
+  "Fail transaction with MSG if value TEST is false. Otherwise, returns true. \
   \`!(enforce (!= (+ 2 2) 4) \"Chaos reigns\")`"
   where
 
@@ -175,7 +175,7 @@ hashDef = defRNative "hash" hash' (funType tTyString [("value",a)])
 
 ifDef :: NativeDef
 ifDef = defNative "if" if' (funType a [("cond",tTyBool),("then",a),("else",a)])
-  "Test COND, if true evaluate THEN, otherwise evaluate ELSE. \
+  "Test COND. If true, evaluate THEN. Otherwise, evaluate ELSE. \
   \`(if (= (+ 2 2) 4) \"Sanity prevails\" \"Chaos reigns\")`"
   where
 
@@ -206,7 +206,7 @@ langDefs =
      ifDef
     ,defNative "map" map'
      (funType (TyList a) [("app",lam b a),("list",TyList b)])
-     "Apply elements in LIST as last arg to APP, returning list of results. \
+     "Apply APP to each element in LIST, returning a new list of results. \
      \`(map (+ 1) [1 2 3])`"
 
     ,defNative "fold" fold'
@@ -221,18 +221,18 @@ langDefs =
     ,defRNative "make-list" makeList (funType (TyList a) [("length",tTyInteger),("value",a)])
      "Create list by repeating VALUE LENGTH times. `(make-list 5 true)`"
 
-    ,defRNative "reverse" reverse' (funType (TyList a) [("l",TyList a)])
+    ,defRNative "reverse" reverse' (funType (TyList a) [("list",TyList a)])
      "Reverse a list. `(reverse [1 2 3])`"
 
     ,defNative "filter" filter'
      (funType (TyList a) [("app",lam a tTyBool),("list",TyList a)])
-     "Filter LIST by applying APP to each element to get a boolean determining inclusion.\
+     "Filter LIST by applying APP to each element. For each true result, the original value is kept.\
      \`(filter (compose (length) (< 2)) [\"my\" \"dog\" \"has\" \"fleas\"])`"
 
     ,defRNative "sort" sort'
      (funType (TyList a) [("values",TyList a)] <>
       funType (TyList (tTyObject (mkSchemaVar "o"))) [("fields",TyList tTyString),("values",TyList (tTyObject (mkSchemaVar "o")))])
-     "Sort monotyped list of primitive VALUES, or objects using supplied FIELDS list. \
+     "Sort a homogeneous list of primitive VALUES, or objects using supplied FIELDS list. \
      \`(sort [3 1 2])` `(sort ['age] [{'name: \"Lin\",'age: 30} {'name: \"Val\",'age: 25}])`"
 
     ,defNative (specialForm Where) where'
@@ -292,7 +292,7 @@ langDefs =
      (funType (TyList tTyString) []) "List modules available for loading."
     ,defRNative "yield" yield (funType yieldv [("OBJECT",yieldv)])
      "Yield OBJECT for use with 'resume' in following pact step. The object is similar to database row objects, in that \
-     \only the top level can be binded to in 'resume'; nested objects are converted to opaque JSON values. \
+     \only the top level can be bound to in 'resume'; nested objects are converted to opaque JSON values. \
      \`$(yield { \"amount\": 100.0 })`"
     ,defNative "resume" resume
      (funType a [("binding",TySchema TyBinding (mkSchemaVar "y")),("body",TyAny)])
@@ -318,7 +318,7 @@ langDefs =
      (funType a [("value",a),("ignore1",b)] <>
       funType a [("value",a),("ignore1",b),("ignore2",c)] <>
       funType a [("value",a),("ignore1",b),("ignore2",c),("ignore3",d)])
-     "Ignore (lazily) arguments IGNORE* and return VALUE. `(filter (constantly true) [1 2 3])`"
+     "Lazily ignore arguments IGNORE* and return VALUE. `(filter (constantly true) [1 2 3])`"
     ,defRNative "identity" identity (funType a [("value",a)])
      "Return provided value. `(map (identity) [1 2 3])`"
 

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -92,7 +92,7 @@ listA = mkTyVar "a" [TyList (mkTyVar "l" []),TyPrim TyString,TySchema TyObject (
 enforceDef :: NativeDef
 enforceDef = defNative "enforce" enforce
   (funType tTyBool [("test",tTyBool),("msg",tTyString)])
-  "Fail transaction with MSG if value TEST is false. Otherwise, returns true. \
+  "Fail transaction with MSG if pure expression TEST is false. Otherwise, returns true. \
   \`!(enforce (!= (+ 2 2) 4) \"Chaos reigns\")`"
   where
 
@@ -222,7 +222,7 @@ langDefs =
      "Create list by repeating VALUE LENGTH times. `(make-list 5 true)`"
 
     ,defRNative "reverse" reverse' (funType (TyList a) [("list",TyList a)])
-     "Reverse a list. `(reverse [1 2 3])`"
+     "Reverse LIST. `(reverse [1 2 3])`"
 
     ,defNative "filter" filter'
      (funType (TyList a) [("app",lam a tTyBool),("list",TyList a)])
@@ -276,7 +276,7 @@ langDefs =
     ,defRNative "read-msg" readMsg (funType a [] <> funType a [("key",tTyString)])
      "Read KEY from top level of message data body, or data body itself if not provided. \
      \Coerces value to their corresponding pact type: String -> string, Number -> integer, Boolean -> bool, \
-     \List -> list, Object -> object. \
+     \List -> list, Object -> object. However, top-level values are provided as a 'value' JSON type. \
      \`$(defun exec ()\n   (transfer (read-msg \"from\") (read-msg \"to\") (read-decimal \"amount\")))`"
 
     ,defRNative "tx-hash" txHash (funType tTyString [])

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -275,8 +275,8 @@ langDefs =
      "Parse KEY string or number value from top level of message data body as integer. `$(read-integer \"age\")`"
     ,defRNative "read-msg" readMsg (funType a [] <> funType a [("key",tTyString)])
      "Read KEY from top level of message data body, or data body itself if not provided. \
-     \Coerces value to pact type: String -> string, Number -> integer, Boolean -> bool, \
-     \List -> value, Object -> value. NB value types are not introspectable in pact. \
+     \Coerces value to their corresponding pact type: String -> string, Number -> integer, Boolean -> bool, \
+     \List -> list, Object -> object. \
      \`$(defun exec ()\n   (transfer (read-msg \"from\") (read-msg \"to\") (read-decimal \"amount\")))`"
 
     ,defRNative "tx-hash" txHash (funType tTyString [])
@@ -609,13 +609,13 @@ strToInt i as =
     go base' txt =
       if T.all isHexDigit txt
       then
-        if T.length txt <= 128 
+        if T.length txt <= 128
         then case baseStrToInt base' txt of
           Left _ -> argsError i as
           Right n -> return (toTerm n)
         else evalError' i $ "Invalid input: unsupported string length: " ++ (unpack txt)
       else evalError' i $ "Invalid input: supplied string is not hex: " ++ (unpack txt)
-      
+
 txHash :: RNativeFun e
 txHash _ [] = (tStr . asString) <$> view eeHash
 txHash i as = argsError i as
@@ -626,7 +626,7 @@ txHash i as = argsError i as
 -- e.g.
 --   -- hexadecimal to decimal
 --   baseStrToInt 10 "abcdef123456" = 188900967593046
--- 
+--
 baseStrToInt :: Integer -> Text -> Either Text Integer
 baseStrToInt base t =
   if base <= 1 || base > 16
@@ -637,5 +637,5 @@ baseStrToInt base t =
     else Right $ T.foldl' go 0 t
   where
     go :: Integer -> Char -> Integer
-    go acc w = base * acc + (fromIntegral . digitToInt $ w) 
+    go acc w = base * acc + (fromIntegral . digitToInt $ w)
 {-# INLINE baseStrToInt #-}

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -84,7 +84,7 @@ dbDefs =
     ,defGasRNative "read" read'
      (funType rowTy [("table",tableTy),("key",tTyString)] <>
       funType rowTy [("table",tableTy),("key",tTyString),("columns",TyList tTyString)])
-     "Read row from TABLE for KEY returning database record object, or just COLUMNS if specified. \
+     "Read row from TABLE for KEY, returning database record object, or just COLUMNS if specified. \
      \`$(read accounts id ['balance 'ccy])`"
 
     ,defNative (specialForm Select) select
@@ -123,7 +123,7 @@ dbDefs =
      "Get metadata for TABLE. Returns an object with 'name', 'hash', 'blessed', 'code', and 'keyset' fields. \
      \`$(describe-table accounts)`"
     ,setTopLevelOnly $ defRNative "describe-keyset" descKeySet
-     (funType tTyValue [("keyset",tTyString)]) "Get metadata for KEYSET"
+     (funType tTyValue [("keyset",tTyString)]) "Get metadata for KEYSET."
     ,setTopLevelOnly $ defRNative "describe-module" descModule
      (funType tTyValue [("module",tTyString)])
      "Get metadata for MODULE. Returns an object with 'name', 'hash', 'blessed', 'code', and 'keyset' fields. \
@@ -151,7 +151,7 @@ descModule i [TLitString t] = do
   case _mdModule <$> mods of
     Just m ->
       case m of
-        Module{..} -> 
+        Module{..} ->
           return $ TObject
             [ (tStr "name"      , tStr $ asString _mName)
             , (tStr "hash"      , tStr $ asString _mHash)
@@ -366,7 +366,7 @@ enforceBlessedHashes :: FunApp -> ModuleName -> Hash -> Eval e ()
 enforceBlessedHashes i mn h = do
   mmRs <- fmap _mdModule . HM.lookup mn <$> view (eeRefStore . rsModules)
   mm <- maybe (HM.lookup mn <$> use (evalRefs.rsLoadedModules)) (return.Just) mmRs
-  case mm of 
+  case mm of
     Nothing -> evalError' i $ "Internal error: Module " ++ show mn ++ " not found, could not enforce hashes"
     Just m ->
       case m of

--- a/src/Pact/Native/Ops.hs
+++ b/src/Pact/Native/Ops.hs
@@ -116,7 +116,7 @@ lnDef :: NativeDef
 lnDef = defRNative "ln" (unopd log) unopTy "Natural log of X. `(round (ln 60) 6)`"
 
 expDef :: NativeDef
-expDef = defRNative "exp" (unopd exp) unopTy "Exp of X `(round (exp 3) 6)`"
+expDef = defRNative "exp" (unopd exp) unopTy "Exp of X. `(round (exp 3) 6)`"
 
 absDef :: NativeDef
 absDef = defRNative "abs" abs' (unaryTy tTyDecimal tTyDecimal <> unaryTy tTyInteger tTyInteger)

--- a/src/Pact/Native/Time.hs
+++ b/src/Pact/Native/Time.hs
@@ -33,7 +33,7 @@ import Pact.Native.Internal
 
 
 timedoc :: Text
-timedoc = "See [\"Time Formats\" docs](#time-formats) for supported formats."
+timedoc = "See [\"Time Formats\" docs](pact-reference.html#time-formats) for supported formats."
 
 defAddTime :: NativeDef
 defAddTime = defRNative "add-time" addTime

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -84,7 +84,7 @@ replDefs = ("Repl",
      [
       defZRNative "load" load (funType tTyString [("file",tTyString)] <>
                               funType tTyString [("file",tTyString),("reset",tTyBool)]) $
-      "Load and evaluate FILE, resetting repl state beforehand if optional NO-RESET is true. " <>
+      "Load and evaluate FILE, resetting repl state beforehand if optional RESET is true. " <>
       "`$(load \"accounts.repl\")`"
      ,defZRNative "env-keys" setsigs (funType tTyString [("keys",TyList tTyString)])
       "Set transaction signature KEYS. `(env-keys [\"my-key\" \"admin-key\"])`"
@@ -123,13 +123,13 @@ replDefs = ("Repl",
                                  funType tTyString [("module",tTyString),("debug",tTyBool)])
        "Typecheck MODULE, optionally enabling DEBUG output."
      ,defZRNative "env-gaslimit" setGasLimit (funType tTyString [("limit",tTyInteger)])
-       "Set environment gas limit to LIMIT"
+       "Set environment gas limit to LIMIT."
      ,defZRNative "env-gas" envGas (funType tTyInteger [] <> funType tTyString [("gas",tTyInteger)])
-       "Query gas state, or set it to GAS"
+       "Query gas state, or set it to GAS."
      ,defZRNative "env-gasprice" setGasPrice (funType tTyString [("price",tTyDecimal)])
-       "Set environment gas price to PRICE"
+       "Set environment gas price to PRICE."
      ,defZRNative "env-gasrate" setGasRate (funType tTyString [("rate",tTyInteger)])
-       "Update gas model to charge constant RATE"
+       "Update gas model to charge constant RATE."
 #if !defined(ghcjs_HOST_OS)
      ,defZRNative "verify" verify (funType tTyString [("module",tTyString)]) "Verify MODULE, checking that all properties hold."
 #endif
@@ -139,9 +139,9 @@ replDefs = ("Repl",
       "This is only needed for tests, as Pact values are automatically represented as JSON in API output. " <>
       "`(json [{ \"name\": \"joe\", \"age\": 10 } {\"name\": \"mary\", \"age\": 25 }])`"
      ,defZRNative "sig-keyset" sigKeyset (funType tTyKeySet [])
-     "Convenience to build a keyset from keys present in message signatures, using 'keys-all' as the predicate."
+     "Convenience function to build a keyset from keys present in message signatures, using 'keys-all' as the predicate."
      ,defZRNative "print" print' (funType tTyString [("value",a)])
-     "Print a string, mainly to format newlines correctly"
+     "Print a string, to format newlines correctly."
      ,defZRNative "env-hash" envHash (funType tTyString [("hash",tTyString)])
      "Set current transaction hash. HASH must be a valid BLAKE2b 512-bit hash. `(env-hash (hash \"hello\"))`"
      ])

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -141,7 +141,7 @@ replDefs = ("Repl",
      ,defZRNative "sig-keyset" sigKeyset (funType tTyKeySet [])
      "Convenience function to build a keyset from keys present in message signatures, using 'keys-all' as the predicate."
      ,defZRNative "print" print' (funType tTyString [("value",a)])
-     "Print a string, to format newlines correctly."
+     "Output VALUE to terminal as unquoted, unescaped text."
      ,defZRNative "env-hash" envHash (funType tTyString [("hash",tTyString)])
      "Set current transaction hash. HASH must be a valid BLAKE2b 512-bit hash. `(env-hash (hash \"hello\"))`"
      ])


### PR DESCRIPTION
This PR makes certain wording / grammar / punctuation corrections to the English version of Pact's ReadTheDocs documentation. Reading the entire English version was a necessary step in confirming the validity of our translations, and so I made these minor corrections as I found them.

**NOTE:** Some changes in `pact-functions.md` may look arbitrary. They are not! Many are just the official commiting of Docgen'd changes from `master` that were not previously included (which indicates a tiny hole in Pact's PR process).