### PR TITLE
[WIP] Verification API

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ rpRef ? "503519c3188a54e02ac82b76fee5b9530a731f9b", rpSha ?  "00b3cjwy6h4pvjvclscwyjkd0p730nwsxbfh9v7f48w05b6bzpi5" }:
+{ rpRef ? "f3ff81d519b226752c83eefd4df6718539c3efdc", rpSha ?  "1ijxfwl36b9b2j4p9j3bv8vf7qfi570m1c5fjyvyac0gy0vi5g8j" }:
 
 let rp = (import <nixpkgs> {}).fetchFromGitHub {
            owner = "reflex-frp";
@@ -14,40 +14,11 @@ in
       let guardGhcjs = p: if self.ghc.isGhcjs or false then null else p;
        in {
             pact = pkgs.haskell.lib.addBuildDepend super.pact pkgs.z3;
-            aeson = self.callHackage "aeson" "1.1.2.0" {};
-            blake2 = guardGhcjs super.blake2;
             haskeline = guardGhcjs super.haskeline;
 
             # Needed to get around a requirement on `hspec-discover`.
             megaparsec = pkgs.haskell.lib.dontCheck super.megaparsec;
 
-            # Needed to build with the below version of statistics
-            criterion = self.callCabal2nix "criterion" (pkgs.fetchFromGitHub {
-              owner = "bos";
-              repo = "criterion";
-              rev = "5a704392b670c189475649c32d05eeca9370d340";
-              sha256 = "1kp0l78l14w0mmva1gs9g30zdfjx4jkl5avl6a3vbww3q50if8pv";
-            }) {};
-
-            # Version 1.6.4, needed by weeder, not in callHackage yet
-            extra = pkgs.haskell.lib.dontCheck (self.callCabal2nix "extra" (pkgs.fetchFromGitHub {
-              owner = "ndmitchell";
-              repo = "extra";
-              rev = "4064bfa7e48a7f1b79f791560d51dbefed879219";
-              sha256 = "1p7rc5m70rkm1ma8gnihfwyxysr0n3wxk8ijhp6qjnqp5zwifhhn";
-            }) {});
-
-            # 1.20.2 not available to callHackage yet
-            haskell-src-exts = self.callCabal2nix "haskell-src-exts" (pkgs.fetchFromGitHub {
-              owner = "haskell-suite";
-              repo = "haskell-src-exts";
-              rev = "4954767e371590ba11ef1edccf904afc9b94f78c";
-              sha256 = "1wy7vqk0w4wx12v803w16dbq64gki7i8xvx7d1ibvlwpw4j4pr8f";
-            }) {};
-            # needed to match haskell-src-exts
-            haskell-src-meta = self.callHackage "haskell-src-meta" "0.8.0.2" {};
-            # needed to match haskell-src-exts
-            haskell-src-exts-util = self.callHackage "haskell-src-exts-util" "0.2.2" {};
             hedgehog = self.callCabal2nix "hedgehog" (pkgs.fetchFromGitHub {
               owner = "hedgehogqa";
               repo = "haskell-hedgehog";
@@ -55,7 +26,7 @@ in
               sha256 = "1z8d3hqrgld1z1fvjd0czksga9lma83caa2fycw0a5gfbs8sh4zh";
             } + "/hedgehog") {};
             hlint = self.callHackage "hlint" "2.0.14" {};
-            hoogle = self.callHackage "hoogle" "5.0.15" {};
+            # hoogle = self.callHackage "hoogle" "5.0.15" {};
 
             # sbv >= 7.9
             sbv = pkgs.haskell.lib.dontCheck (self.callCabal2nix "sbv" (pkgs.fetchFromGitHub {
@@ -63,14 +34,6 @@ in
               repo = "sbv";
               rev = "3dc60340634c82f39f6c5dca2b3859d10925cfdf";
               sha256 = "18xcxg1h19zx6gdzk3dfs87447k3xjqn40raghjz53bg5k8cdc31";
-            }) {});
-
-            # Most recent github commit.  Might also work with 0.14.0.2
-            statistics = pkgs.haskell.lib.dontCheck (self.callCabal2nix "statistics" (pkgs.fetchFromGitHub {
-              owner = "bos";
-              repo = "statistics";
-              rev = "1ed1f2844c5a2209f5ea72e60df7d14d3bb7ac1a";
-              sha256 = "1jjmdhfn198pfl3k5c4826xddskqkfsxyw6l5nmwrc8ibhhnxl7p";
             }) {});
 
             # Our own custom fork
@@ -95,26 +58,19 @@ in
            ["result" "dist" "dist-ghcjs" ".git" ".stack-work"]))
         ./.;
 
-      algebraic-graphs = pkgs.fetchFromGitHub {
-        owner = "snowleopard";
-        repo = "alga";
-        rev = "1c04f5664b9476e0b01a573b40462531e52e8756";
-        sha256 = "0j121551zqjrp4xy0qcz1pk46znr6w59jkg75v5svdh9ag3vmbsp";
-      };
+      # megaparsec = pkgs.fetchFromGitHub {
+      #   owner  = "mrkkrp";
+      #   repo   = "megaparsec";
+      #   rev    = "7b271a5edc1af59fa435a705349310cfdeaaa7e9";
+      #   sha256 = "0415z18gl8dgms57rxzp870dpz7rcqvy008wrw5r22xw8qq0s13c";
+      # };
 
-      megaparsec = pkgs.fetchFromGitHub {
-        owner  = "mrkkrp";
-        repo   = "megaparsec";
-        rev    = "7b271a5edc1af59fa435a705349310cfdeaaa7e9";
-        sha256 = "0415z18gl8dgms57rxzp870dpz7rcqvy008wrw5r22xw8qq0s13c";
-      };
-
-      parser-combinators = pkgs.fetchFromGitHub {
-        owner  = "mrkkrp";
-        repo   = "parser-combinators";
-        rev    = "dd6599224fe7eb224477ef8e9269602fb6b79fe0";
-        sha256 = "11cpfzlb6vl0r5i7vbhp147cfxds248fm5xq8pwxk92d1f5g9pxm";
-      };
+      # parser-combinators = pkgs.fetchFromGitHub {
+      #   owner  = "mrkkrp";
+      #   repo   = "parser-combinators";
+      #   rev    = "dd6599224fe7eb224477ef8e9269602fb6b79fe0";
+      #   sha256 = "11cpfzlb6vl0r5i7vbhp147cfxds248fm5xq8pwxk92d1f5g9pxm";
+      # };
     };
     shellToolOverrides = ghc: super: {
       z3 = pkgs.z3;

--- a/default.nix
+++ b/default.nix
@@ -57,20 +57,6 @@ in
         (path: type: !(builtins.elem (baseNameOf path)
            ["result" "dist" "dist-ghcjs" ".git" ".stack-work"]))
         ./.;
-
-      # megaparsec = pkgs.fetchFromGitHub {
-      #   owner  = "mrkkrp";
-      #   repo   = "megaparsec";
-      #   rev    = "7b271a5edc1af59fa435a705349310cfdeaaa7e9";
-      #   sha256 = "0415z18gl8dgms57rxzp870dpz7rcqvy008wrw5r22xw8qq0s13c";
-      # };
-
-      # parser-combinators = pkgs.fetchFromGitHub {
-      #   owner  = "mrkkrp";
-      #   repo   = "parser-combinators";
-      #   rev    = "dd6599224fe7eb224477ef8e9269602fb6b79fe0";
-      #   sha256 = "11cpfzlb6vl0r5i7vbhp147cfxds248fm5xq8pwxk92d1f5g9pxm";
-      # };
     };
     shellToolOverrides = ghc: super: {
       z3 = pkgs.z3;

--- a/default.nix
+++ b/default.nix
@@ -16,6 +16,21 @@ in
             pact = pkgs.haskell.lib.addBuildDepend super.pact pkgs.z3;
             haskeline = guardGhcjs super.haskeline;
 
+            # tests for extra were failing due to an import clash (`isWindows`)
+            extra = pkgs.haskell.lib.dontCheck super.extra;
+            # tests try to use ghc-pkg and cabal (https://github.com/sol/doctest/issues/213)
+            doctest = guardGhcjs (pkgs.haskell.lib.dontCheck (self.callHackage "doctest" "0.16.0" {}));
+            # these want to use doctest, which doesn't work on ghcjs
+            bytes = pkgs.haskell.lib.dontCheck super.bytes;
+            intervals = pkgs.haskell.lib.dontCheck super.intervals;
+            bound = pkgs.haskell.lib.dontCheck super.bound;
+            trifecta = pkgs.haskell.lib.dontCheck super.trifecta;
+            lens-aeson = pkgs.haskell.lib.dontCheck super.lens-aeson;
+            # test suite for this is failing on ghcjs:
+            hw-hspec-hedgehog = pkgs.haskell.lib.dontCheck super.hw-hspec-hedgehog;
+
+            algebraic-graphs = guardGhcjs super.algebraic-graphs;
+
             ghcjs-dom = self.callHackage "ghcjs-dom" "0.9.2.0" {};
 
             # Needed to get around a requirement on `hspec-discover`.

--- a/default.nix
+++ b/default.nix
@@ -29,7 +29,7 @@ in
             # test suite for this is failing on ghcjs:
             hw-hspec-hedgehog = pkgs.haskell.lib.dontCheck super.hw-hspec-hedgehog;
 
-            algebraic-graphs = guardGhcjs super.algebraic-graphs;
+            algebraic-graphs = pkgs.haskell.lib.dontCheck super.algebraic-graphs;
 
             ghcjs-dom = self.callHackage "ghcjs-dom" "0.9.2.0" {};
 

--- a/default.nix
+++ b/default.nix
@@ -16,6 +16,8 @@ in
             pact = pkgs.haskell.lib.addBuildDepend super.pact pkgs.z3;
             haskeline = guardGhcjs super.haskeline;
 
+            ghcjs-dom = self.callHackage "ghcjs-dom" "0.9.2.0" {};
+
             # Needed to get around a requirement on `hspec-discover`.
             megaparsec = pkgs.haskell.lib.dontCheck super.megaparsec;
 
@@ -64,7 +66,7 @@ in
     };
     shells = {
       ghc = ["pact"];
-      # ghcjs = ["pact"];
+      ghcjs = ["pact"];
     };
 
   })

--- a/pact.cabal
+++ b/pact.cabal
@@ -19,7 +19,8 @@ cabal-version:       >=1.22
 
 library
 
-  exposed-modules:     Pact.Compile
+  exposed-modules:     Pact.Analyze.Remote.Types
+                     , Pact.Compile
                      , Pact.Eval
                      , Pact.Gas
                      , Pact.Native
@@ -54,6 +55,12 @@ library
                      , Crypto.Hash.Blake2Native
                      , Pact.Types.Typecheck
                      , Pact.Typechecker
+
+  if impl(ghcjs)
+    exposed-modules:
+      JavaScript.Web.XMLHttpRequest
+      Pact.Analyze.Remote.Client
+
   if !impl(ghcjs)
     hs-source-dirs: src-ghc
     exposed-modules:
@@ -88,6 +95,7 @@ library
       Pact.Analyze.Types.Shared
       Pact.Analyze.Types.UserShow
       Pact.Analyze.Util
+      Pact.Analyze.Remote.Server
       Pact.ApiReq
       Pact.Bench
       Pact.Docgen
@@ -151,6 +159,11 @@ library
                      , vector >= 0.11.0.0 && < 0.13
                      , vector-space >= 0.10.4 && < 0.14
                      , mmorph >= 1.1 && < 1.2
+
+  if impl(ghcjs)
+    build-depends:
+      ghcjs-base,
+      ghcjs-prim
 
   if !impl(ghcjs)
     build-depends:
@@ -237,9 +250,11 @@ test-suite hspec
       , crypto-api
       , http-client
       , wreq
+      , snap-server
   other-modules:
                 Blake2Spec
                 KeysetSpec
+                RemoteVerifySpec
                 TypesSpec
                 HashSpec
   if !impl(ghcjs)

--- a/pact.cabal
+++ b/pact.cabal
@@ -113,7 +113,7 @@ library
 
   build-depends:       Decimal >= 0.4.2 && < 0.6
                      , aeson >= 0.11.3.0 && < 1.4
-                     , algebraic-graphs >= 0.1.1 && < 0.2
+                     , algebraic-graphs >= 0.2 && < 0.3
                      , ansi-wl-pprint >= 0.6.7.3 && < 0.7
                      , attoparsec >= 0.13.0.2 && < 0.14
                      , base >=4.9.0.0 && < 4.12
@@ -145,12 +145,12 @@ library
                      -- kadena ghcjs compat fork
                      , thyme == 0.3.6.0
                      , transformers >= 0.5.2.0 && < 0.6
-                     , trifecta >= 1.6 && < 1.8
+                     , trifecta >= 2 && < 2.1
                      , unordered-containers >= 0.2.7.2 && < 0.3
                      , utf8-string >= 1.0.1.1 && < 1.1
                      , vector >= 0.11.0.0 && < 0.13
                      , vector-space >= 0.10.4 && < 0.14
-                     , mmorph >= 1.0 && < 1.1
+                     , mmorph >= 1.1 && < 1.2
 
   if !impl(ghcjs)
     build-depends:

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -96,7 +96,7 @@ benchRead KeySets _ = rc (Just benchKeySet)
 benchRead UserTables {} _ = rc (Just acctRow)
 benchRead _ _ = rc Nothing
 
-benchReadValue :: (PactKey k, PactValue v) => Table k -> k -> Persist () (Maybe v)
+benchReadValue :: Table k -> k -> Persist () (Maybe v)
 benchReadValue (DataTable t) _k
   | t == "SYS_keysets" = rcp $ Just (unsafeCoerce benchKeySet)
   | t == "USER_bench_bench-accounts" = rcp $ Just (unsafeCoerce acctRow)

--- a/src-ghc/Pact/Main.hs
+++ b/src-ghc/Pact/Main.hs
@@ -31,7 +31,7 @@ import Text.Trifecta as TF hiding (err)
 import System.IO
 import System.Exit hiding (die)
 import qualified Options.Applicative as O
-import Data.Monoid
+import Data.Monoid ()
 import System.Directory
 import System.FilePath
 

--- a/src-ghc/Pact/Main.hs
+++ b/src-ghc/Pact/Main.hs
@@ -31,7 +31,7 @@ import Text.Trifecta as TF hiding (err)
 import System.IO
 import System.Exit hiding (die)
 import qualified Options.Applicative as O
-import Data.Monoid ()
+import Data.Monoid ((<>))
 import System.Directory
 import System.FilePath
 

--- a/src-ghc/Pact/PersistPactDb/Regression.hs
+++ b/src-ghc/Pact/PersistPactDb/Regression.hs
@@ -44,7 +44,7 @@ runRegression p = do
   let mod' = Module "mod1" "mod-admin-keyset" (Meta Nothing Nothing) "code" (H.hash "code") mempty
   _writeRow pactdb Write Modules "mod1" mod' v
   assertEquals' "module write" (Just mod') $ _readRow pactdb Modules "mod1" v
-  assertEquals' "hash of commit 3" (-8810669039792530227) (hashWithSalt 1 <$> commit v)
+  assertEquals' "hash of commit 3" (314509247989860983) (hashWithSalt 1 <$> commit v)
   _t4 <- begin v t3
   tids <- _txids pactdb user1 t1 v
   assertEquals "user txids" [2] tids

--- a/src-ghc/Pact/ReplTools.hs
+++ b/src-ghc/Pact/ReplTools.hs
@@ -21,7 +21,7 @@ import System.Console.Haskeline
   (runInputT, withInterrupt, InputT, getInputLine, handleInterrupt,
    CompletionFunc, completeQuotedWord, completeWord, listFiles,
    filenameWordBreakChars, Settings(Settings), simpleCompletion)
-import Data.Monoid ()
+import Data.Monoid ((<>))
 
 import Pact.Parse
 import Pact.Types.Runtime

--- a/src-ghc/Pact/ReplTools.hs
+++ b/src-ghc/Pact/ReplTools.hs
@@ -21,7 +21,7 @@ import System.Console.Haskeline
   (runInputT, withInterrupt, InputT, getInputLine, handleInterrupt,
    CompletionFunc, completeQuotedWord, completeWord, listFiles,
    filenameWordBreakChars, Settings(Settings), simpleCompletion)
-import Data.Monoid
+import Data.Monoid ()
 
 import Pact.Parse
 import Pact.Types.Runtime

--- a/src-ghc/Pact/Server/Server.hs
+++ b/src-ghc/Pact/Server/Server.hs
@@ -29,7 +29,7 @@ import qualified Data.ByteString.Char8 as B8
 
 import qualified Data.HashMap.Strict as HashMap
 
-import Data.Monoid
+import Data.Monoid ()
 import Data.Word (Word16)
 import GHC.Generics
 import System.Log.FastLogger

--- a/src-ghc/Pact/Server/Server.hs
+++ b/src-ghc/Pact/Server/Server.hs
@@ -29,7 +29,7 @@ import qualified Data.ByteString.Char8 as B8
 
 import qualified Data.HashMap.Strict as HashMap
 
-import Data.Monoid ()
+import Data.Monoid ((<>))
 import Data.Word (Word16)
 import GHC.Generics
 import System.Log.FastLogger

--- a/src/Crypto/Hash/Blake2Native.hs
+++ b/src/Crypto/Hash/Blake2Native.hs
@@ -18,7 +18,7 @@ import Data.ByteString as B (ByteString,index,unpack,pack,length,take,splitAt,nu
 import Data.Vector as V (Vector,(//),(!),fromList,(++))
 import Control.Lens ((&),(<&>))
 import Prelude as P hiding (last)
-import Data.Monoid
+import Data.Monoid ()
 
 
 type V = Vector

--- a/src/Crypto/Hash/Blake2Native.hs
+++ b/src/Crypto/Hash/Blake2Native.hs
@@ -18,7 +18,7 @@ import Data.ByteString as B (ByteString,index,unpack,pack,length,take,splitAt,nu
 import Data.Vector as V (Vector,(//),(!),fromList,(++))
 import Control.Lens ((&),(<&>))
 import Prelude as P hiding (last)
-import Data.Monoid ()
+import Data.Monoid ((<>))
 
 
 type V = Vector

--- a/src/JavaScript/Web/XMLHttpRequest.hs
+++ b/src/JavaScript/Web/XMLHttpRequest.hs
@@ -1,0 +1,202 @@
+{-# LANGUAGE RankNTypes, OverloadedStrings, DeriveDataTypeable,
+             ForeignFunctionInterface, JavaScriptFFI, EmptyDataDecls,
+             TypeFamilies, DataKinds, ScopedTypeVariables,
+             FlexibleContexts, FlexibleInstances, TypeSynonymInstances,
+             LambdaCase, MultiParamTypeClasses, DeriveGeneric #-}
+
+-- | This is heavily adapted from
+-- https://raw.githubusercontent.com/ghcjs/ghcjs-base/01014ade3f8f5ae677df192d7c2a208bd795b96c/JavaScript/Web/XMLHttpRequest.hs
+-- because reflex-platform uses a patch to omit this module (to avoid a
+-- circular dependency related to @text@). We had to drop support for
+-- non-String/Text types because of lack of access to internal modules of
+-- ghcjs-base.
+module JavaScript.Web.XMLHttpRequest ( xhr
+                                     , xhrText
+                                     , xhrString
+                                     , Method(..)
+                                     , Request(..)
+                                     , RequestData(..)
+                                     , Response(..)
+                                     , ResponseType(..)
+                                     , FormDataVal(..)
+                                     , XHRError(..)
+                                     ) where
+
+import Control.Exception
+import Control.Monad
+
+import GHCJS.Types
+import GHCJS.Marshal.Pure
+
+import GHC.Generics
+
+import Data.Data
+import Data.Text (Text)
+
+import           Data.JSString.Text (textFromJSString)
+import qualified Data.JSString as JSS
+
+import Unsafe.Coerce (unsafeCoerce)
+
+data Method = GET | POST | PUT | DELETE
+  deriving (Show, Eq, Ord, Enum)
+
+data XHRError = XHRError String
+              | XHRAborted
+              deriving (Generic, Data, Typeable, Show, Eq)
+
+instance Exception XHRError
+
+methodJSString :: Method -> JSString
+methodJSString GET    = "GET"
+methodJSString POST   = "POST"
+methodJSString PUT    = "PUT"
+methodJSString DELETE = "DELETE"
+
+type Header = (JSString, JSString)
+
+data FormDataVal = StringVal JSString
+  deriving (Typeable)
+
+data Request = Request { reqMethod          :: Method
+                       , reqURI             :: JSString
+                       , reqLogin           :: Maybe (JSString, JSString)
+                       , reqHeaders         :: [Header]
+                       , reqWithCredentials :: Bool
+                       , reqData            :: RequestData
+                       }
+  deriving (Typeable)
+
+data RequestData = NoData
+                 | StringData     JSString
+  deriving (Typeable)
+
+data Response a = Response { contents              :: Maybe a
+                           , status                :: Int
+                           , getAllResponseHeaders :: IO JSString
+                           , getResponseHeader     :: JSString -> IO (Maybe JSString)
+                           }
+
+instance Functor Response where fmap f r = r { contents = fmap f (contents r) }
+
+class ResponseType a where
+    getResponseTypeString :: Proxy a  -> JSString
+    wrapResponseType      :: JSVal -> a
+
+instance ResponseType JSString where
+  getResponseTypeString _ = "text"
+  wrapResponseType        = unsafeCoerce -- newtype-wrapped JSVal
+
+newtype XHR = XHR JSVal deriving (Typeable)
+
+-- -----------------------------------------------------------------------------
+-- main entry point
+
+xhr :: forall a. ResponseType a => Request -> IO (Response a)
+xhr req = js_createXHR >>= \x ->
+  let doRequest = do
+        case reqLogin req of
+          Nothing           ->
+            js_open2 (methodJSString (reqMethod req)) (reqURI req) x
+          Just (user, pass) ->
+            js_open4 (methodJSString (reqMethod req)) (reqURI req) user pass x
+        --
+        -- TODO: override this so that JS doesn't automatically deserialize
+        -- the JSON -- we'll use Aeson instead:
+        --
+        js_overrideMimeType "text/plain" x
+        js_setResponseType
+          (getResponseTypeString (Proxy :: Proxy a)) x
+        forM_ (reqHeaders req) (\(n,v) -> js_setRequestHeader n v x)
+
+        case reqWithCredentials req of
+          True  -> js_setWithCredentials x
+          False -> return ()
+
+        r <- case reqData req of
+          NoData                            ->
+            js_send0 x
+          StringData str                    ->
+            js_send1 (pToJSVal str) x
+        case r of
+          0 -> do
+            status' <- js_getStatus x
+            r'      <- do
+              hr <- js_hasResponse x
+              if hr then Just . wrapResponseType <$> js_getResponse x
+                    else pure Nothing
+            return $ Response r'
+                              status'
+                              (js_getAllResponseHeaders x)
+                              (\h -> getResponseHeader' h x)
+          1 -> throwIO XHRAborted
+          2 -> throwIO (XHRError "network request error")
+          _ -> throwIO (XHRError "network request error")
+  in doRequest `onException` js_abort x
+
+getResponseHeader' :: JSString -> XHR -> IO (Maybe JSString)
+getResponseHeader' name x = do
+  h <- js_getResponseHeader name x
+  return $ if isNull h then Nothing else Just (wrapResponseType h)
+
+-- -----------------------------------------------------------------------------
+-- utilities
+
+xhrString :: Request -> IO (Response String)
+xhrString = fmap (fmap JSS.unpack) . xhr
+
+xhrText :: Request -> IO (Response Text)
+xhrText = fmap (fmap textFromJSString) . xhr
+
+-- -----------------------------------------------------------------------------
+
+foreign import javascript unsafe
+  "$1.withCredentials = true;"
+  js_setWithCredentials :: XHR -> IO ()
+
+foreign import javascript unsafe
+  "new XMLHttpRequest()"
+  js_createXHR :: IO XHR
+foreign import javascript unsafe
+  "$2.responseType = $1;"
+  js_setResponseType :: JSString -> XHR -> IO ()
+foreign import javascript unsafe
+  "$1.abort();"
+  js_abort :: XHR -> IO ()
+foreign import javascript unsafe
+  "$3.setRequestHeader($1,$2);"
+  js_setRequestHeader :: JSString -> JSString -> XHR -> IO ()
+foreign import javascript unsafe
+  "$3.open($1,$2)"
+  js_open2 :: JSString -> JSString -> XHR -> IO ()
+foreign import javascript unsafe
+  "$5.open($1,$2,true,$4,$5);"
+  js_open4 :: JSString -> JSString -> JSString -> JSString -> XHR -> IO ()
+foreign import javascript unsafe
+  "$1.status"
+  js_getStatus :: XHR -> IO Int
+foreign import javascript unsafe
+  "$1.response"
+  js_getResponse :: XHR -> IO JSVal
+foreign import javascript unsafe
+  "$1.response ? true : false"
+  js_hasResponse :: XHR -> IO Bool
+foreign import javascript unsafe
+  "$1.getAllResponseHeaders()"
+  js_getAllResponseHeaders :: XHR -> IO JSString
+foreign import javascript unsafe
+  "$2.getResponseHeader($1)"
+  js_getResponseHeader :: JSString -> XHR -> IO JSVal
+foreign import javascript unsafe
+  "$2.overrideMimeType($1)"
+  js_overrideMimeType :: JSString -> XHR -> IO ()
+
+-- -----------------------------------------------------------------------------
+
+foreign import javascript interruptible
+  "h$sendXHR($1, null, $c);"
+  js_send0 :: XHR -> IO Int
+foreign import javascript interruptible
+  "h$sendXHR($2, $1, $c);"
+  js_send1 :: JSVal -> XHR -> IO Int
+

--- a/src/Pact/Analyze/Errors.hs
+++ b/src/Pact/Analyze/Errors.hs
@@ -3,7 +3,7 @@
 module Pact.Analyze.Errors where
 
 import qualified Data.SBV.Internals     as SBVI
-import           Data.Semigroup         ()
+import           Data.Semigroup         ((<>))
 import           Data.String            (IsString (fromString))
 import           Data.Text              (Text)
 import qualified Data.Text              as T

--- a/src/Pact/Analyze/Errors.hs
+++ b/src/Pact/Analyze/Errors.hs
@@ -3,7 +3,7 @@
 module Pact.Analyze.Errors where
 
 import qualified Data.SBV.Internals     as SBVI
-import           Data.Semigroup
+import           Data.Semigroup         ()
 import           Data.String            (IsString (fromString))
 import           Data.Text              (Text)
 import qualified Data.Text              as T

--- a/src/Pact/Analyze/Eval/Prop.hs
+++ b/src/Pact/Analyze/Eval/Prop.hs
@@ -147,7 +147,7 @@ evalPropO (PropSpecific (PropRead ba (Schema fields) tn pRk)) = do
 
   pure $ Object aValFields
 
-evalPropSpecific :: SymWord a => PropSpecific a -> Query (S a)
+evalPropSpecific :: PropSpecific a -> Query (S a)
 evalPropSpecific Success = view $ qeAnalyzeState.succeeds
 evalPropSpecific Abort   = bnot <$> evalPropSpecific Success
 evalPropSpecific Result  = expectVal =<< view qeAnalyzeResult

--- a/src/Pact/Analyze/Remote/Client.hs
+++ b/src/Pact/Analyze/Remote/Client.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Pact.Analyze.Remote.Client
+  ( verifyModule
+  ) where
+
+import qualified Control.Exception             as C
+import           Control.Monad.IO.Class        (liftIO)
+import qualified Data.Aeson                    as A
+import qualified Data.Foldable                 as Foldable
+import qualified Data.HashMap.Strict           as HM
+import qualified Data.JSString                 as JS
+import qualified Data.JSString.Text            as JS
+import           Data.Monoid                   ((<>))
+import           Data.Text                     (Text)
+import qualified Data.Text.Lazy                as LT
+import qualified Data.Text.Lazy.Encoding       as LTE
+
+import qualified JavaScript.Web.XMLHttpRequest as XHR
+
+import qualified Pact.Analyze.Remote.Types as Remote
+import           Pact.Types.Exp            (ModuleName)
+import           Pact.Types.Runtime        (ModuleData)
+import           Pact.Types.Term           (Module(_mName))
+import           Pact.Types.Util           (tShow)
+
+verifyModule
+  :: HM.HashMap ModuleName ModuleData -- ^ all loaded modules
+  -> ModuleData                       -- ^ the module we're verifying
+  -> String
+  -> Int
+  -> IO [Text]
+verifyModule namedMods mod' host port = do
+  let requestURI = "http://" ++ host ++ ":" ++ show port ++ "/verify"
+      body       = Remote.Request (Foldable.toList $ fmap fst namedMods) (_mName $ fst mod')
+      jsonBody   = JS.lazyTextToJSString $ LTE.decodeUtf8 $ A.encode body
+  eResponse <- liftIO (C.try $ post requestURI jsonBody :: IO (Either XHR.XHRError (XHR.Response Text)))
+  return $ case eResponse of
+    Left s       -> ["error communicating with verification server: " <> tShow s]
+    Right result -> case XHR.contents result of
+      Nothing  -> ["no response from verification server"]
+      Just txt -> case A.decode $ LTE.encodeUtf8 $ LT.fromStrict txt of
+        Nothing -> ["error parsing result from verification server: " <> txt]
+        Just (Remote.Response outputLines) -> outputLines
+
+  where
+    post requestURI body = XHR.xhrText $ XHR.Request
+      { XHR.reqMethod          = XHR.POST
+      , XHR.reqURI             = JS.pack requestURI
+      , XHR.reqLogin           = Nothing
+      , XHR.reqHeaders         = []
+      , XHR.reqWithCredentials = False
+      , XHR.reqData            = XHR.StringData body
+      }

--- a/src/Pact/Analyze/Remote/Server.hs
+++ b/src/Pact/Analyze/Remote/Server.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Rank2Types        #-}
+
+-- | HTTP Server for GHCJS to use verification from the browser (where we can't
+-- run sbv).
+module Pact.Analyze.Remote.Server
+  ( runServer
+  , v1App
+  ) where
+
+import           Control.Lens               ((^.), (.~), (&))
+import           Control.Monad              (void)
+import           Control.Monad.Except       (ExceptT(..), runExceptT)
+import           Control.Monad.State.Strict (StateT(..))
+import           Control.Monad.IO.Class     (liftIO)
+import qualified Data.Aeson                 as A
+import           Data.Bifunctor             (first)
+import           Data.Default               (def)
+import           Data.Foldable              (traverse_)
+import qualified Data.HashMap.Strict        as HM
+import           Data.Monoid                ((<>))
+import           Data.String                (IsString)
+import qualified Data.Text                  as T
+import           Data.Void                  (Void)
+import           Snap.Core                  (Snap)
+import qualified Snap.Core                  as Snap
+import qualified Snap.Http.Server           as Snap
+import qualified Text.Megaparsec            as MP
+import qualified Text.Megaparsec.Char       as MP
+
+import qualified Pact.Analyze.Check        as Check
+import           Pact.Analyze.Remote.Types (Request(..), Response(..),
+                                            ClientError(..))
+import           Pact.Repl                 (initReplState, evalRepl')
+import           Pact.Repl.Types           (LibState, ReplMode(StringEval),
+                                            ReplState, rEnv)
+import           Pact.Types.Exp            (ModuleName(..), Name(..))
+import           Pact.Types.Info           (Code(_unCode))
+import           Pact.Types.Runtime        (Domain(KeySets), Method,
+                                            ModuleData, PactDb(_readRow),
+                                            eePactDb, eeRefStore, rsModules)
+import           Pact.Types.Term           (Module(_mName, _mCode), KeySet(..))
+
+-- | Convenience function for launching a verification server.
+runServer :: Snap.Config Snap a -> IO ()
+runServer cfg = Snap.httpServe cfg v1App
+
+-- | A Snap verification app for mounting in another app, or to be served.
+v1App :: Snap ()
+v1App = Snap.route
+  [ ("verify", Snap.method Snap.POST verify)
+  ]
+
+-- | This method only returns a 4xx client error when the request can't be
+-- validated. If we can produce a 'ValidRequest' then we will return with a
+-- 200, containing the message that should be displayed in the client's REPL,
+-- whether verification actually ends up succeeding or not.
+verify :: Snap ()
+verify = do
+  eValidReq <- validateRequest
+
+  case eValidReq of
+    Left clientErr -> do
+      Snap.modifyResponse $ Snap.setResponseCode 400
+      Snap.modifyResponse $ Snap.setHeader "Content-Type" "application/json"
+      Snap.writeLBS $ A.encode clientErr
+
+    Right validReq -> do
+      outputLines <- liftIO $ runVerification validReq
+      Snap.modifyResponse $ Snap.setResponseCode 200
+      Snap.modifyResponse $ Snap.setHeader "Content-Type" "application/json"
+      Snap.writeLBS $ A.encode outputLines
+
+data ValidRequest
+  = ValidRequest (HM.HashMap ModuleName ModuleData) ModuleData
+
+validateRequest :: Snap (Either ClientError ValidRequest)
+validateRequest = do
+  payload <- Snap.readRequestBody $ 1024 * 1024 -- max 1MiB
+  runExceptT $ do
+    Request mods modName <- ExceptT $ pure $
+      first ClientError $ A.eitherDecode payload
+
+    modsMap <- ExceptT $ liftIO $ loadModules mods
+    ExceptT $ pure $
+      case HM.lookup modName modsMap of
+        Just mod' -> Right $ ValidRequest modsMap mod'
+        Nothing   -> Left $ ClientError $
+          case modName of
+            ModuleName nm ->
+              let names = HM.keys modsMap
+              in show nm ++ " not found in list of provided modules: "
+                   ++ show names
+
+initializeRepl :: IO ReplState
+initializeRepl = do
+  rs <- initReplState StringEval
+  let dbImpl = rs ^. rEnv . eePactDb
+      dummyKeySet = KeySet [] (Name "keys-all" def)
+
+      -- Stub out all keyset accesses to return a dummy value. We don't care
+      -- about real keys because we're not going to be doing any concrete
+      -- execution.
+      _readRow' :: forall k v. (IsString k, A.FromJSON v)
+                => Domain k v
+                -> k
+                -> Method LibState (Maybe v)
+      _readRow' KeySets _k  = const $ pure $ pure dummyKeySet
+      _readRow' domain  key = _readRow dbImpl domain key
+
+  pure $ rs & rEnv . eePactDb .~ dbImpl { _readRow = _readRow' }
+
+replStateModules :: ReplState -> HM.HashMap ModuleName ModuleData
+replStateModules replState = replState ^. rEnv . eeRefStore . rsModules
+
+-- | Parser for strings like: @<interactive>:2:2: Module "mod2" not found@
+moduleNotFoundP :: MP.Parsec Void String ModuleName
+moduleNotFoundP = MP.string "<interactive>:"
+               *> digitsP *> MP.char ':'
+               *> digitsP *> MP.char ':'
+               *> MP.string " Module \""
+               *> fmap (ModuleName . T.pack) (MP.some $ MP.notChar '"')
+               <* MP.string "\" not found"
+  where
+    digitsP :: MP.Parsec Void String ()
+    digitsP = void $ MP.some MP.digitChar
+
+loadModules
+  :: [Module]
+  -> IO (Either ClientError (HM.HashMap ModuleName ModuleData))
+loadModules mods0 = do
+  let -- - try to load the remaining list of modules
+      -- - when we hit a failure, see whether it's because we need to load a
+      --   certain dependency
+      -- - try to move that dependency to the front of the list of modules that
+      --   still need to be loaded
+      -- - try again. if we have promoted more times than we have modules left,
+      --   we've encountered a cycle and exit.
+      go mods replState promotionsSinceLastSuccess = do
+        (eSuccess, replState') <-
+          runStateT (runExceptT (traverse_ loadModule mods)) replState
+        case eSuccess of
+          Left msg ->
+            if promotionsSinceLastSuccess >= length mods
+            then pure $ Left $ ClientError "detected cycle in modules"
+            else
+              case MP.parseMaybe moduleNotFoundP msg of
+                Nothing       -> pure $ Left $ ClientError msg
+                Just depName -> do
+                  let numLoaded = HM.size (replStateModules replState')
+                                - HM.size (replStateModules replState)
+                  case promoteBy ((== depName) . _mName) (drop numLoaded mods) of
+                    Nothing    -> pure $ Left $ ClientError msg
+                    Just mods' -> do
+                      let promos' = if numLoaded > 0 then 0 else succ promotionsSinceLastSuccess
+                      go mods' replState' promos'
+
+          Right () ->
+            pure $ Right $ replStateModules replState'
+
+  replState0 <- initializeRepl
+  go mods0 replState0 0
+
+  where
+    -- Promotes a value to the front of the list if it passes a test.
+    promoteBy :: (a -> Bool) -> [a] -> Maybe [a]
+    promoteBy isNeedle haystack = case break isNeedle haystack of
+      (_others, [])             -> Nothing
+      (others, found : others') -> Just $ found : (others ++ others')
+
+    loadModule :: Module -> ExceptT String (StateT ReplState IO) ()
+    loadModule = void
+               . ExceptT
+               . evalRepl'
+               . T.unpack
+               . (\code -> "(begin-tx)" <> code <> "(commit-tx)")
+               . _unCode
+               . _mCode
+
+runVerification :: ValidRequest -> IO Response
+runVerification (ValidRequest modsMap mod') =
+  Response . Check.renderVerifiedModule <$> Check.verifyModule modsMap mod'

--- a/src/Pact/Analyze/Remote/Types.hs
+++ b/src/Pact/Analyze/Remote/Types.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Pact.Analyze.Remote.Types where
+
+import           Control.Lens       (makeLenses)
+import qualified Data.Aeson         as A
+import           Data.Text          (Text)
+
+import           Pact.Types.Exp     (ModuleName)
+import           Pact.Types.Term    (Module)
+
+data Request
+  = Request [Module] ModuleName -- ^ verify one of the modules, by name
+
+instance A.FromJSON Request where
+  parseJSON = A.withObject "Request" $ \o ->
+    Request <$> o A..: "modules"
+            <*> o A..: "verify"
+
+instance A.ToJSON Request where
+  toJSON (Request mods modName) = A.object
+    [ "modules" A..= mods
+    , "verify"  A..= modName
+    ]
+
+newtype Response
+  = Response
+    { _responseLines :: [Text] -- ^ REPL output from the server, whether
+                               -- verification has failed or succeeded.
+    }
+
+instance A.FromJSON Response where
+  parseJSON = A.withObject "Response" $ \o ->
+    Response <$> o A..: "output"
+
+instance A.ToJSON Response where
+  toJSON (Response outputLines) = A.object
+    [ "output" A..= outputLines
+    ]
+
+newtype ClientError
+  = ClientError String
+  deriving Show
+
+instance A.FromJSON ClientError where
+  parseJSON = A.withObject "ClientError" $ \o ->
+    ClientError <$> o A..: "error"
+
+instance A.ToJSON ClientError where
+  toJSON (ClientError err) = A.object
+    ["error" A..= err
+    ]
+
+makeLenses ''Response

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -24,7 +24,7 @@ import           Control.Monad.Reader         (MonadReader)
 import           Data.Map.Strict              (Map)
 import qualified Data.Map.Strict              as Map
 import           Data.Maybe                   (mapMaybe)
-import           Data.Semigroup               ((<>))
+import           Data.Semigroup               (Semigroup((<>)))
 import           Data.SBV                     (Boolean (bnot, true, (&&&)),
                                                HasKind, Mergeable, SBV, SBool,
                                                SymArray (readArray, writeArray),

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -24,7 +24,7 @@ import           Control.Monad.Reader         (MonadReader)
 import           Data.Map.Strict              (Map)
 import qualified Data.Map.Strict              as Map
 import           Data.Maybe                   (mapMaybe)
-import           Data.Monoid                  ((<>))
+import           Data.Semigroup               ((<>))
 import           Data.SBV                     (Boolean (bnot, true, (&&&)),
                                                HasKind, Mergeable, SBV, SBool,
                                                SymArray (readArray, writeArray),
@@ -139,6 +139,9 @@ newtype Constraints
 
 instance Show Constraints where
   show _ = "<symbolic>"
+
+instance Semigroup Constraints where
+  (Constraints act1) <> (Constraints act2) = Constraints $ act1 *> act2
 
 instance Monoid Constraints where
   mempty = Constraints (pure ())

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -30,6 +30,7 @@ import           Data.Function                (on)
 import           Data.List                    (sortBy)
 import           Data.Map.Strict              (Map)
 import qualified Data.Map.Strict              as Map
+import           Data.Monoid                  (Monoid(..))
 import           Data.SBV                     (Boolean (bnot, false, true, (&&&), (|||)),
                                                EqSymbolic, HasKind, Int64,
                                                Kind (KString, KUnbounded),
@@ -45,7 +46,7 @@ import           Data.SBV                     (Boolean (bnot, false, true, (&&&)
 import           Data.SBV.Control             (SMTValue (..))
 import qualified Data.SBV.Internals           as SBVI
 import qualified Data.SBV.String              as SBV
-import           Data.Semigroup               ((<>))
+import           Data.Semigroup               (Semigroup(..))
 import qualified Data.Set                     as Set
 import           Data.String                  (IsString (..))
 import           Data.Text                    (Text)

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -399,7 +399,7 @@ type TVal = (EType, AVal)
 
 newtype Object
   = Object (Map Text TVal)
-  deriving (Eq, Show)
+  deriving (Eq, Show, Semigroup)
 
 instance UserShow Object where
   userShowsPrec d (Object m) = userShowsPrec d (fmap snd m)
@@ -418,7 +418,7 @@ objFields = lens getter setter
 
 newtype Schema
   = Schema (Map Text EType)
-  deriving (Show, Eq)
+  deriving (Show, Eq, Semigroup)
 
 instance Monoid Schema where
   mempty = Schema Map.empty
@@ -678,7 +678,7 @@ columnMapToSchema
 
 newtype ColumnMap a
   = ColumnMap { _columnMap :: Map ColumnName a }
-  deriving (Show, Functor, Foldable, Traversable, Monoid)
+  deriving (Show, Functor, Foldable, Traversable, Semigroup, Monoid)
 
 instance Mergeable a => Mergeable (ColumnMap a) where
   symbolicMerge force test (ColumnMap left) (ColumnMap right) = ColumnMap $

--- a/src/Pact/Analyze/Types/UserShow.hs
+++ b/src/Pact/Analyze/Types/UserShow.hs
@@ -5,7 +5,7 @@ module Pact.Analyze.Types.UserShow where
 import           Data.Map        (Map)
 import qualified Data.Map        as Map
 import           Data.SBV        (AlgReal, Int64)
-import           Data.Semigroup
+import           Data.Semigroup  ()
 import           Data.Text       (Text)
 import qualified Data.Text       as T
 

--- a/src/Pact/Analyze/Types/UserShow.hs
+++ b/src/Pact/Analyze/Types/UserShow.hs
@@ -5,7 +5,7 @@ module Pact.Analyze.Types.UserShow where
 import           Data.Map        (Map)
 import qualified Data.Map        as Map
 import           Data.SBV        (AlgReal, Int64)
-import           Data.Semigroup  ()
+import           Data.Semigroup  ((<>))
 import           Data.Text       (Text)
 import qualified Data.Text       as T
 

--- a/src/Pact/Analyze/Util.hs
+++ b/src/Pact/Analyze/Util.hs
@@ -11,7 +11,8 @@ import           Control.Lens         (Iso, Snoc (_Snoc), iso, makeLenses,
                                        prism)
 import qualified Data.Default         as Default
 import qualified Data.Foldable        as Foldable
-import           Data.Semigroup       ((<>))
+import           Data.Monoid          (Monoid(..))
+import           Data.Semigroup       (Semigroup(..))
 import           Pact.Types.Lang      (Info (_iInfo), Parsed)
 import           Pact.Types.Typecheck (AST (_aNode), Node (_aId), _tiInfo)
 
@@ -76,6 +77,7 @@ instance Semigroup (SnocList a) where
 
 instance Monoid (SnocList a) where
   mempty = SnocList []
+  mappend = (<>)
 
 pattern ConsList :: [a] -> SnocList a
 pattern ConsList xs <- SnocList (reverse -> xs)

--- a/src/Pact/Analyze/Util.hs
+++ b/src/Pact/Analyze/Util.hs
@@ -11,6 +11,7 @@ import           Control.Lens         (Iso, Snoc (_Snoc), iso, makeLenses,
                                        prism)
 import qualified Data.Default         as Default
 import qualified Data.Foldable        as Foldable
+import           Data.Semigroup       ((<>))
 import           Pact.Types.Lang      (Info (_iInfo), Parsed)
 import           Pact.Types.Typecheck (AST (_aNode), Node (_aId), _tiInfo)
 
@@ -70,9 +71,11 @@ newtype SnocList a
   = SnocList { _reversed :: [a] }
   deriving (Eq, Ord, Show)
 
+instance Semigroup (SnocList a) where
+  SnocList xs <> SnocList ys = SnocList $ ys ++ xs
+
 instance Monoid (SnocList a) where
   mempty = SnocList []
-  SnocList xs `mappend` SnocList ys = SnocList $ ys ++ xs
 
 pattern ConsList :: [a] -> SnocList a
 pattern ConsList xs <- SnocList (reverse -> xs)

--- a/src/Pact/Docgen.hs
+++ b/src/Pact/Docgen.hs
@@ -25,7 +25,7 @@ import           Control.Monad.Catch
 import           Data.Foldable        (for_)
 import           Data.Function
 import           Data.List
-import           Data.Monoid
+import           Data.Monoid          ()
 import           Data.Text            (replace)
 import qualified Data.Text            as T
 import           System.IO

--- a/src/Pact/Docgen.hs
+++ b/src/Pact/Docgen.hs
@@ -25,7 +25,7 @@ import           Control.Monad.Catch
 import           Data.Foldable        (for_)
 import           Data.Function
 import           Data.List
-import           Data.Monoid          ()
+import           Data.Monoid          ((<>))
 import           Data.Text            (replace)
 import qualified Data.Text            as T
 import           System.IO

--- a/src/Pact/Gas.hs
+++ b/src/Pact/Gas.hs
@@ -8,7 +8,7 @@ import Data.Text
 import Pact.Types.Runtime
 import Control.Lens
 import Control.Arrow
-import Data.Monoid ()
+import Data.Monoid ((<>))
 import Data.Word
 
 -- | Compute gas for some application or evaluation.

--- a/src/Pact/Gas.hs
+++ b/src/Pact/Gas.hs
@@ -8,7 +8,7 @@ import Data.Text
 import Pact.Types.Runtime
 import Control.Lens
 import Control.Arrow
-import Data.Monoid
+import Data.Monoid ()
 import Data.Word
 
 -- | Compute gas for some application or evaluation.

--- a/src/Pact/Native/Ops.hs
+++ b/src/Pact/Native/Ops.hs
@@ -27,7 +27,7 @@ module Pact.Native.Ops
 import Data.Decimal
 import Data.Default
 import qualified Data.Map.Strict as M
-import Data.Semigroup ()
+import Data.Semigroup ((<>))
 
 import Pact.Native.Internal
 import Pact.Types.Runtime

--- a/src/Pact/Native/Ops.hs
+++ b/src/Pact/Native/Ops.hs
@@ -27,7 +27,7 @@ module Pact.Native.Ops
 import Data.Decimal
 import Data.Default
 import qualified Data.Map.Strict as M
-import Data.Semigroup
+import Data.Semigroup ()
 
 import Pact.Native.Internal
 import Pact.Types.Runtime

--- a/src/Pact/Native/Time.hs
+++ b/src/Pact/Native/Time.hs
@@ -26,7 +26,7 @@ import Data.Thyme
 import Data.Decimal
 import System.Locale
 import Data.AffineSpace
-import Data.Semigroup
+import Data.Semigroup ()
 
 import Pact.Types.Runtime
 import Pact.Native.Internal

--- a/src/Pact/Native/Time.hs
+++ b/src/Pact/Native/Time.hs
@@ -26,7 +26,7 @@ import Data.Thyme
 import Data.Decimal
 import System.Locale
 import Data.AffineSpace
-import Data.Semigroup ()
+import Data.Semigroup ((<>))
 
 import Pact.Types.Runtime
 import Pact.Native.Internal

--- a/src/Pact/Persist.hs
+++ b/src/Pact/Persist.hs
@@ -21,7 +21,7 @@ module Pact.Persist
 
 import Data.Aeson
 import Data.String
-import Data.Monoid
+import Data.Monoid ()
 import Data.Hashable
 import Data.Typeable
 

--- a/src/Pact/Persist.hs
+++ b/src/Pact/Persist.hs
@@ -21,7 +21,7 @@ module Pact.Persist
 
 import Data.Aeson
 import Data.String
-import Data.Monoid ()
+import Data.Monoid ((<>))
 import Data.Hashable
 import Data.Typeable
 

--- a/src/Pact/PersistPactDb.hs
+++ b/src/Pact/PersistPactDb.hs
@@ -39,7 +39,7 @@ import Data.Typeable
 import Data.Aeson hiding ((.=))
 import GHC.Generics
 
-import Data.Monoid ()
+import Data.Monoid ((<>))
 import qualified Data.Map.Strict as M
 import Data.Maybe
 

--- a/src/Pact/PersistPactDb.hs
+++ b/src/Pact/PersistPactDb.hs
@@ -39,7 +39,7 @@ import Data.Typeable
 import Data.Aeson hiding ((.=))
 import GHC.Generics
 
-import Data.Monoid
+import Data.Monoid ()
 import qualified Data.Map.Strict as M
 import Data.Maybe
 

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -357,25 +357,7 @@ verify i as = case as of
       Nothing -> evalError' i $ "No such module: " ++ show modName
       Just md -> do
         modResult <- liftIO $ verifyModule modules md
-        -- TODO: build describeModuleResult
-        case modResult of
-          Left (ModuleParseFailure failure)  -> setop $ TcErrors
-            [Text.unpack $ describeParseFailure failure]
-          Left (ModuleCheckFailure checkFailure) -> setop $ TcErrors
-            [Text.unpack $ describeCheckFailure checkFailure]
-          Left (TypeTranslationFailure msg ty) -> setop $ TcErrors
-            [Text.unpack $ msg <> ": " <> tShow ty]
-          Left (InvalidRefType) -> setop $ TcErrors
-            ["Invalid reference type given to typechecker."]
-          Left (FailedConstTranslation msg) -> setop $ TcErrors
-            [msg]
-          Right (ModuleChecks propResults invariantResults warnings) -> setop $ TcErrors $
-            let propResults'      = propResults      ^.. traverse . each
-                invariantResults' = invariantResults ^.. traverse . traverse . each
-            in fmap Text.unpack $
-                 (describeCheckResult <$> propResults' <> invariantResults') <>
-                 [describeVerificationWarnings warnings]
-
+        setop $ TcErrors $ fmap Text.unpack $ renderVerifiedModule modResult
         return (tStr "")
 
   _ -> argsError i as

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -132,9 +132,7 @@ replDefs = ("Repl",
        "Set environment gas price to PRICE"
      ,defZRNative "env-gasrate" setGasRate (funType tTyString [("rate",tTyInteger)])
        "Update gas model to charge constant RATE"
-#if !defined(ghcjs_HOST_OS)
      ,defZRNative "verify" verify (funType tTyString [("module",tTyString)]) "Verify MODULE, checking that all properties hold."
-#endif
 
      ,defZRNative "json" json' (funType tTyValue [("exp",a)]) $
       "Encode pact expression EXP as a JSON value. " <>

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -30,15 +30,17 @@ import qualified Data.Set as S
 import qualified Data.ByteString.Lazy as BSL
 import Control.Concurrent.MVar
 import Data.Aeson (eitherDecode,toJSON)
+import qualified Data.Text as Text
 import Data.Text.Encoding
 import Data.Maybe
-#if !defined(ghcjs_HOST_OS)
+#if defined(ghcjs_HOST_OS)
+import qualified Pact.Analyze.Remote.Client as RemoteClient
+#else
 import Control.Monad.State.Strict (get)
 import Criterion
 import Criterion.Types
 import qualified Data.Map as M
-import qualified Data.Text as Text
-import Pact.Analyze.Check
+import qualified Pact.Analyze.Check as Check
 #if MIN_VERSION_statistics(0,14,0)
 import Statistics.Types (Estimate(..))
 #else
@@ -347,7 +349,6 @@ tc i as = case as of
                 setop $ TcErrors $ map (\(Failure ti s) -> renderInfo (_tiInfo ti) ++ ":Warning: " ++ s) fails
                 return $ tStr $ "Typecheck " <> modname <> ": Unable to resolve all types"
 
-#if !defined(ghcjs_HOST_OS)
 verify :: RNativeFun LibState
 verify i as = case as of
   [TLitString modName] -> do
@@ -356,12 +357,17 @@ verify i as = case as of
     case mdm of
       Nothing -> evalError' i $ "No such module: " ++ show modName
       Just md -> do
-        modResult <- liftIO $ verifyModule modules md
-        setop $ TcErrors $ fmap Text.unpack $ renderVerifiedModule modResult
+#if defined(ghcjs_HOST_OS)
+        renderedLines <- liftIO $
+          RemoteClient.verifyModule modules md "localhost" 3000
+#else
+        modResult <- liftIO $ Check.verifyModule modules md
+        let renderedLines = Check.renderVerifiedModule modResult
+#endif
+        setop $ TcErrors $ Text.unpack <$> renderedLines
         return (tStr "")
 
   _ -> argsError i as
-#endif
 
 json' :: RNativeFun LibState
 json' _ [a] = return $ TValue (toJSON a) def

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -49,7 +49,7 @@ import Data.Foldable
 import Text.PrettyPrint.ANSI.Leijen hiding ((<$>),(<>))
 import Data.String
 import Data.List
-import Data.Monoid ()
+import Data.Monoid ((<>))
 import Data.Maybe (isJust)
 import Control.Compactable (traverseMaybe)
 

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -49,7 +49,7 @@ import Data.Foldable
 import Text.PrettyPrint.ANSI.Leijen hiding ((<$>),(<>))
 import Data.String
 import Data.List
-import Data.Monoid
+import Data.Monoid ()
 import Data.Maybe (isJust)
 import Control.Compactable (traverseMaybe)
 

--- a/src/Pact/Types/Info.hs
+++ b/src/Pact/Types/Info.hs
@@ -33,7 +33,7 @@ import Data.Default
 import GHC.Generics (Generic)
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import Text.PrettyPrint.ANSI.Leijen hiding ((<>),(<$>))
-import Data.Monoid
+import Data.Monoid ()
 import Data.Semigroup (Semigroup)
 import Control.DeepSeq
 

--- a/src/Pact/Types/Info.hs
+++ b/src/Pact/Types/Info.hs
@@ -33,7 +33,7 @@ import Data.Default
 import GHC.Generics (Generic)
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import Text.PrettyPrint.ANSI.Leijen hiding ((<>),(<$>))
-import Data.Monoid ()
+import Data.Monoid ((<>))
 import Data.Semigroup (Semigroup)
 import Control.DeepSeq
 

--- a/src/Pact/Types/Logger.hs
+++ b/src/Pact/Types/Logger.hs
@@ -21,7 +21,7 @@ import Control.Arrow
 import Data.Maybe
 #if !defined(ghcjs_HOST_OS)
 import Data.List
-import Data.Monoid
+import Data.Monoid()
 import Data.Yaml as Y
 #endif
 import qualified Data.Text as T
@@ -128,7 +128,7 @@ _test = do
                "  include: [INFO] \n" <>
                "ExcludeINFO:      \n" <>
                "  exclude: [INFO]"
-      rules = either error id $ Y.decodeEither config
+      rules = either (error . Y.prettyPrintParseException) id $ Y.decodeEither' config
       loggers = initLoggers putStrLn doLog rules
   forM_ (sort $ HM.keys (logRules rules)) $ \ln -> runLogIO (newLogger loggers ln) _stuff
   runLogIO (newLogger loggers "Unconfigured") _stuff

--- a/src/Pact/Types/Logger.hs
+++ b/src/Pact/Types/Logger.hs
@@ -21,7 +21,7 @@ import Control.Arrow
 import Data.Maybe
 #if !defined(ghcjs_HOST_OS)
 import Data.List
-import Data.Monoid()
+import Data.Monoid ((<>))
 import Data.Yaml as Y
 #endif
 import qualified Data.Text as T

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -74,8 +74,8 @@ import Data.Hashable
 import Data.Foldable
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import Text.PrettyPrint.ANSI.Leijen hiding ((<>),(<$>))
-import Data.Monoid ()
-import Data.Semigroup ((<>))
+import Data.Monoid (Monoid(..))
+import Data.Semigroup (Semigroup(..))
 import Control.DeepSeq
 import Data.Maybe
 import qualified Data.HashSet as HS
@@ -175,10 +175,11 @@ newtype Gas = Gas Int64
 instance Show Gas where show (Gas g) = show g
 
 instance Semigroup Gas where
-  (Gas a) <> (Gas b) = Gas $ a + b
+  Gas a <> Gas b = Gas $ a + b
 
 instance Monoid Gas where
   mempty = 0
+  mappend = (<>)
 
 data NativeDFun = NativeDFun {
       _nativeName :: NativeDefName,

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -74,7 +74,8 @@ import Data.Hashable
 import Data.Foldable
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import Text.PrettyPrint.ANSI.Leijen hiding ((<>),(<$>))
-import Data.Monoid
+import Data.Monoid ()
+import Data.Semigroup ((<>))
 import Control.DeepSeq
 import Data.Maybe
 import qualified Data.HashSet as HS
@@ -172,10 +173,12 @@ instance Show Ref where
 newtype Gas = Gas Int64
   deriving (Eq,Ord,Num,Real,Integral,Enum)
 instance Show Gas where show (Gas g) = show g
+
+instance Semigroup Gas where
+  (Gas a) <> (Gas b) = Gas $ a + b
+
 instance Monoid Gas where
   mempty = 0
-  (Gas a) `mappend` (Gas b) = Gas $ a + b
-
 
 data NativeDFun = NativeDFun {
       _nativeName :: NativeDefName,

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -49,7 +49,7 @@ import Data.Aeson hiding (Object)
 import Data.Foldable
 import Text.PrettyPrint.ANSI.Leijen hiding ((<$$>),(<>))
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
-import Data.Monoid ()
+import Data.Monoid ((<>))
 
 import Pact.Types.Lang
 import Pact.Types.Native

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -49,7 +49,7 @@ import Data.Aeson hiding (Object)
 import Data.Foldable
 import Text.PrettyPrint.ANSI.Leijen hiding ((<$$>),(<>))
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
-import Data.Monoid
+import Data.Monoid ()
 
 import Pact.Types.Lang
 import Pact.Types.Native

--- a/stack-nix.yaml
+++ b/stack-nix.yaml
@@ -1,3 +1,3 @@
-resolver: ghc-8.0.2
+resolver: ghc-8.4.3
 system-ghc: true
 install-ghc: false

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,18 +1,16 @@
 # stack yaml for ghc builds
 
-resolver: lts-8.15
+resolver: lts-12.9
 
 packages:
   - '.'
 
 extra-deps:
-  - bound-2
+  - algebraic-graphs-0.2
+  - crackNum-2.2
+  - FloatingHex-0.4
   - compactable-0.1.2.2
   - ed25519-donna-0.1.1
-  - megaparsec-6.5.0
-  - parser-combinators-1.0.0
-  - algebraic-graphs-0.1.1.1
-  - hedgehog-0.6
   - hw-hspec-hedgehog-0.1.0.5
   - git: https://github.com/slpopejoy/snap-cors.git
     commit: cc88bab1fd3f62dc4d9f9ad81a231877a639c812

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ packages:
   - '.'
 
 extra-deps:
+  - aeson-1.3.1.1
   - algebraic-graphs-0.2
   - crackNum-2.2
   - FloatingHex-0.4

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -1249,8 +1249,7 @@ spec = describe "analyze" $ do
                 it "should have no keyset provenance" $ do
                   ksProvs `shouldBe` Map.empty
 
-              other -> it "didn't find a single CheckFailure" $
-                HUnit.assertFailure $ show other
+              other -> runIO $ HUnit.assertFailure $ show other
 
   describe "cell-delta.integer" $ do
     let code =

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -6,7 +6,7 @@ module PactContinuationSpec (spec) where
 import Test.Hspec
 import Utils.TestRunner
 import qualified Data.HashMap.Strict as HM
-import Data.Aeson
+import Data.Aeson hiding (Options)
 import qualified Network.HTTP.Client as HTTP
 import Network.Wreq
 import Control.Lens ((&), (.~))

--- a/tests/RemoteVerifySpec.hs
+++ b/tests/RemoteVerifySpec.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
+-- | Tests remote verification on the server side (i.e. no GHCJS involvement)
+module RemoteVerifySpec (spec) where
+
+import Control.Concurrent
+import Control.Exception (finally)
+import Control.Lens
+import Control.Monad.State.Strict
+import Data.Aeson
+import qualified Data.HashMap.Strict as HM
+import Data.Maybe
+import qualified Data.Text as T
+import Snap.Http.Server.Config
+import Test.Hspec
+import NeatInterpolation (text)
+import Network.Wreq
+
+import qualified Pact.Analyze.Remote.Types as Remote
+import Pact.Analyze.Remote.Server (runServer)
+import Pact.Repl
+import Pact.Repl.Types
+import Pact.Types.Runtime
+
+spec :: Spec
+spec = do
+  describe "single module"                       testSingleModule
+  describe "multiple modules, sent out of order" testUnsortedModules
+
+data TestFailure
+  = ReplError String
+  deriving Show
+
+loadCode :: Text -> IO (Either TestFailure ReplState)
+loadCode code = do
+  replState0 <- initReplState StringEval
+  (eTerm, replState) <- runStateT (evalRepl' $ T.unpack code) replState0
+  pure $ case eTerm of
+    Left err -> Left $ ReplError err
+    Right _t -> Right replState
+
+stateModuleData :: ModuleName -> ReplState -> Maybe (Module, HM.HashMap Text Ref)
+stateModuleData nm replState = replState ^. rEnv . eeRefStore . rsModules . at nm
+
+serve :: Int -> IO ThreadId
+serve port = forkIO $ runServer config
+  where
+    config = mempty
+           & setVerbose False
+           & setPort port
+           & setAccessLog ConfigNoLog
+           & setErrorLog ConfigNoLog
+
+serveAndRequest :: Int -> Remote.Request -> IO (Response (Remote.Response))
+serveAndRequest port body = do
+  let url = "http://localhost:" ++ show port ++ "/verify"
+  tid <- serve port
+  finally
+    (asJSON =<< post url (toJSON body) :: IO (Response Remote.Response))
+    (killThread tid)
+
+testSingleModule :: Spec
+testSingleModule = do
+  eReplState0 <- runIO $ loadCode
+    [text|
+      (env-keys ["admin"])
+      (env-data { "keyset": { "keys": ["admin"], "pred": "=" } })
+      (begin-tx)
+
+      (define-keyset 'ks (read-keyset "keyset"))
+      (module mod1 'ks
+        (defun f:integer ()
+          @doc   "always returns 1"
+          @model (property (= result 1))
+          1))
+
+      (commit-tx)
+    |]
+
+  it "loads locally" $ do
+    Right replState0 <- pure eReplState0
+    stateModuleData "mod1" replState0 `shouldSatisfy` isJust
+
+  Right replState0 <- pure eReplState0
+  Just (mod1, _refs) <- pure $ stateModuleData "mod1" replState0
+
+  resp <- runIO $ serveAndRequest 3000 $ Remote.Request [mod1] "mod1"
+
+  it "verifies over the network" $
+    "Property proven valid" == resp ^. responseBody . Remote.responseLines . ix 0
+
+testUnsortedModules :: Spec
+testUnsortedModules = do
+  eReplState0 <- runIO $ loadCode
+    [text|
+      (env-keys ["admin"])
+      (env-data { "keyset": { "keys": ["admin"], "pred": "=" } })
+      (begin-tx)
+      (define-keyset 'ks (read-keyset "keyset"))
+      (module mod1 'ks
+        (defun f:integer ()
+          @doc   "always returns 1"
+          @model (property (= result 1))
+          1))
+      (commit-tx)
+      (begin-tx)
+      (define-keyset 'ks2 (read-keyset "keyset"))
+      (module mod2 'ks2
+        (use mod1)
+        (defun g:integer ()
+          @doc   "always returns 2"
+          @model (property (= result 2))
+          2))
+      (commit-tx)
+    |]
+
+  it "loads when topologically sorted locally" $ do
+    Right replState0 <- pure eReplState0
+    stateModuleData "mod2" replState0 `shouldSatisfy` isJust
+
+  Right replState0 <- pure eReplState0
+  Just (mod1, _refs) <- pure $ stateModuleData "mod1" replState0
+  Just (mod2, _refs) <- pure $ stateModuleData "mod2" replState0
+
+  resp <- runIO $ serveAndRequest 3001 $ Remote.Request [mod2, mod1] "mod2"
+
+  it "verifies over the network" $
+    "Property proven valid" == resp ^. responseBody . Remote.responseLines . ix 0

--- a/tests/TypecheckSpec.hs
+++ b/tests/TypecheckSpec.hs
@@ -14,7 +14,7 @@ import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import Control.Monad
 import Data.Foldable
 import qualified Data.Text as T
-import Data.Monoid ()
+import Data.Monoid ((<>))
 
 spec :: Spec
 spec = do

--- a/tests/TypecheckSpec.hs
+++ b/tests/TypecheckSpec.hs
@@ -14,7 +14,7 @@ import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import Control.Monad
 import Data.Foldable
 import qualified Data.Text as T
-import Data.Monoid
+import Data.Monoid ()
 
 spec :: Spec
 spec = do

--- a/tests/Utils/TestRunner.hs
+++ b/tests/Utils/TestRunner.hs
@@ -29,7 +29,7 @@ import Pact.Types.Command
 import "crypto-api" Crypto.Random
 import Crypto.Ed25519.Pure
 
-import Data.Aeson
+import Data.Aeson hiding (Options)
 import Test.Hspec
 import qualified Data.Text as T
 import qualified Data.HashMap.Strict as HM


### PR DESCRIPTION
/cc @slpopejoy @mightybyte

This PR is built off a few commits behind the head of #248, for GHCJS+8.4 support.

This is the last part of #271. We have a few items left:

(1) test the frontend module that we introduced: `Pact.Analyze.Remote.Client`. It's not doing a lot, but we should be careful here because I had to steal and adapt XHR code from `ghcjs-base` to be able to make ajax requests without pulling in reflex as a dependency. And we couldn't use the existing impl in `ghcjs-base` because `reflex-platform` patches-out the module we need: `JavaScript.Web.XMLHttpRequest`. `Pact.Analyze.Remote.Client` is being called when we use `verify` in the Pact REPL when we are running GHCJS. See https://github.com/kadena-io/pact/compare/verify-api?expand=1#diff-b8561870967a93bc587966c19f4b8243R358. I've tried testing this locally by pointing `pact-web`'s `default.nix` to this branch of `pact` and running `ob run`, but obelisk seems to be running the browser REPL on GHC+jsaddle by default -- whenever I interact with the REPL, I see the browser perform a jsaddle XHR.

(2) mount/run the single-endpoint verification `snap` app `Pact.Analyze.Remote.Server.v1App`. This component is covered by server-side HTTP tests: https://github.com/kadena-io/pact/compare/verify-api?expand=1#diff-b6e5059f024a43195662bc755c0606fb

(3) inject the appropriate URL into where we call out to this verification endpoint. it's currently hard-coded to `localhost` in `Pact.Repl.Lib`: https://github.com/kadena-io/pact/compare/verify-api?expand=1#diff-b8561870967a93bc587966c19f4b8243R360