### PR TITLE
Fix model extraction for arguments

### DIFF
--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -290,7 +290,7 @@ verifyFunctionInvariants' funName funInfo tables pactArgs body = runExceptT $ do
 
     ExceptT $ catchingExceptions $ runSymbolic $ runExceptT $ do
       modelArgs' <- lift $ runAlloc $ allocArgs args
-      tags <- lift $ runAlloc $ allocModelTags (Located funInfo tm) graph
+      tags <- lift $ runAlloc $ allocModelTags modelArgs' (Located funInfo tm) graph
       let rootPath = _egRootPath graph
       resultsTable <- withExceptT analyzeToCheckFailure $
         runInvariantAnalysis tables (analysisArgs modelArgs') tm rootPath tags
@@ -348,7 +348,7 @@ verifyFunctionProperty funName funInfo tables pactArgs body (Located propInfo ch
           runTranslation funName funInfo pactArgs body
       ExceptT $ catchingExceptions $ runSymbolic $ runExceptT $ do
         modelArgs' <- lift $ runAlloc $ allocArgs args
-        tags <- lift $ runAlloc $ allocModelTags (Located funInfo tm) graph
+        tags <- lift $ runAlloc $ allocModelTags modelArgs' (Located funInfo tm) graph
         let rootPath = _egRootPath graph
         AnalysisResult _querySucceeds prop ksProvs
           <- withExceptT analyzeToCheckFailure $

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -1428,8 +1428,8 @@ spec = describe "analyze" $ do
                 (defun test:bool (x:integer)
                   (let ((x (let ((y 2)) y))
                         (y (let ((x 3)) x)))
-                   (let ((z (let ((w 1)) (+ (+ x y) w))))
-                     (enforce (= 6 z) "2 + 3 + 1 != 6"))))
+                    (let ((z (let ((w 1)) (+ (+ x y) w))))
+                      (enforce (= 6 z) "2 + 3 + 1 != 6"))))
               |]
         in expectPass code $ Valid $ bnot Abort'
 


### PR DESCRIPTION
Fixes #293.

`traverse translateBinding pactArgs` in translation was generating a
superfluous set of variables for arguments. Additionally now `allocVars`
in `allocModelTags` will reuse variables already allocated for
arguments.