### PR TITLE
Fix constraint vacuity for single-case enforce-one

### DIFF
--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -153,8 +153,8 @@ tagSubpathStart p active = do
 
 tagFork :: Path -> Path -> S Bool -> S Bool -> Analyze ()
 tagFork pathL pathR reachable lPasses = do
-    tagSubpathStart pathL $ reachable &&& lPasses
-    tagSubpathStart pathR $ reachable &&& bnot lPasses
+  tagSubpathStart pathL $ reachable &&& lPasses
+  tagSubpathStart pathR $ reachable &&& bnot lPasses
 
 tagResult :: AVal -> Analyze ()
 tagResult av = do

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -166,8 +166,8 @@ data TranslateState
       --
       -- 'TraceSubpathStart's are emitted once for each path: at the start of
       -- an execution trace, and at the beginning of either side of a
-      -- conditional.  After a conditional, we resume the path from before the
-      -- conditional.  Either side of a conditional will contain a minimum of
+      -- conditional. After a conditional, we resume the path from before the
+      -- conditional. Either side of a conditional will contain a minimum of
       -- two edges: splitting away from the other branch, and then rejoining
       -- back to the other branch at the join point. The following program:
       --
@@ -672,13 +672,9 @@ translateNode astNode = withAstContext astNode $ case astNode of
     let n = length casesA -- invariant: n > 0
         genPath = Path <$> genTagId
     preEnforcePath <- use tsCurrentPath
-    pathPairs <- (++)
-        -- For the first n-1 cases, we generate a failure, then success, tag,
-        -- for each possibility after the case runs.
-        <$> replicateM (pred n) ((,) <$> genPath <*> genPath)
-        -- For the last case, we generate a single tag for both, to result in a
-        -- fully-connected graph:
-        <*> replicateM 1        (genPath <&> \p -> (p, p))
+    -- Generate failure and success paths for each case. We generate and tag
+    -- the final failure path, but don't include it in the graph.
+    pathPairs <- replicateM n ((,) <$> genPath <*> genPath)
 
     let (failurePaths, successPaths) = unzip pathPairs
         -- we don't start a new path for the first case -- we *always* run it:

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -858,6 +858,18 @@ spec = describe "analyze" $ do
 
     expectPass code $ Valid Success'
 
+  describe "enforce-one.single-case-regression" $ do
+    let code =
+          [text|
+            (defun test:bool ()
+              (enforce-one "regression" [true]))
+          |]
+    expectPass code $ Satisfiable true
+    expectFail code $ Satisfiable Abort'
+    expectFail code $ Valid Abort'
+    expectPass code $ Satisfiable Success'
+    expectPass code $ Valid Success'
+
   describe "logical short-circuiting" $ do
     describe "and" $ do
       let code =


### PR DESCRIPTION
Fixes #292.

In the event of a single case, we were tagging a single path shared between both success and failure with mutually exclusive constraints. Now we generate two paths for the exit from the final case, but don't
include the failure path in the graph.