### PR TITLE
Change `@meta` to be a list of `Exp`s.

### DIFF
--- a/examples/verified-accounts/accounts.pact
+++ b/examples/verified-accounts/accounts.pact
@@ -36,7 +36,7 @@
 
   (defschema account
     @doc   "Row type for accounts table."
-    @model (invariant (>= balance 0.0))
+    @model [(invariant (>= balance 0.0))]
     balance:decimal
     amount:decimal
     ccy:string

--- a/src-ghc/Pact/PersistPactDb/Regression.hs
+++ b/src-ghc/Pact/PersistPactDb/Regression.hs
@@ -9,6 +9,7 @@ module Pact.PersistPactDb.Regression
 import Control.Concurrent.MVar
 import Control.Exception
 import qualified Data.Map.Strict as M
+import qualified Data.Vector as V
 
 import Pact.PersistPactDb
 import Pact.Persist
@@ -45,7 +46,7 @@ runRegression p = do
   let ks = KeySet [PublicKey "skdjhfskj"] (Name "predfun" def)
   _writeRow pactdb Write KeySets "ks1" ks v
   assertEquals' "keyset write" (Just ks) $ _readRow pactdb KeySets "ks1" v
-  let mod' = Module "mod1" "mod-admin-keyset" (Meta Nothing Nothing) "code" (H.hash "code") mempty
+  let mod' = Module "mod1" "mod-admin-keyset" (Meta Nothing []) "code" (H.hash "code") mempty
   _writeRow pactdb Write Modules "mod1" mod' v
   assertEquals' "module write" (Just mod') $ _readRow pactdb Modules "mod1" v
   assertEquals' "result of commit 3"
@@ -58,7 +59,7 @@ runRegression p = do
               ,("keyset" .= String "mod-admin-keyset")
               ,("name" .= String "mod1")
               ,("code" .= String "code")
-              ,("meta" .= object [("model" .= Null)
+              ,("meta" .= object [("model" .= Array (V.fromList []))
                                  ,("docs" .= Null)])]
      ,TxLog "USER_user1" "key1" $
        object [("gah" .= object [("_P_decm" .= Number 1.23454345e8)

--- a/src-ghc/Pact/PersistPactDb/Regression.hs
+++ b/src-ghc/Pact/PersistPactDb/Regression.hs
@@ -45,7 +45,7 @@ runRegression p = do
   let ks = KeySet [PublicKey "skdjhfskj"] (Name "predfun" def)
   _writeRow pactdb Write KeySets "ks1" ks v
   assertEquals' "keyset write" (Just ks) $ _readRow pactdb KeySets "ks1" v
-  let mod' = Module "mod1" "mod-admin-keyset" (Meta Nothing []) "code" (H.hash "code") mempty
+  let mod' = Module "mod1" "mod-admin-keyset" (Meta Nothing []) "code" (H.hash "code") mempty mempty
   _writeRow pactdb Write Modules "mod1" mod' v
   assertEquals' "module write" (Just mod') $ _readRow pactdb Modules "mod1" v
   assertEquals' "result of commit 3"

--- a/src-ghc/Pact/PersistPactDb/Regression.hs
+++ b/src-ghc/Pact/PersistPactDb/Regression.hs
@@ -9,7 +9,6 @@ module Pact.PersistPactDb.Regression
 import Control.Concurrent.MVar
 import Control.Exception
 import qualified Data.Map.Strict as M
-import qualified Data.Vector as V
 
 import Pact.PersistPactDb
 import Pact.Persist
@@ -59,7 +58,7 @@ runRegression p = do
               ,("keyset" .= String "mod-admin-keyset")
               ,("name" .= String "mod1")
               ,("code" .= String "code")
-              ,("meta" .= object [("model" .= Array (V.fromList []))
+              ,("meta" .= object [("model" .= ([] :: [Text]))
                                  ,("docs" .= Null)])]
      ,TxLog "USER_user1" "key1" $
        object [("gah" .= object [("_P_decm" .= Number 1.23454345e8)

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -30,7 +30,7 @@ import           Control.Exception         as E
 import           Control.Lens              (at, ifoldrM, ifor, itraversed, ix,
                                             traversed, view, (%~), (&), (<&>),
                                             (?~), (^.), (^?), (^@..), _1, _2,
-                                            _Just, _Left)
+                                            _Left)
 import           Control.Monad             (void, (<=<))
 
 import           Control.Monad.Except      (Except, ExceptT (ExceptT),
@@ -409,17 +409,13 @@ moduleTables modules (_mod, modRefs) = do
     let TC.Schema{_utName,_utFields} = schema
         schemaName = asString _utName
 
-    invariants <- case schemas ^? ix schemaName.tMeta.mModel._Just of
+    invariants <- case schemas ^? ix schemaName.tMeta.mModel of
       -- no model = no invariants
-      Nothing    -> pure []
-      Just model -> liftEither $ case expToMapping ["invariant", "invariants"] model of
-        Nothing -> throwError (model, "expected \"invariant\" or \"invariants\"")
-        Just model' -> do
-          let expInvariants = model' ^? ix "invariants"
-              expInvariant  = model' ^? ix "invariant"
-          exps <- collectExps "invariants" expInvariants expInvariant
-          runExpParserOver exps $
-            flip runReaderT (varIdArgs _utFields) . expToInvariant TBool
+      Nothing -> pure []
+      Just model -> liftEither $ do
+        exps <- collectExps "invariant" model
+        runExpParserOver exps $
+          flip runReaderT (varIdArgs _utFields) . expToInvariant TBool
 
     pure $ Table tabName schema invariants
 
@@ -467,19 +463,19 @@ normalizeListLit lits = case lits of
 -- * '(defproperty foo (> 1 0))'
 -- * '(defproperty foo (a:integer b:integer) (> a b))'
 -- * '(property foo)'
-parseModelDecl
-  :: Exp Info
+parseModuleModelDecl
+  :: [Exp Info]
   -> Either ParseFailure [Either (Text, DefinedProperty (Exp Info)) ModuleProperty]
-parseModelDecl (SquareList exps) = traverse parseDefprops' exps where
+parseModuleModelDecl exps = traverse parseDecl exps where
 
-  parseDefprops' exp@(ParenList (EAtom' "defproperty" : rest)) = case rest of
+  parseDecl exp@(ParenList (EAtom' "defproperty" : rest)) = case rest of
     [ EAtom' propname, ParenList args, body ] -> do
       args' <- parseBindings (curry Right) args & _Left %~ (exp,)
       pure $ Left (propname, DefinedProperty args' body)
     [ EAtom' propname,              body ] ->
       pure $ Left (propname, DefinedProperty [] body)
     _ -> Left (exp, "Invalid property definition")
-  parseDefprops' exp = do
+  parseDecl exp = do
     (body, propScope) <- parsePropertyExp exp
     pure $ Right $ ModuleProperty body propScope
 
@@ -505,8 +501,6 @@ parseModelDecl (SquareList exps) = traverse parseDefprops' exps where
       _ -> Left (exp, "malformed property definition")
     _ -> Left (exp, "expected a set of property / defproperty")
 
-parseModelDecl exp = Left (exp, "expected set of defproperty")
-
 -- Get the set (HashMap) of refs to functions in this module.
 moduleTypecheckableRefs :: ModuleData -> HM.HashMap Text Ref
 moduleTypecheckableRefs (_mod, modRefs) = flip HM.filter modRefs $ \case
@@ -521,13 +515,10 @@ data ModelDecl = ModelDecl
 
 -- Get the model defined in this module
 moduleModelDecl :: ModuleData -> Either ParseFailure ModelDecl
-moduleModelDecl (Pact.Module{Pact._mMeta=Pact.Meta _ model}, _modRefs)
-  = case model of
-      Just model' -> do
-        lst <- parseModelDecl model'
-        let (propList, checkList) = partitionEithers lst
-        pure $ ModelDecl (HM.fromList propList) checkList
-      Nothing     -> Right $ ModelDecl HM.empty []
+moduleModelDecl (Pact.Module{Pact._mMeta=Pact.Meta _ model}, _modRefs) = do
+  lst <- parseModuleModelDecl model
+  let (propList, checkList) = partitionEithers lst
+  pure $ ModelDecl (HM.fromList propList) checkList
 
 moduleFunChecks
   :: [Table]
@@ -588,45 +579,23 @@ moduleFunChecks tables modCheckExps funTypes consts propDefs = for funTypes $ \c
                     (ColumnName (T.unpack argName),) <$> maybeTranslateType ty
             in (TableName (T.unpack _tableName), colMap)
 
-    checks <- withExcept ModuleParseFailure $ liftEither $ do
-      exps <- case defn ^? tMeta . mModel . _Just of
-        Just model -> case expToMapping ["property", "properties"] model of
-          Nothing -> throwError (model, "expected \"property\" or \"properties\"")
-          Just model' ->
-            let expProperties = model' ^? ix "properties"
-                expProperty   = model' ^? ix "property"
-            in collectExps "properties" expProperties expProperty
-        Nothing -> pure []
-      let funName = _tDefName defn
-          applicableModuleChecks = map _moduleProperty $
-            filter (applicableCheck funName) modCheckExps
-      runExpParserOver (applicableModuleChecks <> exps) $
-        expToCheck tableEnv vidStart nameVids vidTys consts propDefs
+    checks <- case defn ^? tMeta . mModel of
+      Nothing -> pure []
+      Just model -> withExcept ModuleParseFailure $ liftEither $ do
+        exps <- collectExps "property" model
+        let funName = _tDefName defn
+            applicableModuleChecks = map _moduleProperty $
+              filter (applicableCheck funName) modCheckExps
+        runExpParserOver (applicableModuleChecks <> exps) $
+          expToCheck tableEnv vidStart nameVids vidTys consts propDefs
 
     pure (ref, Right checks)
 
--- | Given an exp like '(k v)', and a set (list) of allowed keys, convert it to
--- a singleton map
-expToMapping :: [Text] -> Exp Info -> Maybe (Map Text (Exp Info))
-expToMapping allowed = \case
-  ParenList [EAtom' k, v]
-    | k `elem` allowed -> Just $ Map.singleton k v
-  _                    -> Nothing
-
--- | For both properties and invariants you're allowed to use either the
--- singular ("property") or plural ("properties") name. This helper just
--- collects the properties / invariants in a list.
-collectExps
-  :: String
-  -> Maybe (Exp Info)
-  -> Maybe (Exp Info)
-  -> Either ParseFailure [Exp Info]
-collectExps name multiExp singularExp = case multiExp of
-  Just (SquareList exps') -> Right exps'
-  Just exp -> Left (exp, name ++ " must be a list")
-  Nothing -> case singularExp of
-    Just exp -> Right [exp]
-    Nothing  -> Right []
+-- | Remove the "invariant" or "property" application from every exp
+collectExps :: Text -> [Exp Info] -> Either ParseFailure [Exp Info]
+collectExps name multiExp = for multiExp $ \case
+  ParenList [EAtom' name', v] | name' == name -> Right v
+  exp -> Left (exp, "expected an application of " ++ T.unpack name)
 
 -- | This runs a parser over a collection of 'Exp's, collecting the failures
 -- or successes.

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -519,16 +519,15 @@ data ModelDecl = ModelDecl
 
 -- Get the model defined in this module
 moduleModelDecl :: ModuleData -> Either ParseFailure ModelDecl
-moduleModelDecl ModuleData{..} = do 
-
-  let model = case _mdModule of
-      Pact.Module{Pact._mMeta=Pact.Meta _ m}            -> m
-      Pact.Interface{Pact._interfaceMeta=Pact.Meta _ m} -> m
-      
+moduleModelDecl ModuleData{..} = do
   lst <- parseModuleModelDecl model
   let (propList, checkList) = partitionEithers lst
   pure $ ModelDecl (HM.fromList propList) checkList
-  
+  where
+    model = case _mdModule of
+      Pact.Module{Pact._mMeta=Pact.Meta _ m}            -> m
+      Pact.Interface{Pact._interfaceMeta=Pact.Meta _ m} -> m
+
 
 moduleFunChecks
   :: [Table]
@@ -748,7 +747,7 @@ verifyCheck
 verifyCheck moduleData funName check = do
   let info       = dummyInfo
       module'    = moduleData ^. mdModule
-      moduleName = nameOf module' 
+      moduleName = nameOf module'
       modules    = HM.fromList [(moduleName, moduleData)]
       moduleFun :: ModuleData -> Text -> Maybe Ref
       moduleFun ModuleData{..} name = name `HM.lookup` _mdRefMap

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -235,7 +235,8 @@ meta modelAllowed = atPairs <|> try docStr <|> return def
       doc <- optional (try docPair)
       model <- optional (try modelPair)
       case (doc, model, modelAllowed) of
-        (Nothing, Nothing    , _              ) -> expected "@doc or @model declarations"
+        (Nothing, Nothing    , ModelAllowed   ) -> expected "@doc or @model declarations"
+        (Nothing, Nothing    , ModelNotAllowed) -> expected "@doc declaration"
         (_      , Just model', ModelAllowed   ) -> return (Meta doc model')
         (_      , Just _     , ModelNotAllowed) -> syntaxError "@model not allowed in this declaration"
         (_      , Nothing    , _              ) -> return (Meta doc [])

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -322,11 +322,11 @@ implements = do
   ifName <- (ModuleName . _atomAtom) <$> bareAtom
   info <- contextInfo
   return $ TImplements ifName modName info
-  
+
 interface :: Compile (Term Name)
 interface = do
   iname' <- _atomAtom <$> bareAtom
-  m <- meta
+  m <- metaWithModel
   use (psUser . csModule) >>= \ci -> case ci of
     Just {} -> syntaxError "invalid nested interface or module"
     Nothing -> return ()
@@ -342,14 +342,14 @@ interface = do
   return $ TModule
     (Interface iname code m)
     (abstract (const Nothing) (TList defs TyAny defInfo)) info
-    
+
 interfaceForm :: Compile ([Term Name], Info)
 interfaceForm = (,) <$> some interfaceForms <*> contextInfo
   where
-    interfaceForms = withList' Parens $ do 
+    interfaceForms = withList' Parens $ do
       AtomExp{..} <- bareAtom
       case _atomAtom of
-        "defun" -> commit >> emptyDef 
+        "defun" -> commit >> emptyDef
         "defconst" -> commit >> defconst
         "use" -> commit >> useForm
         t -> syntaxError $ "Invalid interface declaration: " ++ unpack t
@@ -359,13 +359,13 @@ emptyDef = do
   modName <- currentModule'
   (defName, returnTy) <- first _atomAtom <$> typedAtom
   args <- withList' Parens $ many arg
-  m <- meta
+  m <- metaWithModel
   info <- contextInfo
   return $
     TDef defName modName Defun
     (FunType args returnTy) (abstract (const Nothing) (TList [] TyAny info)) m info
-  
-  
+
+
 step :: Compile (Term Name)
 step = do
   cont <- try (TStep <$> (Just <$> term) <*> term) <|>

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -91,7 +91,7 @@ import Pact.Types.Exp
 
 data Meta = Meta
   { _mDocs  :: !(Maybe Text) -- ^ docs
-  , _mModel :: !(Maybe (Exp Info))  -- ^ model
+  , _mModel :: ![Exp Info]   -- ^ model
   } deriving (Eq, Show, Generic)
 instance ToJSON Meta where
   toJSON Meta {..} = object
@@ -226,7 +226,7 @@ instance ToJSON Module where
 -- address _mMeta not having a FromJSON, for now harmless
 instance FromJSON Module where
   parseJSON = withObject "Module" $ \o -> Module <$>
-    o .: "name" <*> o .: "keyset" <*> pure (Meta Nothing Nothing) {- o .:? "meta" -} <*>
+    o .: "name" <*> o .: "keyset" <*> pure (Meta Nothing []) {- o .:? "meta" -} <*>
     o .: "code" <*> o .: "hash" <*> (HS.fromList <$> o .: "blessed")
 
 data ConstVal n =

--- a/tests/Analyze/Translate.hs
+++ b/tests/Analyze/Translate.hs
@@ -233,7 +233,7 @@ toAnalyze ty tm = do
         (Pact.Arg "tm" ty dummyInfo)
         "module"
         (Pact.CVRaw tm)
-        (Meta Nothing Nothing)
+        (Meta Nothing [])
         dummyInfo
       ref = Pact.Ref cnst
   maybeConst <- lift $ Pact.runTC 0 False $ typecheckTopLevel ref

--- a/tests/pact/meta.repl
+++ b/tests/pact/meta.repl
@@ -2,7 +2,7 @@
 
 (module mod 'k
   @doc   "this defines mod"
-  @model (property (do (crazy stuff)))
+  @model [(property (do (crazy stuff)))]
 
   (defun foo ()
     @doc "foo the town"

--- a/tests/pact/signatures.repl
+++ b/tests/pact/signatures.repl
@@ -2,23 +2,23 @@
 
 ; simple interfaces with only defun and defconst
 (interface sig-test1
-  ; simple defuns of varying parameter list sizes, 
+  ; simple defuns of varying parameter list sizes,
   ; typed and untyped
   (defun test1-f1:bool ())
   (defun test1-f2:string (x:bool))
   (defun test1-f3:decimal (x:bool y:string z:decimal))
-  
+
   ; simple defconsts
   (defconst TEST1-C1 0)
   (defconst TEST1-C2 "const 1")
   (defconst TEST1-C3 2.0)
 )
 
-; more complex interface with model properties 
+; more complex interface with model properties
 ; and  docstrings at the module level
 (interface sig-test2
   @doc "this is a docstring for sig-test2"
-  @model (property (do (something)))
+  @model [(property (do (something)))]
 
   (defun test2-f1:decimal (x:bool))
   (defun test2-f2:string ())
@@ -27,21 +27,21 @@
 )
 
 ; most complex interface with model properties
-; defined at module and function level, as well 
+; defined at module and function level, as well
 ; as docstrings in both positions, typed and untyped
 (interface sig-test3
   @doc "this is a docstring for sig-test3"
-  @model (property (do (something)))
+  @model [(property (do (something)))]
 
   (defun test3-f1:bool (x:bool))
   (defun test3-f2:bool (x:decimal y:bool) @doc "i love pact")
   (defun test3-f3:string () "docs work without the doc")
-  (defun test3-f4:decimal () 
-    @model (property (do (subproperty))))
+  (defun test3-f4:decimal ()
+    @model [(property (do (subproperty)))])
 
   ; a full example of what a function may look like
   (defun test3-f5:bool (x:bool y:bool)
-    @model (property (do (subproperty)))
+    @model [(property (do (subproperty)))]
     @doc "example function docstring")
 
   ; typed and inferred variants
@@ -56,7 +56,7 @@
 (module mod-test1 'test-keyset
 
   @doc "my module documentation"
-  @model (property (do (mymodule prop)))
+  @model [(property (do (mymodule prop)))]
 
   ; implement arbitrarily many interfaces
   (implements sig-test1)
@@ -64,17 +64,17 @@
   (implements sig-test3)
 
 
-  (defun test1-f1:bool () 
+  (defun test1-f1:bool ()
     true)
 
-  (defun test1-f2:string (x:bool) 
+  (defun test1-f2:string (x:bool)
     @doc "implementation of test1-f2"
     "forget about x")
 
-  (defun test1-f3:decimal (x: bool y: string z:decimal) 
+  (defun test1-f3:decimal (x: bool y: string z:decimal)
     z)
 
-  (defun test2-f1:decimal (x:bool) 
+  (defun test2-f1:decimal (x:bool)
     2.0)
 
   (defun test2-f2:string ()
@@ -83,26 +83,26 @@
 
   (defun test3-f1:bool (x:bool)
     true)
-  (defun test3-f2:bool (x:decimal y:bool) 
+  (defun test3-f2:bool (x:decimal y:bool)
     @doc "i love pact"
     y)
 
-  (defun test3-f3:string () 
+  (defun test3-f3:string ()
     "docs work without the doc"
     "i love pact twice")
-  (defun test3-f4:decimal () 
-    @model (property (do (subproperty)))
+  (defun test3-f4:decimal ()
+    @model [(property (do (subproperty)))]
     2.0)
 
   ; a full example of what a function may look like
   ; using constants defined in interfaces
   (defun test3-f5:bool (x: bool y: bool)
-    @model (property (do (subproperty)))
+    @model [(property (do (subproperty)))]
     "example function docstring"
     (and x y))
 
   ; access to constants defined in signatures
   ; is allowed via dot-accessor notation.
-  (defun use-consts:integer () 
+  (defun use-consts:integer ()
     (+ sig-test1.TEST1-C1 sig-test3.TEST3-C2))
 )


### PR DESCRIPTION
As requested by Emily to make it easier to monoidally combine Metas when
extending interfaces.

This has the downside of adding a bit of boilerplate (repeated
`property` / `invariant`, list syntax).