### PR TITLE
Fail in str-to-int upon character out of the base's range

### DIFF
--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -326,7 +326,8 @@ langDefs =
      (funType tTyInteger [("str-val", tTyString)] <>
       funType tTyInteger [("base", tTyInteger), ("str-val", tTyString)])
      "Compute the integer value of STR-VAL in base 10, or in BASE if specified. STR-VAL must be <= 128 \
-     \chars in length and BASE must be between 2 and 16. `(str-to-int 16 \"123456\")` `(str-to-int \"abcdef123456\")`"
+     \chars in length and BASE must be between 2 and 16. Each digit must be in the correct range for \
+     \the base. `(str-to-int 16 \"abcdef123456\")` `(str-to-int \"123456\")`"
     ,hashDef
     ])
     where b = mkTyVar "b" []

--- a/tests/pact/strtoint.repl
+++ b/tests/pact/strtoint.repl
@@ -1,5 +1,4 @@
 (expect "str-to-int decimal identity - no base" (str-to-int "12345") 12345)
-(expect "str-to-int hex to decimal - no base" (str-to-int "12345abcdef") 12346123455)
 (expect "str-to-int hex identity" (str-to-int 16 "12345abcdef") 1251004370415)
 (expect "str-to-int binary identity" (str-to-int 2 "101010111100110111101111000100100011010001010110") 188900967593046)
 (expect "str-to-int roundtrip" (str-to-int 16 "12345abcdef") (str-to-int "1251004370415"))
@@ -8,4 +7,6 @@
 (expect-failure "str-to-int base == 1" (str-to-int 1 "12345"))
 (expect-failure "str-to-int base < 1" (str-to-int -1 "12345"))
 (expect-failure "str-to-int base > 16" (str-to-int 17 "12345"))
-(expect-failure "str-to-int empty string" (str-to-int "")) 
+(expect-failure "str-to-int empty string" (str-to-int ""))
+(expect-failure "str-to-int char out of range with base" (str-to-int 8 "8"))
+(expect-failure "str-to-int char out of range without base" (str-to-int "a"))


### PR DESCRIPTION
As currently implemented, `str-to-int` silently treats any characters out of range for the supplied base as belonging to base 16. z3's `str.to.int`, which we use for our `str-to-int` implementation on the analysis side (#295), does not allow characters outside of the base's range, and so the semantics of `str-to-int` currently differs between our concrete and symbolic domains.

Normal, happy path usage (which is the same both before and after this change):

```lisp
pact> (str-to-int "123") ; defaults to base 10 / decimal
123

pact> (str-to-int 8 "10") ; base 8 / octal
8
```

Before change:

```lisp
pact> (str-to-int "f") ; 'f' is beyond the valid range for base 10 / decimal
15

pact> (str-to-int 8 "f") ; 'f' is beyond the valid range for base 8 / octal
15
```

After change:

```lisp
pact> (str-to-int "f") ; 'f' is beyond the valid range for base 10 / decimal
<interactive>:0:0: Invalid arguments, received ["f"] for [(str-val:string -> integer),(base:integer str-val:string -> integer)]
 at <interactive>:0:0: (str-to-int "f")

pact> (str-to-int 8 "f") ; 'f' is beyond the valid range for base 8 / octal
<interactive>:0:0: Invalid arguments, received [8,"f"] for [(str-val:string -> integer),(base:integer str-val:string -> integer)]
 at <interactive>:0:0: (str-to-int 8 "f")
```

Pact is currently not surfacing the more helpful error messages (https://github.com/kadena-io/pact/compare/str-to-int-range-check?expand=1#diff-d2fa593375d972a4063162ec29592d5fR644) that we are producing, but that's a separate issue.

For whatever it's worth, in addition to Z3's implementation disallowing characters outside of the base's range, Haskell's `Read` instance for `Int` (which uses base 10) and `Numeric.readInt` (which supports arbitrary bases) similarly validate & fail.