### PR TITLE
Restricted Alloc monad and str-to-int analysis

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -57,6 +57,7 @@ library
   if !impl(ghcjs)
     hs-source-dirs: src-ghc
     exposed-modules:
+      Pact.Analyze.Alloc
       Pact.Analyze.Eval
       Pact.Analyze.Eval.Invariant
       Pact.Analyze.Eval.Numerical

--- a/src/Pact/Analyze/Alloc.hs
+++ b/src/Pact/Analyze/Alloc.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE DefaultSignatures          #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Pact.Analyze.Alloc
+  ( MonadAlloc (forAll, exists, free)
+  , Alloc
+  , runAlloc
+  ) where
+
+import           Control.Monad.Except        (ExceptT)
+import           Control.Monad.Reader        (ReaderT)
+import qualified Control.Monad.State.Lazy    as LS
+import           Control.Monad.State.Strict  (StateT)
+import           Control.Monad.Trans         (MonadTrans (lift))
+import           Control.Monad.Trans.Maybe   (MaybeT)
+import           Control.Monad.Writer.Strict (WriterT)
+import qualified Control.Monad.Writer.Lazy   as LW
+import           Data.SBV                    (Symbolic, SymWord)
+import qualified Data.SBV                    as SBV
+
+import           Pact.Analyze.Types          (S, sansProv)
+
+-- | A restricted symbolic context in which only quantified variable allocation
+-- is permitted.
+class Monad m => MonadAlloc m where
+  forAll :: SymWord a => m (S a) -- ^ universally quantified
+  exists :: SymWord a => m (S a) -- ^ existentially quantified
+  free   :: SymWord a => m (S a) -- ^ quantified per the context of sat vs prove
+
+  default forAll :: (MonadTrans t, MonadAlloc m', m ~ t m', SymWord a) => m (S a)
+  forAll = lift forAll
+
+  default exists :: (MonadTrans t, MonadAlloc m', m ~ t m', SymWord a) => m (S a)
+  exists = lift exists
+
+  default free :: (MonadTrans t, MonadAlloc m', m ~ t m', SymWord a) => m (S a)
+  free = lift free
+
+instance MonadAlloc m             => MonadAlloc (ExceptT e m)
+instance MonadAlloc m             => MonadAlloc (MaybeT m)
+instance MonadAlloc m             => MonadAlloc (ReaderT r m)
+instance MonadAlloc m             => MonadAlloc (StateT s m)
+instance MonadAlloc m             => MonadAlloc (LS.StateT s m)
+instance (MonadAlloc m, Monoid w) => MonadAlloc (WriterT w m)
+instance (MonadAlloc m, Monoid w) => MonadAlloc (LW.WriterT w m)
+
+-- * Standard 'MonadAlloc' implementation; 'Symbolic' restricted to use only
+-- use quantified variable allocation.
+
+-- We can't implement @AllocT@ yet because sbv doesn't have a @SymbolicT@.
+
+newtype Alloc a = Alloc { runAlloc :: Symbolic a }
+  deriving (Functor, Applicative, Monad)
+
+instance MonadAlloc Alloc where
+  forAll = Alloc $ sansProv <$> SBV.forall_
+  exists = Alloc $ sansProv <$> SBV.exists_
+  free   = Alloc $ sansProv <$> SBV.free_

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -32,7 +32,6 @@ import           Control.Lens              (at, ifoldrM, ifor, itraversed, ix,
                                             (?~), (^.), (^?), (^@..), _1, _2,
                                             _Left)
 import           Control.Monad             (void, (<=<))
-
 import           Control.Monad.Except      (Except, ExceptT (ExceptT),
                                             MonadError, catchError, runExceptT,
                                             throwError, withExcept, withExceptT)
@@ -57,31 +56,30 @@ import qualified Data.Text                 as T
 import           Data.Traversable          (for)
 import           Prelude                   hiding (exp)
 
-import           Pact.Analyze.Parse        hiding (tableEnv)
-import           Pact.Typechecker          (typecheckTopLevel)
-import           Pact.Types.Lang           (pattern ColonExp, pattern CommaExp,
-                                            Info, mModel, renderInfo,
-                                            renderParsed, tMeta, _tDefName)
-import           Pact.Types.Runtime        (Exp, ModuleData(..), ModuleName,
-                                            Ref (Ref), mdRefMap, mdModule,
-                                            Term (TConst, TDef, TSchema, TTable),
-                                            asString, getInfo, tShow)
-import qualified Pact.Types.Runtime        as Pact
-import           Pact.Types.Term           (Module(..))
-import           Pact.Types.Typecheck      (AST,
-                                            Fun (FDefun, _fArgs, _fBody, _fInfo),
-                                            Named, Node, TcId (_tiInfo),
-                                            TopLevel (TopConst, TopFun, TopTable),
-                                            UserType (_utFields, _utName),
-                                            runTC, tcFailures)
-import qualified Pact.Types.Typecheck      as TC
+import           Pact.Typechecker     (typecheckTopLevel)
+import           Pact.Types.Lang      (pattern ColonExp, pattern CommaExp,
+                                       Info, mModel, renderInfo, renderParsed,
+                                       tMeta, _tDefName)
+import           Pact.Types.Runtime   (Exp, ModuleData(..), ModuleName,
+                                       Ref (Ref), mdRefMap, mdModule,
+                                       Term (TConst, TDef, TSchema, TTable),
+                                       asString, getInfo, tShow)
+import qualified Pact.Types.Runtime   as Pact
+import           Pact.Types.Term      (Module(..))
+import           Pact.Types.Typecheck (AST,
+                                       Fun (FDefun, _fArgs, _fBody, _fInfo),
+                                       Named, Node, TcId (_tiInfo),
+                                       TopLevel (TopConst, TopFun, TopTable),
+                                       UserType (_utFields, _utName), runTC,
+                                       tcFailures)
+import qualified Pact.Types.Typecheck as TC
 
+import           Pact.Analyze.Alloc     (runAlloc)
 import           Pact.Analyze.Errors
-import           Pact.Analyze.Eval         hiding (invariants)
-import           Pact.Analyze.Model        (allocArgs, allocModelTags,
-                                            saturateModel, showModel)
-import           Pact.Analyze.Parse        (expToCheck, expToInvariant,
-                                            parseBindings)
+import           Pact.Analyze.Eval      hiding (invariants)
+import           Pact.Analyze.Model     (allocArgs, allocModelTags,
+                                         saturateModel, showModel)
+import           Pact.Analyze.Parse     hiding (tableEnv)
 import           Pact.Analyze.Translate
 import           Pact.Analyze.Types
 import           Pact.Analyze.Util
@@ -291,10 +289,12 @@ verifyFunctionInvariants' funName funInfo tables pactArgs body = runExceptT $ do
       withExcept translateToCheckFailure $ runTranslation funName funInfo pactArgs body
 
     ExceptT $ catchingExceptions $ runSymbolic $ runExceptT $ do
-      modelArgs' <- lift $ allocArgs args
-      tags <- lift $ allocModelTags (Located funInfo tm) graph
+      modelArgs' <- lift $ runAlloc $ allocArgs args
+      tags <- lift $ runAlloc $ allocModelTags (Located funInfo tm) graph
+      let rootPath = _egRootPath graph
       resultsTable <- withExceptT analyzeToCheckFailure $
-        runInvariantAnalysis tables (analysisArgs modelArgs') tm tags funInfo
+        runInvariantAnalysis tables (analysisArgs modelArgs') tm rootPath tags
+          funInfo
 
       -- Iterate through each invariant in a single query so we can reuse our
       -- assertion stack.
@@ -347,12 +347,13 @@ verifyFunctionProperty funName funInfo tables pactArgs body (Located propInfo ch
         withExcept translateToCheckFailure $
           runTranslation funName funInfo pactArgs body
       ExceptT $ catchingExceptions $ runSymbolic $ runExceptT $ do
-        modelArgs' <- lift $ allocArgs args
-        tags <- lift $ allocModelTags (Located funInfo tm) graph
+        modelArgs' <- lift $ runAlloc $ allocArgs args
+        tags <- lift $ runAlloc $ allocModelTags (Located funInfo tm) graph
+        let rootPath = _egRootPath graph
         AnalysisResult _querySucceeds prop ksProvs
           <- withExceptT analyzeToCheckFailure $
-            runPropertyAnalysis check tables (analysisArgs modelArgs') tm tags
-              funInfo
+            runPropertyAnalysis check tables (analysisArgs modelArgs') tm
+              rootPath tags funInfo
 
         -- TODO: bring back the query success check when we've resolved the SBV
         -- query / quantified variables issue:

--- a/src/Pact/Analyze/Eval.hs
+++ b/src/Pact/Analyze/Eval.hs
@@ -28,6 +28,7 @@ import           Data.Functor.Identity       (Identity (Identity, runIdentity))
 import           Data.Map.Strict             (Map)
 import           Data.SBV                    (Boolean ((==>)), SBV, Symbolic,
                                               true)
+import qualified Data.SBV                    as SBV
 import           Data.String                 (fromString)
 
 import           Pact.Types.Lang             (Info)
@@ -100,7 +101,7 @@ runAnalysis' query tables args tm tags info = do
   (funResult, state1, ()) <- hoist generalize $
     runRWST (runAnalyze act) aEnv state0
 
-  lift $ runConstraints $ state1 ^. globalState.gasConstraints
+  lift $ SBV.constrain $ _sSbv $ state1 ^. latticeState.lasConstraints
 
   let cv0     = state0 ^. latticeState . lasExtra
       cv1     = state1 ^. latticeState . lasExtra

--- a/src/Pact/Analyze/Eval.hs
+++ b/src/Pact/Analyze/Eval.hs
@@ -33,6 +33,7 @@ import           Data.String                 (fromString)
 
 import           Pact.Types.Lang             (Info)
 
+import           Pact.Analyze.Alloc          (runAlloc)
 import           Pact.Analyze.Errors
 import           Pact.Analyze.Eval.Core
 import           Pact.Analyze.Eval.Invariant
@@ -110,7 +111,7 @@ runAnalysis' query tables args tm tags info = do
       ksProvs = state1 ^. globalState.gasKsProvenances
 
   (results, querySucceeds)
-    <- runReaderT (runStateT (queryAction query) true) qEnv
+    <- hoist runAlloc $ runReaderT (runStateT (queryAction query) true) qEnv
   pure $ results <&> \prop -> AnalysisResult querySucceeds (_sSbv prop) ksProvs
 
 runPropertyAnalysis

--- a/src/Pact/Analyze/Eval/Core.hs
+++ b/src/Pact/Analyze/Eval/Core.hs
@@ -8,6 +8,7 @@ module Pact.Analyze.Eval.Core where
 import           Control.Lens                (over)
 import           Data.Foldable               (foldrM)
 import qualified Data.Map.Strict             as Map
+import           Data.Monoid                 ((<>))
 import           Data.SBV                    (Boolean (bnot, false, true),
                                               EqSymbolic ((./=), (.==)),
                                               OrdSymbolic ((.<), (.<=), (.>), (.>=)),
@@ -21,6 +22,7 @@ import           Pact.Analyze.Eval.Numerical
 import           Pact.Analyze.Types
 import           Pact.Analyze.Types.Eval
 import           Pact.Analyze.Util
+import qualified Pact.Native                 as Pact
 
 
 -- Note [Time Representation]
@@ -133,6 +135,8 @@ evalCore (Lit a)                           = pure (literalS a)
 evalCore (Sym s)                           = pure s
 evalCore (StrConcat p1 p2)                 = (.++) <$> eval p1 <*> eval p2
 evalCore (StrLength p)                     = over s2Sbv SBV.length <$> eval p
+evalCore (StrToInt s)                      = evalStrToInt s
+evalCore (StrToIntBase b s)                = evalStrToIntBase b s
 evalCore (Numerical a)                     = evalNumerical a
 evalCore (IntAddTime time secs)            = evalIntAddTime time secs
 evalCore (DecAddTime time secs)            = evalDecAddTime time secs
@@ -156,6 +160,71 @@ evalCore (Var vid name) = do
     Just (AVal mProv sval) -> pure $ mkS mProv sval
     Just (AnObj obj)       -> throwErrorNoLoc $ AValUnexpectedlyObj obj
     Just OpaqueVal         -> throwErrorNoLoc OpaqueValEncountered
+
+evalStrToInt :: Analyzer m => TermOf m String -> m (S Integer)
+evalStrToInt sT = do
+  s <- _sSbv <$> eval sT
+  markFailure $ SBV.null s
+  markFailure $ SBV.length s .> 128
+  let nat = SBV.strToNat s
+  markFailure $ nat .< 0 -- will happen if empty or contains a non-digit
+  pure $ sansProv nat
+
+evalStrToIntBase :: (Analyzer m) => TermOf m Integer -> TermOf m String -> m (S Integer)
+evalStrToIntBase bT sT = do
+  b <- eval bT
+  s <- eval sT
+
+  markFailure $ SBV.null $ _sSbv s
+  markFailure $ SBV.length (_sSbv s) .> 128
+
+  case (unliteralS b, unliteralS s) of
+    -- Symbolic base and string: give up; too many possible solutions.
+    (Nothing, Nothing) ->
+      throwErrorNoLoc "Unable to convert string to integer for symbolic base and string"
+
+    -- Symbolic base and concrete string: pre-compute all 17 possible outcomes
+    (Nothing, Just conStr) ->
+      let conText = T.pack conStr
+      in iteS (sansProv $ b .== 1) (precompute 1 conText) $
+           iteS (sansProv $ b .== 2) (precompute 2 conText) $
+           iteS (sansProv $ b .== 3) (precompute 3 conText) $
+           iteS (sansProv $ b .== 4) (precompute 4 conText) $
+           iteS (sansProv $ b .== 5) (precompute 5 conText) $
+           iteS (sansProv $ b .== 6) (precompute 6 conText) $
+           iteS (sansProv $ b .== 7) (precompute 7 conText) $
+           iteS (sansProv $ b .== 8) (precompute 8 conText) $
+           iteS (sansProv $ b .== 9) (precompute 9 conText) $
+           iteS (sansProv $ b .== 10) (precompute 10 conText) $
+           iteS (sansProv $ b .== 11) (precompute 11 conText) $
+           iteS (sansProv $ b .== 12) (precompute 12 conText) $
+           iteS (sansProv $ b .== 13) (precompute 13 conText) $
+           iteS (sansProv $ b .== 14) (precompute 14 conText) $
+           iteS (sansProv $ b .== 15) (precompute 15 conText) $
+           iteS (sansProv $ b .== 16) (precompute 16 conText) $
+           symbolicFailure
+
+    -- Concrete base and symbolic string: only support base 10
+    (Just conBase, Nothing)
+      | conBase == 10 -> evalStrToInt $ inject s
+      | otherwise     -> throwErrorNoLoc $ FailureMessage $ T.pack $ "Unable to statically determine the string for conversion to integer from base " ++ show conBase
+
+    -- Concrete base and string: use pact native impl
+    (Just conBase, Just conStr) ->
+      case Pact.baseStrToInt conBase (T.pack conStr) of
+        Left err -> throwErrorNoLoc $
+          FailureMessage $ "Failed to convert string to integer: " <> err
+        Right res -> pure $ literalS res
+
+  where
+    symbolicFailure = do
+      markFailure true
+      pure (literalS 0)
+
+    precompute base conText =
+      case Pact.baseStrToInt base conText of
+        Left _err -> symbolicFailure
+        Right res -> pure (literalS res)
 
 evalAt
   :: (Analyzer m, SymWord a)

--- a/src/Pact/Analyze/Eval/Core.hs
+++ b/src/Pact/Analyze/Eval/Core.hs
@@ -186,23 +186,13 @@ evalStrToIntBase bT sT = do
     -- Symbolic base and concrete string: pre-compute all 17 possible outcomes
     (Nothing, Just conStr) ->
       let conText = T.pack conStr
-      in iteS (sansProv $ b .== 1) (precompute 1 conText) $
-           iteS (sansProv $ b .== 2) (precompute 2 conText) $
-           iteS (sansProv $ b .== 3) (precompute 3 conText) $
-           iteS (sansProv $ b .== 4) (precompute 4 conText) $
-           iteS (sansProv $ b .== 5) (precompute 5 conText) $
-           iteS (sansProv $ b .== 6) (precompute 6 conText) $
-           iteS (sansProv $ b .== 7) (precompute 7 conText) $
-           iteS (sansProv $ b .== 8) (precompute 8 conText) $
-           iteS (sansProv $ b .== 9) (precompute 9 conText) $
-           iteS (sansProv $ b .== 10) (precompute 10 conText) $
-           iteS (sansProv $ b .== 11) (precompute 11 conText) $
-           iteS (sansProv $ b .== 12) (precompute 12 conText) $
-           iteS (sansProv $ b .== 13) (precompute 13 conText) $
-           iteS (sansProv $ b .== 14) (precompute 14 conText) $
-           iteS (sansProv $ b .== 15) (precompute 15 conText) $
-           iteS (sansProv $ b .== 16) (precompute 16 conText) $
+      in foldr
+           (\conBase rest ->
+             iteS (sansProv $ b .== literalS conBase)
+               (precompute conBase conText)
+               rest)
            symbolicFailure
+           [2..16]
 
     -- Concrete base and symbolic string: only support base 10
     (Just conBase, Nothing)

--- a/src/Pact/Analyze/Eval/Invariant.hs
+++ b/src/Pact/Analyze/Eval/Invariant.hs
@@ -5,9 +5,11 @@ module Pact.Analyze.Eval.Invariant where
 import           Control.Lens               (at, view, (%=))
 import           Control.Monad.Except       (MonadError (throwError))
 import           Control.Monad.Reader       (MonadReader, ReaderT)
-import           Control.Monad.State.Strict (MonadState, StateT)
+import           Control.Monad.State.Strict (MonadState,
+                                             StateT(StateT, runStateT))
 import           Data.Map.Strict            (Map)
-import           Data.SBV                   (bnot, (&&&))
+import           Data.SBV                   (Mergeable(symbolicMerge),
+                                             bnot, (&&&))
 
 import           Pact.Analyze.Errors
 import           Pact.Analyze.Eval.Core
@@ -22,6 +24,14 @@ newtype InvariantCheck a = InvariantCheck
     (Either AnalyzeFailure)) a
   } deriving (Functor, Applicative, Monad, MonadError AnalyzeFailure,
     MonadReader (Located (Map VarId AVal)), MonadState SymbolicSuccess)
+
+instance (Mergeable a) => Mergeable (InvariantCheck a) where
+  symbolicMerge force test left right = InvariantCheck $ StateT $ \s0 -> do
+    (resL, sL) <- runStateT (unInvariantCheck left) s0
+    (resR, sR) <- runStateT (unInvariantCheck right) s0
+    pure ( symbolicMerge force test resL resR
+         , symbolicMerge force test sL   sR
+         )
 
 instance Analyzer InvariantCheck where
   type TermOf InvariantCheck = Invariant

--- a/src/Pact/Analyze/Eval/Invariant.hs
+++ b/src/Pact/Analyze/Eval/Invariant.hs
@@ -37,7 +37,6 @@ instance Analyzer InvariantCheck where
   type TermOf InvariantCheck = Invariant
   eval  (CoreInvariant tm)   = evalCore tm
   evalO (CoreInvariant tm)   = evalCoreO tm
-  evalLogicalOp              = evalLogicalOp'
   throwErrorNoLoc err = do
     info <- view location
     throwError $ AnalyzeFailure info err

--- a/src/Pact/Analyze/Eval/Numerical.hs
+++ b/src/Pact/Analyze/Eval/Numerical.hs
@@ -16,6 +16,22 @@ import           Pact.Analyze.Errors
 import           Pact.Analyze.Types
 import           Pact.Analyze.Types.Eval
 
+-- When doing binary arithmetic involving:
+-- * decimal x decimal
+-- * integer x decimal
+-- * decimal x integer
+--
+-- We widen / downcast the integer to be a decimal. This just requires shifting
+-- the number left 255 decimal digits in the case of an integer.
+class DecimalRepresentable a where
+  widenToDecimal :: S a -> S Decimal
+
+instance DecimalRepresentable Integer where
+  widenToDecimal = lShift255D . coerceS
+
+instance DecimalRepresentable Decimal where
+  widenToDecimal = id
+
 -- This module handles evaluation of unary and binary integers and decimals.
 -- Two tricky details to watch out for:
 --
@@ -161,19 +177,3 @@ evalRoundingLikeOp2 op xT precisionT = do
 -- Round a real exactly between two integers (_.5) to the nearest even
 banker'sMethodS :: S Decimal -> S Integer
 banker'sMethodS (S prov x) = S prov $ banker'sMethod x
-
--- When doing binary arithmetic involving:
--- * decimal x decimal
--- * integer x decimal
--- * decimal x integer
---
--- We widen / downcast the integer to be a decimal. This just requires shifting
--- the number left 255 decimal digits in the case of an integer.
-class DecimalRepresentable a where
-  widenToDecimal :: S a -> S Decimal
-
-instance DecimalRepresentable Integer where
-  widenToDecimal = lShift255D . coerceS
-
-instance DecimalRepresentable Decimal where
-  widenToDecimal = id

--- a/src/Pact/Analyze/Eval/Prop.hs
+++ b/src/Pact/Analyze/Eval/Prop.hs
@@ -55,7 +55,6 @@ instance Analyzer Query where
   type TermOf Query = Prop
   eval           = evalProp
   evalO          = evalPropO
-  evalLogicalOp  = evalLogicalOp'
   throwErrorNoLoc err = do
     info <- view (analyzeEnv . aeInfo)
     throwError $ AnalyzeFailure info err

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -62,25 +62,11 @@ instance Analyzer Analyze where
   type TermOf Analyze = Term
   eval             = evalTerm
   evalO            = evalTermO
-  evalLogicalOp    = evalTermLogicalOp
   throwErrorNoLoc err = do
     info <- view (analyzeEnv . aeInfo)
     throwError $ AnalyzeFailure info err
   getVar vid = view (scope . at vid)
   markFailure b = succeeds %= (&&& sansProv (bnot b))
-
-evalTermLogicalOp
-  :: LogicalOp
-  -> [Term Bool]
-  -> Analyze (S Bool)
-evalTermLogicalOp AndOp [a, b] = do
-  a' <- eval a
-  ite (_sSbv a') (eval b) (pure false)
-evalTermLogicalOp OrOp [a, b] = do
-  a' <- eval a
-  ite (_sSbv a') (pure true) (eval b)
-evalTermLogicalOp NotOp [a] = bnot <$> eval a
-evalTermLogicalOp op terms = throwErrorNoLoc $ MalformedLogicalOpExec op $ length terms
 
 addConstraint :: S Bool -> Analyze ()
 addConstraint b = modify' $ latticeState.lasConstraints %~ (&&& b)

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -27,7 +27,7 @@ import           Data.SBV                    (Boolean (bnot, true, (&&&), (|||))
                                               EqSymbolic ((.==)),
                                               Mergeable (symbolicMerge), SBV,
                                               SymArray (readArray), SymWord,
-                                              constrain, false, ite, (.<))
+                                              false, ite, (.<))
 import qualified Data.SBV.String             as SBV
 import           Data.String                 (fromString)
 import           Data.Text                   (Text, pack)
@@ -83,9 +83,7 @@ evalTermLogicalOp NotOp [a] = bnot <$> eval a
 evalTermLogicalOp op terms = throwErrorNoLoc $ MalformedLogicalOpExec op $ length terms
 
 addConstraint :: S Bool -> Analyze ()
-addConstraint s = modify' $ globalState.gasConstraints %~ (<> c)
-  where
-    c = Constraints $ constrain $ _sSbv s
+addConstraint b = modify' $ latticeState.lasConstraints %~ (&&& b)
 
 instance (Mergeable a) => Mergeable (Analyze a) where
   symbolicMerge force test left right = Analyze $ RWST $ \r s ->

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -144,18 +144,17 @@ tagAuth tid sKs sb = do
       addConstraint $ sansProv $ sbv .== _sSbv sb
       globalState.gasKsProvenances.at tid .= (sKs ^. sProv)
 
+tagSubpathStart :: Path -> S Bool -> Analyze ()
+tagSubpathStart p active = do
+  mTag <- preview $ aeModelTags.mtPaths.at p._Just
+  case mTag of
+    Nothing  -> pure ()
+    Just sbv -> addConstraint $ sansProv $ sbv .== _sSbv active
+
 tagFork :: Path -> Path -> S Bool -> S Bool -> Analyze ()
 tagFork pathL pathR reachable lPasses = do
     tagSubpathStart pathL $ reachable &&& lPasses
     tagSubpathStart pathR $ reachable &&& bnot lPasses
-
-  where
-    tagSubpathStart :: Path -> S Bool -> Analyze ()
-    tagSubpathStart p active = do
-      mTag <- preview $ aeModelTags.mtPaths.at p._Just
-      case mTag of
-        Nothing  -> pure ()
-        Just sbv -> addConstraint $ sansProv $ sbv .== _sSbv active
 
 tagResult :: AVal -> Analyze ()
 tagResult av = do

--- a/src/Pact/Analyze/Feature.hs
+++ b/src/Pact/Analyze/Feature.hs
@@ -85,6 +85,7 @@ data Feature
   -- String operators
   | FStringLength
   | FStringConcatenation
+  | FStringToInteger
   -- Temporal operators
   | FTemporalAddition
   -- Quantification forms
@@ -681,6 +682,29 @@ doc FStringConcatenation = Doc
         ]
         (TyCon str)
   ]
+doc FStringToInteger = Doc
+  "str-to-int"
+  CString
+  InvAndProp
+  "String to integer conversion"
+  [ Usage
+      "(str-to-int s)"
+      Map.empty
+      $ Fun
+        Nothing
+        [ ("s", TyCon str)
+        ]
+        (TyCon int)
+  , Usage
+      "(str-to-int b s)"
+      Map.empty
+      $ Fun
+        Nothing
+        [ ("b", TyCon int)
+        , ("s", TyCon str)
+        ]
+        (TyCon int)
+  ]
 
 -- Temporal features
 
@@ -1090,6 +1114,7 @@ PAT(SObjectProjection, FObjectProjection)
 PAT(SObjectMerge, FObjectMerge)
 PAT(SStringLength, FStringLength)
 PAT(SStringConcatenation, FStringConcatenation)
+PAT(SStringToInteger, FStringToInteger)
 PAT(STemporalAddition, FTemporalAddition)
 PAT(SUniversalQuantification, FUniversalQuantification)
 PAT(SExistentialQuantification, FExistentialQuantification)

--- a/src/Pact/Analyze/Model/Tags.hs
+++ b/src/Pact/Analyze/Model/Tags.hs
@@ -19,10 +19,10 @@ module Pact.Analyze.Model.Tags
 
 import           Control.Lens         (Traversal', toListOf, traverseOf,
                                        traversed, (<&>), (?~), (^.), _1, _2, _3)
-import           Control.Monad        (when, (>=>))
+import           Control.Monad        ((>=>))
 import           Data.Map.Strict      (Map)
 import qualified Data.Map.Strict      as Map
-import           Data.SBV             (SBV, SymWord, Symbolic)
+import           Data.SBV             (SBV, SymWord)
 import qualified Data.SBV             as SBV
 import qualified Data.SBV.Control     as SBV
 import qualified Data.SBV.Internals   as SBVI
@@ -30,34 +30,37 @@ import           Data.Traversable     (for)
 
 import qualified Pact.Types.Typecheck as TC
 
+import           Pact.Analyze.Alloc   (Alloc, free)
 import           Pact.Analyze.Types
 
-alloc :: SymWord a => Symbolic (SBV a)
-alloc = SBV.free_
+allocS :: SymWord a => Alloc (S a)
+allocS = free
 
-allocSchema :: Schema -> Symbolic Object
+allocSbv :: SymWord a => Alloc (SBV a)
+allocSbv = _sSbv <$> allocS
+
+allocSchema :: Schema -> Alloc Object
 allocSchema (Schema fieldTys) = Object <$>
   for fieldTys (\ety -> (ety,) <$> allocAVal ety)
 
-allocAVal :: EType -> Symbolic AVal
+allocAVal :: EType -> Alloc AVal
 allocAVal = \case
   EObjectTy schema -> AnObj <$> allocSchema schema
-  EType (_ :: Type t) -> mkAVal . sansProv <$>
-    (alloc :: Symbolic (SBV t))
+  EType (_ :: Type t) -> mkAVal <$> (allocS :: Alloc (S t))
 
-allocTVal :: EType -> Symbolic TVal
+allocTVal :: EType -> Alloc TVal
 allocTVal ety = (ety,) <$> allocAVal ety
 
-allocForETerm :: ETerm -> Symbolic TVal
+allocForETerm :: ETerm -> Alloc TVal
 allocForETerm (existentialType -> ety) = allocTVal ety
 
-allocArgs :: [Arg] -> Symbolic (Map VarId (Located (Unmunged, TVal)))
+allocArgs :: [Arg] -> Alloc (Map VarId (Located (Unmunged, TVal)))
 allocArgs args = fmap Map.fromList $ for args $ \(Arg nm vid node ety) -> do
   let info = node ^. TC.aId . TC.tiInfo
   av <- allocAVal ety <&> _AVal._1 ?~ FromInput nm
   pure (vid, Located info (nm, (ety, av)))
 
-allocModelTags :: Located ETerm -> ExecutionGraph -> Symbolic (ModelTags 'Symbolic)
+allocModelTags :: Located ETerm -> ExecutionGraph -> Alloc (ModelTags 'Symbolic)
 allocModelTags locatedTm graph = ModelTags
     <$> allocVars
     <*> allocReads
@@ -74,26 +77,23 @@ allocModelTags locatedTm graph = ModelTags
     events :: [TraceEvent]
     events = toListOf (egEdgeEvents.traverse.traverse) graph
 
-    allocVars :: Symbolic (Map VarId (Located (Unmunged, TVal)))
+    allocVars :: Alloc (Map VarId (Located (Unmunged, TVal)))
     allocVars = fmap Map.fromList $
       for (toListOf (traverse._TracePushScope._3.traverse) events) $
         \(Located info (Binding vid nm _ ety)) ->
           allocTVal ety <&> \tv -> (vid, Located info (nm, tv))
 
-    allocS :: SymWord a => Symbolic (S a)
-    allocS = sansProv <$> alloc
-
     allocAccesses
       :: Traversal' TraceEvent (Schema, Located TagId)
-      -> Symbolic (Map TagId (Located Access))
+      -> Alloc (Map TagId (Located Access))
     allocAccesses p = fmap Map.fromList $
       for (toListOf (traverse.p) events) $ \(schema, Located info tid) -> do
         srk <- allocS
         obj <- allocSchema schema
-        suc <- alloc
+        suc <- allocSbv
         pure (tid, Located info (Access srk obj suc))
 
-    allocReads :: Symbolic (Map TagId (Located Access))
+    allocReads :: Alloc (Map TagId (Located Access))
     allocReads = allocAccesses _TraceRead
 
     traceWriteT :: Traversal' TraceEvent (Schema, Located TagId)
@@ -101,20 +101,20 @@ allocModelTags locatedTm graph = ModelTags
       TraceWrite _writeType schema tagid -> const event <$> f (schema, tagid)
       _                                  -> pure event
 
-    allocWrites :: Symbolic (Map TagId (Located Access))
+    allocWrites :: Alloc (Map TagId (Located Access))
     allocWrites = allocAccesses traceWriteT
 
-    allocAsserts :: Symbolic (Map TagId (Located (SBV Bool)))
+    allocAsserts :: Alloc (Map TagId (Located (SBV Bool)))
     allocAsserts = fmap Map.fromList $
       for (toListOf (traverse._TraceAssert._2) events) $ \(Located info tid) ->
-        (tid,) . Located info <$> alloc
+        (tid,) . Located info <$> allocSbv
 
-    allocAuths :: Symbolic (Map TagId (Located Authorization))
+    allocAuths :: Alloc (Map TagId (Located Authorization))
     allocAuths = fmap Map.fromList $
       for (toListOf (traverse._TraceAuth._2) events) $ \(Located info tid) ->
-        (tid,) . Located info <$> (Authorization <$> allocS <*> alloc)
+        (tid,) . Located info <$> (Authorization <$> allocS <*> allocSbv)
 
-    allocResult :: Symbolic (TagId, Located TVal)
+    allocResult :: Alloc (TagId, Located TVal)
     allocResult = do
       let tid :: TagId = last $ toListOf (traverse._TracePopScope._3) events
       fmap (tid,) $ sequence $ allocForETerm <$> locatedTm
@@ -123,17 +123,13 @@ allocModelTags locatedTm graph = ModelTags
     -- start of "subpaths" on either side of a conditional. the root path is
     -- always trivially reachable, because it corresponds to the start of a
     -- program.
-    allocPaths :: Symbolic (Map Path (SBV Bool))
+    allocPaths :: Alloc (Map Path (SBV Bool))
     allocPaths = do
       let rootPath = _egRootPath graph
           paths    = rootPath : toListOf (traverse._TraceSubpathStart) events
-      fmap Map.fromList $
-        for paths $ \p -> do
-          sbool <- alloc
-          when (p == rootPath) $ SBV.constrain sbool
-          pure (p, sbool)
+      Map.fromList <$> for paths (\p -> (p,) <$> allocSbv)
 
-    allocReturns :: Symbolic (Map TagId TVal)
+    allocReturns :: Alloc (Map TagId TVal)
     allocReturns = fmap Map.fromList $
       for (toListOf (traverse._TracePopScope) events) $ \(_, _, tid, ety) ->
         (tid,) <$> allocTVal ety

--- a/src/Pact/Analyze/PrenexNormalize.hs
+++ b/src/Pact/Analyze/PrenexNormalize.hs
@@ -74,7 +74,12 @@ floatIntegerQuantifiers :: Prop Integer -> ([Quantifier], Prop Integer)
 floatIntegerQuantifiers p = case p of
   STANDARD_INSTANCES
 
-  CoreProp (StrLength pStr) -> PStrLength <$> float pStr
+  CoreProp (StrLength s)
+    -> PStrLength <$> float s
+  CoreProp (StrToInt s)
+    -> PStrToInt <$> float s
+  CoreProp (StrToIntBase b s)
+    -> PStrToIntBase <$> float b <*> float s
 
   CoreProp (Numerical (IntArithOp op a b))
     -> PNumerical ... IntArithOp      op <$> float a <*> float b

--- a/src/Pact/Analyze/PrenexNormalize.hs
+++ b/src/Pact/Analyze/PrenexNormalize.hs
@@ -77,9 +77,9 @@ floatIntegerQuantifiers p = case p of
   CoreProp (StrLength s)
     -> PStrLength <$> float s
   CoreProp (StrToInt s)
-    -> PStrToInt <$> float s
+    -> CoreProp . StrToInt <$> float s
   CoreProp (StrToIntBase b s)
-    -> PStrToIntBase <$> float b <*> float s
+    -> CoreProp ... StrToIntBase <$> float b <*> float s
 
   CoreProp (Numerical (IntArithOp op a b))
     -> PNumerical ... IntArithOp      op <$> float a <*> float b

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -883,6 +883,15 @@ translateNode astNode = withAstContext astNode $ case astNode of
       Just Refl -> pure $ ESimple ta $ IfThenElse cond' (truePath, a) (falsePath, b)
       _         -> throwError' (BranchesDifferentTypes (EType ta) (EType tb))
 
+  AST_NFun _node "str-to-int" [s] -> do
+    ESimple TStr s' <- translateNode s
+    pure $ ESimple TInt $ CoreTerm $ StrToInt s'
+
+  AST_NFun _node "str-to-int" [b, s] -> do
+    ESimple TInt b' <- translateNode b
+    ESimple TStr s' <- translateNode s
+    pure $ ESimple TInt $ CoreTerm $ StrToIntBase b' s'
+
   AST_NFun _node "pact-version" [] -> pure $ ESimple TStr PactVersion
 
   AST_WithRead node table key bindings schemaNode body -> do

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -61,20 +61,20 @@ instance Wrapped SymbolicSuccess where
   type Unwrapped SymbolicSuccess = SBV Bool
   _Wrapped' = iso successBool SymbolicSuccess
 
-class (MonadError AnalyzeFailure m, S :<: TermOf m) => Analyzer m where
-  type TermOf m   :: * -> *
-  eval            :: (Show a, SymWord a) => TermOf m a -> m (S a)
-  evalO           :: TermOf m Object -> m Object
-  throwErrorNoLoc :: AnalyzeFailureNoLoc -> m a
-  getVar          :: VarId -> m (Maybe AVal)
-  markFailure     :: SBV Bool -> m ()
-
-  -- unfortunately, because `Query` and `InvariantCheck` include `Symbolic` in
-  -- their monad stack, they can't use `ite`, which we need to use to implement
-  -- short-circuiting ops correctly for (effectful) terms. Though, luckily the
-  -- invariant and prop languages are pure, so we're fine to implement them in
-  -- terms of `|||` / `&&&`.
-  evalLogicalOp   :: LogicalOp -> [TermOf m Bool] -> m (S Bool)
+class ( MonadError AnalyzeFailure m
+      , S :<: TermOf m
+      , Mergeable (m (S Bool)) -- TODO: We only need Mergeable for Bool at the
+      )                        -- moment, but really this should probably be
+                               -- done for all Mergeable values, perhaps via
+                               -- QuantifiedConstraints, once we're on 8.6
+      => Analyzer m
+  where
+    type TermOf m   :: * -> *
+    eval            :: (Show a, SymWord a) => TermOf m a -> m (S a)
+    evalO           :: TermOf m Object -> m Object
+    throwErrorNoLoc :: AnalyzeFailureNoLoc -> m a
+    getVar          :: VarId -> m (Maybe AVal)
+    markFailure     :: SBV Bool -> m ()
 
 data AnalyzeEnv
   = AnalyzeEnv

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -63,10 +63,12 @@ instance Wrapped SymbolicSuccess where
 
 class ( MonadError AnalyzeFailure m
       , S :<: TermOf m
-      , Mergeable (m (S Bool)) -- TODO: We only need Mergeable for Bool at the
-      )                        -- moment, but really this should probably be
-                               -- done for all Mergeable values, perhaps via
-                               -- QuantifiedConstraints, once we're on 8.6
+      -- TODO: We only need Mergeable for Bool and Integer at the moment, but
+      -- really this should probably be done for all Mergeable values, perhaps
+      -- via QuantifiedConstraints, once we're on 8.6:
+      , Mergeable (m (S Bool))
+      , Mergeable (m (S Integer))
+      )
       => Analyzer m
   where
     type TermOf m   :: * -> *

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -45,8 +45,6 @@ module Pact.Analyze.Types.Languages
   , pattern POr
   , pattern PStrConcat
   , pattern PStrLength
-  , pattern PStrToInt
-  , pattern PStrToIntBase
   , pattern PVar
   ) where
 
@@ -440,12 +438,6 @@ pattern PLogical op args = CoreProp (Logical op args)
 
 pattern PStrLength :: Prop String -> Prop Integer
 pattern PStrLength str = CoreProp (StrLength str)
-
-pattern PStrToInt :: Prop String -> Prop Integer
-pattern PStrToInt str = CoreProp (StrToInt str)
-
-pattern PStrToIntBase :: Prop Integer -> Prop String -> Prop Integer
-pattern PStrToIntBase base str = CoreProp (StrToIntBase base str)
 
 pattern PAnd :: Prop Bool -> Prop Bool -> Prop Bool
 pattern PAnd a b = CoreProp (Logical AndOp [a, b])

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -45,6 +45,8 @@ module Pact.Analyze.Types.Languages
   , pattern POr
   , pattern PStrConcat
   , pattern PStrLength
+  , pattern PStrToInt
+  , pattern PStrToIntBase
   , pattern PVar
   ) where
 
@@ -131,12 +133,16 @@ data Core t a where
 
   -- string ops
   -- | The concatenation of two 'String' expressions
-  StrConcat :: t String -> t String -> Core t String
+  StrConcat    :: t String  -> t String  -> Core t String
   -- | The length of a 'String' expression
-  StrLength :: t String                     -> Core t Integer
+  StrLength    :: t String  ->              Core t Integer
+  -- | Conversion of a base-10 string to an integer
+  StrToInt     :: t String  ->              Core t Integer
+  -- | Conversion of a base-1-16 string to an integer
+  StrToIntBase :: t Integer -> t String  -> Core t Integer
 
   -- numeric ops
-  Numerical :: Numerical t a -> Core t a
+  Numerical    :: Numerical t a -> Core t a
 
   -- Time
   -- | Adds an 'Integer' expression to a 'Time' expression
@@ -195,6 +201,8 @@ instance
     Sym s                    -> tShow s
     StrConcat x y            -> parenList [SAddition, userShow x, userShow y]
     StrLength str            -> parenList [SStringLength, userShow str]
+    StrToInt s               -> parenList ["str-to-int", userShow s]
+    StrToIntBase b s         -> parenList ["str-to-int", userShow b, userShow s]
     Numerical tm             -> userShowsPrec d tm
     IntAddTime x y           -> parenList [STemporalAddition, userShow x, userShow y]
     DecAddTime x y           -> parenList [STemporalAddition, userShow x, userShow y]
@@ -432,6 +440,12 @@ pattern PLogical op args = CoreProp (Logical op args)
 
 pattern PStrLength :: Prop String -> Prop Integer
 pattern PStrLength str = CoreProp (StrLength str)
+
+pattern PStrToInt :: Prop String -> Prop Integer
+pattern PStrToInt str = CoreProp (StrToInt str)
+
+pattern PStrToIntBase :: Prop Integer -> Prop String -> Prop Integer
+pattern PStrToIntBase base str = CoreProp (StrToIntBase base str)
 
 pattern PAnd :: Prop Bool -> Prop Bool -> Prop Bool
 pattern PAnd a b = CoreProp (Logical AndOp [a, b])

--- a/src/Pact/Analyze/Types/Numerical.hs
+++ b/src/Pact/Analyze/Types/Numerical.hs
@@ -301,7 +301,7 @@ instance (UserShow (t Integer), UserShow (t Decimal))
     IntUnaryArithOp op a   -> [userShow op, userShow a]
     DecIntArithOp op a b   -> [userShow op, userShow a, userShow b]
     IntDecArithOp op a b   -> [userShow op, userShow a, userShow b]
-    ModOp a b              -> ["mod", userShow a, userShow b]
+    ModOp a b              -> [SModulus, userShow a, userShow b]
     RoundingLikeOp1 op a   -> [userShow op, userShow a]
     RoundingLikeOp2 op a b -> [userShow op, userShow a, userShow b]
 

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -28,6 +28,7 @@ module Pact.Native
     ,hashDef
     ,ifDef
     ,readDecimalDef
+    ,baseStrToInt
     ) where
 
 import Control.Lens hiding (parts,Fold,contains)

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -25,6 +25,7 @@ module Pact.Native
     ,enforceOneDef
     ,pactVersionDef
     ,formatDef
+    ,strToIntDef
     ,hashDef
     ,ifDef
     ,readDecimalDef
@@ -161,6 +162,14 @@ formatDef =
                   (head parts)
                   (zip es (tail parts))
     format i as = argsError i as
+
+strToIntDef :: NativeDef
+strToIntDef = defRNative "str-to-int" strToInt
+  (funType tTyInteger [("str-val", tTyString)] <>
+   funType tTyInteger [("base", tTyInteger), ("str-val", tTyString)])
+  "Compute the integer value of STR-VAL in base 10, or in BASE if specified. STR-VAL must be <= 128 \
+  \chars in length and BASE must be between 2 and 16. Each digit must be in the correct range for \
+  \the base. `(str-to-int 16 \"abcdef123456\")` `(str-to-int \"123456\")`"
 
 hashDef :: NativeDef
 hashDef = defRNative "hash" hash' (funType tTyString [("value",a)])
@@ -323,12 +332,7 @@ langDefs =
     ,defRNative "identity" identity (funType a [("value",a)])
      "Return provided value. `(map (identity) [1 2 3])`"
 
-     ,defRNative "str-to-int" strToInt
-     (funType tTyInteger [("str-val", tTyString)] <>
-      funType tTyInteger [("base", tTyInteger), ("str-val", tTyString)])
-     "Compute the integer value of STR-VAL in base 10, or in BASE if specified. STR-VAL must be <= 128 \
-     \chars in length and BASE must be between 2 and 16. Each digit must be in the correct range for \
-     \the base. `(str-to-int 16 \"abcdef123456\")` `(str-to-int \"123456\")`"
+    ,strToIntDef
     ,hashDef
     ])
     where b = mkTyVar "b" []

--- a/tests/Analyze/Gen.hs
+++ b/tests/Analyze/Gen.hs
@@ -290,7 +290,18 @@ genTerm size = scale 2 $ Gen.choice [genCore size, genTermSpecific size]
 genTermSpecific
   :: (MonadGen m, MonadReader GenEnv m, MonadState GenState m, HasCallStack)
   => BoundedType -> m ETerm
-genTermSpecific size@BoundedInt{} = genTermSpecific' size
+genTermSpecific size@BoundedInt{} = Gen.choice
+  [ do
+      base <- Gen.int (Range.linear 2 16)
+      formatted <- Gen.string (Range.exponential 1 128) (genBaseChar base)
+      pure $ ESimple TInt $ inject $ StrToIntBase
+        (lit (fromIntegral base :: Integer))
+        (lit formatted)
+  , do
+      formatted <- Gen.string (Range.exponential 1 128) (genBaseChar 10)
+      pure $ ESimple TInt $ inject $ StrToInt $ lit formatted
+  , genTermSpecific' size
+  ]
 genTermSpecific BoundedBool       = Gen.choice
   [
   -- TODO: temporarily disabled pending
@@ -378,6 +389,10 @@ genTermSpecific BoundedTime = scale 8 $ Gen.choice
        timeStr <- genTimeOfFormat standardTimeFormat
        pure $ ESimple TTime $ ParseTime Nothing $ lit timeStr
   ]
+
+genBaseChar :: MonadGen m => Int -> m Char
+genBaseChar base = Gen.element $
+  take (2 * base) "00112233445566778899aAbBcCdDeEfF"
 
 genWriteType :: MonadGen m => m WriteType
 genWriteType = Gen.enumBounded

--- a/tests/Analyze/Translate.hs
+++ b/tests/Analyze/Translate.hs
@@ -20,7 +20,7 @@ import           Pact.Eval                  (liftTerm)
 import           Pact.Native                (enforceDef, enforceOneDef,
                                              formatDef, hashDef, ifDef,
                                              lengthDef, pactVersionDef,
-                                             readDecimalDef)
+                                             readDecimalDef, strToIntDef)
 import           Pact.Native.Keysets
 import           Pact.Native.Ops
 import           Pact.Native.Time
@@ -72,6 +72,12 @@ toPactTm = \case
 
   ESimple TStr (Inj (StrConcat x y)) ->
     mkApp addDef [ESimple TStr x, ESimple TStr y]
+
+  ESimple TInt (Inj (StrToInt s)) ->
+    mkApp strToIntDef [ESimple TStr s]
+
+  ESimple TInt (Inj (StrToIntBase b s)) ->
+    mkApp strToIntDef [ESimple TInt b, ESimple TStr s]
 
   ESimple TBool (Inj (IntegerComparison op x y)) ->
     mkApp (comparisonOpToDef op) [ESimple TInt x, ESimple TInt y]

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -848,6 +848,16 @@ spec = describe "analyze" $ do
 
     expectPass code $ Valid $ bnot Success'
 
+  describe "enforce-one.10" $ do
+    let code =
+          [text|
+            (defun test:bool ()
+              (enforce-one "" [true])
+              (enforce-one "" [false]))
+          |]
+
+    expectPass code $ Valid Success'
+
   describe "logical short-circuiting" $ do
     describe "and" $ do
       let code =

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -1521,10 +1521,7 @@ spec = describe "analyze" $ do
           in expectPass code $ Valid Success'
 
         describe "invalid inputs" $ do
-          --
-          -- TODO: uncomment case once the concrete impl is fixed:
-          --
-          for_ [(0, "23"), (6, ""){- , (6, "77") -}] $ \(base, str) ->
+          for_ [(0, "23"), (6, ""), (6, "77")] $ \(base, str) ->
             let baseText = tShow (base :: Int)
             in expectFail [text|(defun test:integer () (str-to-int $baseText "$str"))|] $
                  Valid Success'


### PR DESCRIPTION
- Add a stripped down version of `Symbolic` called `Alloc` that only permits quantified variable allocation (i.e. no effectful things like `SBV.constrain`)
- Switch to pure constraint logging during evaluation (via a symbolic value) and switch `Query` to use `Alloc` instead of `Symbolic` -- this affords a valid `Mergeable` instance for `Query`
- Add `Mergeable` instances for `Query` and `InvariantCheck`
- Use single (`Mergeable`-based) implementation of `evalLogicalOp`
- Switch tag allocation to use `Alloc` instead of `Symbolic`
- Implement analysis for `str-to-int`, using different strategies for concrete/symbolic combinations of inputs

/cc @emilypi 