### PR TITLE
Run 100 property tests instead of 1000.

### DIFF
--- a/tests/AnalyzePropertiesSpec.hs
+++ b/tests/AnalyzePropertiesSpec.hs
@@ -114,6 +114,6 @@ sequentialChecks :: IO Bool
 sequentialChecks = checkSequential $ Group "checks"
   [ ("prop_round_trip_type", prop_round_trip_type)
   , ("prop_round_trip_term", prop_round_trip_term)
-  , ("prop_evaluation",      withTests 1000 prop_evaluation)
+  , ("prop_evaluation",      prop_evaluation)
   , ("prop_evaluation_time", prop_evaluation_time)
   ]


### PR DESCRIPTION
This is a simple first attempt at fixing the timeout issue we sometimes
see in CI running on linux.