### PR TITLE
Fix empty list runtime type enforce bug 

### DIFF
--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -118,6 +118,9 @@
   (defun tc-obj-eq (a:object{account})
     (= a a))
 
+  ;;not tc per se but runtime type enforce error
+  (defun rtc-empty-string-list:[string] (input:[string]) input)
+
 )
 
 (create-table persons)
@@ -138,3 +141,5 @@
 (expect-failure "bad int list" (addToAll 1 [1 2 3 "hi"]))
 
 (typecheck 'tctest)
+
+(rtc-empty-string-list [])


### PR DESCRIPTION
for #221. Note code changed considerably as I needed to doco/reformat to understand the tc code, and found additional cruft: tc was skipping type vars on lists/objects as these would never be found in user defs (not expressible in surface type lang). Bug fix is in `checkList` inner function, optimization on empty list was returning parameterized type, not list type; got rid of optimization (lesson re-learned :\ )