### PR TITLE
Make sure all tokens in expressions are consumed.

### DIFF
--- a/src/Pact/Types/ExpParser.hs
+++ b/src/Pact/Types/ExpParser.hs
@@ -140,7 +140,7 @@ runCompile act cs a =
         (Label s:_) -> doErr def (toList s)
         er -> doErr def (show er)
       Label ne -> doErr def (toList ne)
-      Tokens (x :| _) -> doErr (getInfo x) $ showExpect expect
+      Tokens (x :| _) -> doErr (getInfo x) $ "expected " <> showExpect expect
     (Left e) -> doErr def (show e)
     where doErr i s = Left $ PactError SyntaxError i def (pack s)
           showExpect e = case labelText $ S.toList e of
@@ -148,7 +148,7 @@ runCompile act cs a =
             ss -> intercalate "," ss
           labelText [] = []
           labelText (Label s:r) = toList s:labelText r
-          labelText (EndOfInput:r) = "End of input":labelText r
+          labelText (EndOfInput:r) = "end of expression or input":labelText r
           labelText (_:r) = labelText r
 
 


### PR DESCRIPTION
Problem: Arbitrary tokens could be left in some forms, like `defconst`,
but also others, and not consumed:

```
(defconst AUTH_KEYSET 'K
  "Indicates keyset-governed account"
  sfkldjs
  sldkjflsdk
  slkdfjlsd)
```

Here, we add an `eof` to ensure that all tokens are consumed before the
closing paren.

This change also improves the error message. Previously it looked like
`examples/verified-accounts/accounts.pact:52:3: error: End of file`.
After this change it's `examples/verified-accounts/accounts.pact:52:3:
error: expected end of expression or input`. The location is still wrong
but the message is better.