### PR TITLE
Improve compiler, remove TBless, TImplements, fix meta bug

### DIFF
--- a/src-ghc/Pact/PersistPactDb/Regression.hs
+++ b/src-ghc/Pact/PersistPactDb/Regression.hs
@@ -45,7 +45,7 @@ runRegression p = do
   let ks = KeySet [PublicKey "skdjhfskj"] (Name "predfun" def)
   _writeRow pactdb Write KeySets "ks1" ks v
   assertEquals' "keyset write" (Just ks) $ _readRow pactdb KeySets "ks1" v
-  let mod' = Module "mod1" "mod-admin-keyset" (Meta Nothing []) "code" (H.hash "code") mempty mempty
+  let mod' = Module "mod1" "mod-admin-keyset" (Meta Nothing []) "code" (H.hash "code") mempty mempty mempty
   _writeRow pactdb Write Modules "mod1" mod' v
   assertEquals' "module write" (Just mod') $ _readRow pactdb Modules "mod1" v
   assertEquals' "result of commit 3"

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -44,9 +44,9 @@ import Control.Lens hiding (prism)
 import Data.Maybe
 import Data.Default
 import Data.Text (Text,pack,unpack)
-import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import qualified Data.HashSet as HS
+import qualified Data.HashMap.Strict as HM
 
 import Pact.Types.ExpParser
 import Pact.Types.Exp
@@ -69,13 +69,59 @@ type Compile a = ExpParse CompileState a
 initParseState :: Exp Info -> ParseState CompileState
 initParseState e = ParseState e $ CompileState 0 Nothing
 
+data Reserved =
+    RBless
+  | RDefconst
+  | RDefpact
+  | RDefschema
+  | RDeftable
+  | RDefun
+  | RFalse
+  | RImplements
+  | RInterface
+  | RLet
+  | RLetStar
+  | RModule
+  | RStep
+  | RStepWithRollback
+  | RTrue
+  | RUse
+  deriving (Eq,Enum,Bounded)
+
+instance AsString Reserved where
+  asString a = case a of
+    RBless -> "bless"
+    RDefconst -> "defconst"
+    RDefpact -> "defpact"
+    RDefschema -> "defschema"
+    RDeftable -> "deftable"
+    RDefun -> "defun"
+    RFalse -> "false"
+    RImplements -> "implements"
+    RInterface -> "interface"
+    RLet -> "let"
+    RLetStar -> "let*"
+    RModule -> "module"
+    RStep -> "step"
+    RStepWithRollback -> "step-with-rollback"
+    RTrue -> "true"
+    RUse -> "use"
+
+instance Show Reserved where show = unpack . asString
+
+reserveds :: HM.HashMap Text Reserved
+reserveds = (`foldMap` [minBound .. maxBound]) $ \r -> HM.singleton (asString r) r
 
 reserved :: [Text]
-reserved =
-  T.words "use module defun defpact step step-with-rollback true false let let* defconst interface implements"
+reserved = HM.keys reserveds
+
+reservedAtom :: Compile Reserved
+reservedAtom = bareAtom >>= \AtomExp{..} -> case HM.lookup _atomAtom reserveds of
+  Nothing -> expected "reserved word"
+  Just r -> return r
 
 compile :: MkInfo -> Exp Parsed -> Either PactError (Term Name)
-compile mi e = let ei = mi <$> e in runCompile term (initParseState ei) ei
+compile mi e = let ei = mi <$> e in runCompile topLevel (initParseState ei) ei
 
 compileExps :: Traversable t => MkInfo -> t (Exp Parsed) -> Either PactError (t (Term Name))
 compileExps mi exps = sequence $ compile mi <$> exps
@@ -100,14 +146,54 @@ cToTV n | n < 26 = fromString [toC n]
   where toC i = toEnum (fromEnum 'a' + i)
 
 
-term :: Compile (Term Name)
-term =
+sexp :: (Compile (Term Name)) -> Compile (Term Name)
+sexp body = withList' Parens (body <* eof)
+
+specialFormOrApp :: (Reserved -> Compile (Compile (Term Name))) -> Compile (Term Name)
+specialFormOrApp forms = sexp (sf <|> app) where
+  sf = reservedAtom >>= forms >>= \a -> commit >> a
+
+specialForm :: (Reserved -> Compile (Compile (Term Name))) -> Compile (Term Name)
+specialForm forms = sexp $ reservedAtom >>= forms >>= \a -> commit >> a
+
+
+topLevel :: Compile (Term Name)
+topLevel = specialFormOrApp topLevelForm <|> literals <|> varAtom  where
+  topLevelForm r = case r of
+    RUse -> return useForm
+    RLet -> return letForm
+    RLetStar -> return letsForm
+    RModule -> return moduleForm
+    RInterface -> return interface
+    _ -> expected "top-level form (use, let[*], module, interface)"
+
+
+valueLevel :: Compile (Term Name)
+valueLevel = literals <|> varAtom <|> specialFormOrApp valueLevelForm where
+  valueLevelForm r = case r of
+    RLet -> return letForm
+    RLetStar -> return letsForm
+    _ -> expected "value level form (let, let*)"
+
+moduleLevel :: Compile (Term Name)
+moduleLevel = specialForm $ \r -> case r of
+    RUse -> return useForm
+    RDefconst -> return defconst
+    RBless -> return bless
+    RDeftable -> return deftable
+    RDefschema -> return defschema
+    RDefun -> return defun
+    RDefpact -> return defpact
+    RImplements -> return implements
+    _ -> expected "module level form (use, def..., special form)"
+
+
+literals :: Compile (Term Name)
+literals =
   literal
-  <|> varAtom
-  <|> withList' Parens
-    ((specialForm <|> app) <* eof)
   <|> listLiteral
   <|> objectLiteral
+
 
 -- | User-available atoms (excluding reserved words).
 userAtom :: Compile (AtomExp Info)
@@ -116,29 +202,12 @@ userAtom = do
   when (_atomAtom `elem` reserved) $ unexpected' "reserved word"
   pure a
 
-specialForm :: Compile (Term Name)
-specialForm = bareAtom >>= \AtomExp{..} -> case _atomAtom of
-    "use" -> commit >> useForm
-    "let" -> commit >> letForm
-    "let*" -> commit >> letsForm
-    "defconst" -> commit >> defconst
-    "step" -> commit >> step
-    "step-with-rollback" -> commit >> stepWithRollback
-    "bless" -> commit >> bless
-    "deftable" -> commit >> deftable
-    "defschema" -> commit >> defschema
-    "defun" -> commit >> defun
-    "defpact" -> commit >> defpact
-    "module" -> commit >> moduleForm
-    "interface" -> commit >> interface
-    "implements" -> commit >> implements
-    _ -> expected "special form"
 
 
 app :: Compile (Term Name)
 app = do
   v <- varAtom
-  body <- many (term <|> bindingForm)
+  body <- many (valueLevel <|> bindingForm)
   TApp v body <$> contextInfo
 
 -- | Bindings (`{ "column" := binding }`) do not syntactically scope the
@@ -149,12 +218,12 @@ app = do
 bindingForm :: Compile (Term Name)
 bindingForm = do
   let pair = do
-        col <- term
+        col <- valueLevel
         a <- sep ColonEquals *> arg
         return (a,col)
   (bindings,bi) <- withList' Braces $
     (,) <$> pair `sepBy1` sep Comma <*> contextInfo
-  TBinding bindings <$> abstractBody (map fst bindings) <*>
+  TBinding bindings <$> abstractBody valueLevel (map fst bindings) <*>
     pure (BindSchema TyAny) <*> pure bi
 
 varAtom :: Compile (Term Name)
@@ -173,8 +242,8 @@ varAtom = do
 listLiteral :: Compile (Term Name)
 listLiteral = withList Brackets $ \ListExp{..} -> do
   ls <- case _listList of
-    _ : CommaExp : _ -> term `sepBy` sep Comma
-    _                -> many term
+    _ : CommaExp : _ -> valueLevel `sepBy` sep Comma
+    _                -> many valueLevel
   let lty = case nub (map typeof ls) of
               [Right ty] -> ty
               _ -> TyAny
@@ -183,8 +252,8 @@ listLiteral = withList Brackets $ \ListExp{..} -> do
 objectLiteral :: Compile (Term Name)
 objectLiteral = withList Braces $ \ListExp{..} -> do
   let pair = do
-        key <- term
-        val <- sep Colon *> term
+        key <- valueLevel
+        val <- sep Colon *> valueLevel
         return (key,val)
   ps <- pair `sepBy` sep Comma
   return $ TObject ps TyAny _listInfo
@@ -213,7 +282,7 @@ defconst :: Compile (Term Name)
 defconst = do
   modName <- currentModule'
   a <- arg
-  v <- term
+  v <- valueLevel
 
   m <- meta ModelNotAllowed
   TConst a modName (CVRaw v) m <$> contextInfo
@@ -222,24 +291,29 @@ data ModelAllowed
   = ModelAllowed
   | ModelNotAllowed
 
+data AtPair = DocPair Text | ModelPair [Exp Info] deriving (Eq,Ord)
+
 meta :: ModelAllowed -> Compile Meta
 meta modelAllowed = atPairs <|> try docStr <|> return def
   where
     docStr = Meta <$> (Just <$> str) <*> pure []
-    docPair = symbol "@doc" >> str
+    docPair = symbol "@doc" >> (DocPair <$> str)
     modelPair = do
       symbol "@model"
       (ListExp exps _ _i, _) <- list' Brackets
-      pure exps
+      pure (ModelPair exps)
+    whenModelAllowed a = case modelAllowed of
+      ModelAllowed -> a
+      ModelNotAllowed -> unexpected' "@model not allowed in this declaration"
     atPairs = do
-      doc <- optional (try docPair)
-      model <- optional (try modelPair)
-      case (doc, model, modelAllowed) of
-        (Nothing, Nothing    , ModelAllowed   ) -> expected "@doc or @model declarations"
-        (Nothing, Nothing    , ModelNotAllowed) -> expected "@doc declaration"
-        (_      , Just model', ModelAllowed   ) -> return (Meta doc model')
-        (_      , Just _     , ModelNotAllowed) -> syntaxError "@model not allowed in this declaration"
-        (_      , Nothing    , _              ) -> return (Meta doc [])
+      ps <- sort <$> (some (docPair <|> modelPair))
+      case ps of
+        [DocPair doc] -> return (Meta (Just doc) [])
+        [ModelPair es] -> whenModelAllowed $ return (Meta Nothing es)
+        [DocPair doc, ModelPair es] -> whenModelAllowed $ return (Meta (Just doc) es)
+        _ -> expected $ case modelAllowed of
+          ModelNotAllowed -> "@doc declaration"
+          ModelAllowed -> "@doc and/or @model declarations"
 
 defschema :: Compile (Term Name)
 defschema = do
@@ -256,7 +330,7 @@ defun = do
   args <- withList' Parens $ many arg
   m <- meta ModelAllowed
   TDef defname modName Defun (FunType args returnTy)
-    <$> abstractBody args <*> pure m <*> contextInfo
+    <$> abstractBody valueLevel args <*> pure m <*> contextInfo
 
 defpact :: Compile (Term Name)
 defpact = do
@@ -264,9 +338,9 @@ defpact = do
   (defname,returnTy) <- first _atomAtom <$> typedAtom
   args <- withList' Parens $ many arg
   m <- meta ModelAllowed
-  (body,bi) <- bodyForm'
-  forM_ body $ \t -> case t of
-    TStep {} -> return ()
+  (body,bi) <- bodyForm' $ specialForm $ \r -> case r of
+    RStep -> return step
+    RStepWithRollback -> return stepWithRollback
     _ -> expected "step or step-with-rollback"
   TDef defname modName Defpact (FunType args returnTy)
     (abstractBody' args (TList body TyAny bi)) m <$> contextInfo
@@ -286,7 +360,7 @@ moduleForm = do
       modName = ModuleName modName'
       modHash = hash $ encodeUtf8 $ _unCode code
   (psUser . csModule) .= Just (modName,modHash)
-  (bd,bi) <- bodyForm'
+  (bd,bi) <- bodyForm' moduleLevel
   blessed <- fmap (HS.fromList . concat) $ forM bd $ \d -> case d of
     TDef {} -> return []
     TNative {} -> return []
@@ -325,21 +399,14 @@ interface = do
       iname = ModuleName iname'
       ihash = hash $ encodeUtf8 (_unCode code)
   (psUser . csModule) .= Just (iname, ihash)
-  (defs, defInfo) <- interfaceForm
+  bd <- bodyForm $ specialForm $ \r -> case r of
+        RDefun -> return emptyDef
+        RDefconst -> return defconst
+        RUse -> return useForm
+        t -> syntaxError $ "Invalid interface declaration: " ++ show (asString t)
   return $ TModule
     (Interface iname code m)
-    (abstract (const Nothing) (TList defs TyAny defInfo)) info
-
-interfaceForm :: Compile ([Term Name], Info)
-interfaceForm = (,) <$> some interfaceForms <*> contextInfo
-  where
-    interfaceForms = withList' Parens $ do
-      AtomExp{..} <- bareAtom
-      case _atomAtom of
-        "defun" -> commit >> emptyDef
-        "defconst" -> commit >> defconst
-        "use" -> commit >> useForm
-        t -> syntaxError $ "Invalid interface declaration: " ++ unpack t
+    (abstract (const Nothing) bd) info
 
 emptyDef :: Compile (Term Name)
 emptyDef = do
@@ -355,24 +422,25 @@ emptyDef = do
 
 step :: Compile (Term Name)
 step = do
-  cont <- try (TStep <$> (Just <$> term) <*> term) <|>
-          (TStep Nothing <$> term)
+  cont <- try (TStep <$> (Just <$> valueLevel) <*> valueLevel) <|>
+          (TStep Nothing <$> valueLevel)
   cont <$> pure Nothing <*> contextInfo
 
 stepWithRollback :: Compile (Term Name)
 stepWithRollback = do
-  try (TStep <$> (Just <$> term) <*> term <*> (Just <$> term) <*> contextInfo) <|>
-      (TStep Nothing <$> term <*> (Just <$> term) <*> contextInfo)
+  try (TStep <$> (Just <$> valueLevel) <*> valueLevel <*>
+         (Just <$> valueLevel) <*> contextInfo)
+  <|> (TStep Nothing <$> valueLevel <*> (Just <$> valueLevel) <*> contextInfo)
 
 
 
 letBindings :: Compile [(Arg (Term Name),Term Name)]
 letBindings = withList' Parens $
               some $ withList' Parens $
-              (,) <$> arg <*> term
+              (,) <$> arg <*> valueLevel
 
-abstractBody :: [Arg (Term Name)] -> Compile (Scope Int Term Name)
-abstractBody args = abstractBody' args <$> bodyForm
+abstractBody :: Compile (Term Name) -> [Arg (Term Name)] -> Compile (Scope Int Term Name)
+abstractBody term args = abstractBody' args <$> bodyForm term
 
 abstractBody' :: [Arg (Term Name)] -> Term Name -> Scope Int Term Name
 abstractBody' args = abstract (`elemIndex` bNames)
@@ -382,7 +450,7 @@ abstractBody' args = abstract (`elemIndex` bNames)
 letForm :: Compile (Term Name)
 letForm = do
   bindings <- letBindings
-  TBinding bindings <$> abstractBody (map fst bindings) <*>
+  TBinding bindings <$> abstractBody valueLevel (map fst bindings) <*>
     pure BindLet <*> contextInfo
 
 -- | let* is a macro to nest lets for referencing previous
@@ -393,7 +461,7 @@ letsForm = do
   let nest (binding:rest) = do
         let bName = [arg2Name (fst binding)]
         scope <- abstract (`elemIndex` bName) <$> case rest of
-          [] -> bodyForm
+          [] -> bodyForm valueLevel
           _ -> do
             rest' <- nest rest
             pure $ TList [rest'] TyAny def
@@ -454,23 +522,26 @@ parseUserSchemaType = withList Braces $ \ListExp{..} -> do
   AtomExp{..} <- userAtom
   return $ TyUser (return $ Name _atomAtom _listInfo)
 
-bodyForm :: Compile (Term Name)
-bodyForm = do
-  (bs,i) <- bodyForm'
+bodyForm :: Compile (Term Name) -> Compile (Term Name)
+bodyForm term = do
+  (bs,i) <- bodyForm' term
   return $ TList bs TyAny i
 
-bodyForm' :: Compile ([Term Name],Info)
-bodyForm' = (,) <$> some term <*> contextInfo
+bodyForm' :: Compile (Term Name) -> Compile ([Term Name],Info)
+bodyForm' term = (,) <$> some term <*> contextInfo
 
 _compileAccounts :: IO (Either PactError [Term Name])
-_compileAccounts = _parseF "examples/accounts/accounts.pact" >>= _compile id
+_compileAccounts = _compileF "examples/accounts/accounts.pact"
+
+_compileF :: FilePath -> IO (Either PactError [Term Name])
+_compileF f = _parseF f >>= _compile id
 
 _compile :: (ParseState CompileState -> ParseState CompileState) ->
             TF.Result ([Exp Parsed],String) -> IO (Either PactError [Term Name])
 _compile _ (TF.Failure f) = putDoc (TF._errDoc f) >> error "Parse failed"
 _compile sfun (TF.Success (a,s)) = return $ forM a $ \e ->
   let ei = mkStringInfo s <$> e
-  in runCompile term (sfun (initParseState ei)) ei
+  in runCompile topLevel (sfun (initParseState ei)) ei
 
 -- | run a string as though you were in a module (test deftable, etc)
 _compileStrInModule :: String -> IO [Term Name]

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -139,8 +139,8 @@ topLevelCall i name gasArgs action = call (StackFrame name i Nothing) $
 
 -- | Evaluate top-level term.
 eval ::  Term Name ->  Eval e (Term Name)
-eval (TUse mn h i) = topLevelCall i "use" (GUse mn h) $ \g ->
-  evalUse mn h i >> return (g,tStr $ pack $ "Using " ++ show mn)
+eval (TUse u@Use{..} i) = topLevelCall i "use" (GUse _uModuleName _uModuleHash) $ \g ->
+  evalUse u >> return (g,tStr $ pack $ "Using " ++ show _uModuleName)
 eval (TModule m@Module{..} bod i) =
   topLevelCall i "module" (GModule m) $ \g0 -> do
     -- enforce old module keysets
@@ -170,11 +170,11 @@ eval (TModule m@Interface{..} bod i) =
           Interface{..} -> return ()
     (g, _) <- loadModule m bod i gas
     writeRow i Write Modules _interfaceName m
-    return $ (g, msg $ pack $ "Loaded interface " ++ show _interfaceName)
+    return (g, msg $ pack $ "Loaded interface " ++ show _interfaceName)
 eval t = enscope t >>= reduce
 
-evalUse :: ModuleName -> Maybe Hash -> Info -> Eval e ()
-evalUse mn h i = do
+evalUse :: Use -> Eval e ()
+evalUse (Use mn h i) = do
   mm <- preview $ eeRefStore . rsModules . ix mn
   case mm of
     Nothing -> evalError i $ "Module " ++ show mn ++ " not found"
@@ -205,9 +205,7 @@ loadModule m@Module{..} bod1 mi g0 = do
                 TConst {..} -> return $ Just $ _aName _tConstArg
                 TSchema {..} -> return $ Just $ asString _tSchemaName
                 TTable {..} -> return $ Just $ asString _tTableName
-                TUse {..} -> evalUse _tModuleName _tModuleHash _tInfo >> return Nothing
-                TBless {..} -> return Nothing
-                TImplements {..} -> return $ Just (asString _tInterfaceName)
+                TUse (Use {..}) _ -> return Nothing
                 _ -> evalError (_tInfo t) "Invalid module member"
               case dnm of
                 Nothing -> return (g, rs)
@@ -216,6 +214,7 @@ loadModule m@Module{..} bod1 mi g0 = do
                   return (g + g',(dn,t):rs)
         second HM.fromList <$> foldM doDef (g0,[]) bd
       t -> evalError (_tInfo t) "Malformed module"
+  mapM_ evalUse _mImports
   evaluatedDefs <- evaluateDefs mi modDefs1
   evaluateConstraints mi m evaluatedDefs
   let md = ModuleData m evaluatedDefs
@@ -230,7 +229,7 @@ loadModule i@Interface{..} body info gas0 = do
               TDef {..} -> return $ Just _tDefName
               TConst {..} -> return $ Just $ _aName _tConstArg
               TSchema {..} -> return $ Just $ asString _tSchemaName
-              TUse {..} -> evalUse _tModuleName _tModuleHash _tInfo >> return Nothing
+              TUse (Use {..}) _ -> return Nothing
               _ -> evalError (_tInfo t) "Invalid interface member"
             case dnm of
               Nothing -> return (g, rs)
@@ -239,6 +238,7 @@ loadModule i@Interface{..} body info gas0 = do
                 return (g + g',(dn,t):rs)
       second HM.fromList <$> foldM doDef (gas0,[]) bd
     t -> evalError (_tInfo t) "Malformed interface"
+  mapM_ evalUse _interfaceImports
   evaluatedDefs <- evaluateDefs info idefs
   let md = ModuleData i evaluatedDefs
   installModule md
@@ -284,7 +284,7 @@ evaluateConstraints
   -> HM.HashMap Text Ref
   -> Eval e ()
 evaluateConstraints info Interface{} _ =
-  evalError info $ "Unexpected: interface found in module position while solving constraints"
+  evalError info "Unexpected: interface found in module position while solving constraints"
 evaluateConstraints info Module{..} evalMap = foldMap evaluateConstraint _mInterfaces
   where
     evaluateConstraint ifn = do
@@ -320,7 +320,6 @@ solveConstraint info em refName (Ref t) _ =
           forM_ (args `zip` args') $ \((Arg n ty _), (Arg n' ty' _)) -> do
             when (n /= n') $ evalError info $ "mismatching argument names: " ++ show n ++ " and " ++ show n'
             when (ty /= ty') $ evalError info $ "mismatching types: " ++ show ty ++ " and " ++ show ty'
-            return ()
         _ -> evalError info $ "found overlapping const refs - please resolve: " ++ show t
 
 resolveRef :: Name -> Eval e (Maybe Ref)
@@ -382,11 +381,9 @@ reduce (TBinding ps bod c i) = case c of
   BindSchema _ -> evalError i "Unexpected schema binding"
 reduce t@TModule{} = evalError (_tInfo t) "Modules and Interfaces only allowed at top level"
 reduce t@TUse {} = evalError (_tInfo t) "Use only allowed at top level"
-reduce t@TBless {} = evalError (_tInfo t) "Bless only allowed at top level"
 reduce t@TStep {} = evalError (_tInfo t) "Step at invalid location"
 reduce TSchema {..} = TSchema _tSchemaName _tModule _tMeta <$> traverse (traverse reduce) _tFields <*> pure _tInfo
 reduce TTable {..} = TTable _tTableName _tModule _tHash <$> mapM reduce _tTableType <*> pure _tMeta <*> pure _tInfo
-reduce t@TImplements{} = evalError (_tInfo t) "Interface implementations only allowed at top level"
 
 mkDirect :: Term Name -> Term Ref
 mkDirect = (`TVar` def) . Direct
@@ -509,7 +506,7 @@ instantiate' = instantiate1 (toTerm ("No bindings" :: Text))
 -- Output checking -- app return values -- left to static TC.
 -- Native funs not checked here, as they use pattern-matching etc.
 typecheck :: [(Arg (Term Name),Term Name)] -> Eval e ()
-typecheck ps = void $ foldM tvarCheck M.empty ps where
+typecheck ps = foldM_ tvarCheck M.empty ps where
   tvarCheck m (Arg {..},t) = do
     r <- typecheckTerm _aInfo _aType t
     case r of

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -770,7 +770,6 @@ toAST TTable {..} = do
     <*> pure _tTableName
 toAST TModule {..} = die _tInfo "Modules not supported"
 toAST TUse {..} = die _tInfo "Use not supported"
-toAST TBless {..} = die _tInfo "Bless not supported"
 toAST TStep {..} = do
   ent <- forM _tStepEntity $ \e -> do
     e' <- toAST e
@@ -781,7 +780,6 @@ toAST TStep {..} = do
   ex <- toAST _tStepExec
   assocAST si ex
   Step sn ent ex <$> traverse toAST _tStepRollback
-toAST TImplements{..} = die _tInfo "Implements not supported"
 
 trackPrim :: Info -> PrimType -> PrimValue -> TC (AST Node)
 trackPrim inf pty v = do

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -35,17 +35,18 @@ module Pact.Types.Term
    NativeDFun(..),
    BindType(..),
    TableName(..),
-   Module(..),mName,mKeySet,mMeta,mCode,mHash,mBlessed,mInterfaces,
-   interfaceCode, interfaceMeta, interfaceName,
+   Module(..),mName,mKeySet,mMeta,mCode,mHash,mBlessed,mInterfaces,mImports,
+   interfaceCode, interfaceMeta, interfaceName, interfaceImports,
    ModuleName(..),
    Name(..),
    ConstVal(..),
+   Use(..),
    Term(..),
-   tAppArgs,tAppFun,tBindBody,tBindPairs,tBindType,tBlessed,tConstArg,tConstVal,
+   tAppArgs,tAppFun,tBindBody,tBindPairs,tBindType,tConstArg,tConstVal,
    tDefBody,tDefName,tDefType,tMeta,tFields,tFunTypes,tFunType,tHash,tInfo,tKeySet,
-   tListType,tList,tLiteral,tModuleBody,tModuleDef,tModuleName,tModuleHash,tModule,
+   tListType,tList,tLiteral,tModuleBody,tModuleDef,tModule,tUse,
    tNativeDocs,tNativeFun,tNativeName,tNativeTopLevelOnly,tObjectType,tObject,tSchemaName,
-   tStepEntity,tStepExec,tStepRollback,tTableName,tTableType,tValue,tVar,tInterfaceName,
+   tStepEntity,tStepExec,tStepRollback,tTableName,tTableType,tValue,tVar,
    ToTerm(..),
    toTermList,toTObject,toTList,
    typeof,typeof',
@@ -155,7 +156,7 @@ data FunApp = FunApp {
     , _faTypes :: !(FunTypes (Term Name))
     , _faDocs :: !(Maybe Text)
     }
-            
+
 
 instance Show FunApp where
   show FunApp {..} =
@@ -254,7 +255,17 @@ instance Ord Name where
   (Name a _) `compare` (Name b _) = a `compare` b
   Name {} `compare` QName {} = LT
   QName {} `compare` Name {} = GT
-  
+
+
+data Use = Use
+  { _uModuleName :: !ModuleName
+  , _uModuleHash :: !(Maybe Hash)
+  , _uInfo :: !Info
+  } deriving (Eq)
+instance Show Use where
+  show Use {..} = "(use " ++ show _uModuleName ++ maybeDelim " " _uModuleHash ++ ")"
+
+
 
 -- TODO: We need a more expressive, safer ADT for this.
 data Module
@@ -266,11 +277,13 @@ data Module
  , _mHash :: !Hash
  , _mBlessed :: !(HS.HashSet Hash)
  , _mInterfaces :: [ModuleName]
+ , _mImports :: [Use]
  }
  | Interface
  { _interfaceName :: !ModuleName
  , _interfaceCode :: !Code
  , _interfaceMeta :: !Meta
+ , _interfaceImports :: [Use]
  } deriving Eq
 
 instance Show Module where
@@ -278,7 +291,7 @@ instance Show Module where
     Module{..} -> "(Module " ++ asString' _mName ++ " '" ++ asString' _mKeySet ++ " " ++ show _mHash ++ ")"
     Interface{..} -> "(Interface " ++ asString' _interfaceName ++ ")"
 
-                     
+
 instance ToJSON Module where
   toJSON Module{..} = object
     [ "name" .= _mName
@@ -304,6 +317,7 @@ instance FromJSON Module where
     <*> o .: "hash"
     <*> (HS.fromList <$> o .: "blessed")
     <*> o .: "interfaces"
+    <*> pure []
 
 data ConstVal n =
   CVRaw { _cvRaw :: !n } |
@@ -392,13 +406,8 @@ data Term n =
     , _tInfo :: !Info
     } |
     TUse {
-      _tModuleName :: !ModuleName
-    , _tModuleHash :: !(Maybe Hash)
-    , _tInfo :: !Info
-    } |
-    TBless {
-      _tBlessed :: !Hash
-    , _tInfo :: !Info
+      _tUse :: Use
+    , _tInfo :: Info
     } |
     TValue {
       _tValue :: !Value
@@ -416,11 +425,6 @@ data Term n =
     , _tHash :: !Hash
     , _tTableType :: !(Type (Term n))
     , _tMeta :: !Meta
-    , _tInfo :: !Info
-    } |
-    TImplements {
-      _tInterfaceName :: !ModuleName
-    , _tModuleName :: !ModuleName
     , _tInfo :: !Info
     }
     deriving (Functor,Foldable,Traversable,Eq)
@@ -443,8 +447,7 @@ instance Show n => Show (Term n) where
       "{" ++ intercalate ", " (map (\(a,b) -> show a ++ ": " ++ show b) bs) ++ "}"
     show (TLiteral l _) = show l
     show (TKeySet k _) = show k
-    show (TUse m h _) = "(TUse " ++ show m ++ maybeDelim " " h ++ ")"
-    show (TBless hs _) = "(TBless " ++ show hs ++ ")"
+    show (TUse u _) = show u
     show (TValue v _) = BSL.toString $ encode v
     show (TStep ent e r _) =
       "(TStep " ++ show ent ++ " " ++ show e ++ maybeDelim " " r ++ ")"
@@ -454,8 +457,6 @@ instance Show n => Show (Term n) where
     show TTable {..} =
       "(TTable " ++ asString' _tModule ++ "." ++ asString' _tTableName ++ ":" ++ show _tTableType
       ++ " " ++ show _tMeta ++ ")"
-    show TImplements{..} =
-      "(TImplements " ++ show _tInterfaceName ++ ")"
 
 showParamType :: Show n => Type n -> String
 showParamType TyAny = ""
@@ -485,9 +486,7 @@ instance Eq1 Term where
     a == m && b == n
   liftEq _ (TKeySet a b) (TKeySet m n) =
     a == m && b == n
-  liftEq _ (TUse a b c) (TUse m n o) =
-    a == m && b == n && c == o
-  liftEq _ (TBless a b) (TBless m n) =
+  liftEq _ (TUse a b) (TUse m n) =
     a == m && b == n
   liftEq _ (TValue a b) (TValue m n) =
     a == m && b == n
@@ -497,7 +496,6 @@ instance Eq1 Term where
     a == m && b == n && c == o && liftEq (liftEq (liftEq eq)) d p && e == q
   liftEq eq (TTable a b c d e f) (TTable m n o p q r) =
     a == m && b == n && c == o && liftEq (liftEq eq) d p && e == q && f == r
-  liftEq _ (TImplements ifs mn i) (TImplements ifs' mn' i') = ifs == ifs' && mn == mn' && i == i'
   liftEq _ _ _ = False
 
 
@@ -518,13 +516,11 @@ instance Monad Term where
     TObject bs t i >>= f = TObject (map ((>>= f) *** (>>= f)) bs) (fmap (>>= f) t) i
     TLiteral l i >>= _ = TLiteral l i
     TKeySet k i >>= _ = TKeySet k i
-    TUse m h i >>= _ = TUse m h i
-    TBless hs i >>= _ = TBless hs i
+    TUse u i >>= _ = TUse u i
     TValue v i >>= _ = TValue v i
     TStep ent e r i >>= f = TStep (fmap (>>= f) ent) (e >>= f) (fmap (>>= f) r) i
     TSchema {..} >>= f = TSchema _tSchemaName _tModule _tMeta (fmap (fmap (>>= f)) _tFields) _tInfo
     TTable {..} >>= f = TTable _tTableName _tModule _tHash (fmap (>>= f) _tTableType) _tMeta _tInfo
-    TImplements ifs mn i >>= _ = TImplements ifs mn i 
 
 
 instance FromJSON (Term n) where
@@ -589,12 +585,10 @@ typeof t = case t of
       TObject {..} -> Right $ TySchema TyObject _tObjectType
       TKeySet {} -> Right $ TyPrim TyKeySet
       TUse {} -> Left "use"
-      TBless {} -> Left "bless"
       TValue {} -> Right $ TyPrim TyValue
       TStep {} -> Left "step"
       TSchema {..} -> Left $ "defobject:" <> asString _tSchemaName
       TTable {..} -> Right $ TySchema TyTable _tTableType
-      TImplements{} -> Left "implements"
 {-# INLINE typeof #-}
 
 -- | Return string type description.
@@ -648,14 +642,12 @@ abbrev TBinding {} = "<binding>"
 abbrev TObject {..} = "<object" ++ showParamType _tObjectType ++ ">"
 abbrev (TLiteral l _) = show l
 abbrev TKeySet {} = "<keyset>"
-abbrev (TUse m h _) = "<use '" ++ show m ++ maybeDelim " " h ++ ">"
-abbrev TBless {} = "<bless ...>"
+abbrev (TUse (Use m h _) _) = "<use '" ++ show m ++ maybeDelim " " h ++ ">"
 abbrev (TVar s _) = show s
 abbrev (TValue v _) = show v
 abbrev TStep {} = "<step>"
 abbrev TSchema {..} = "<defschema " ++ asString' _tSchemaName ++ ">"
 abbrev TTable {..} = "<deftable " ++ asString' _tTableName ++ ">"
-abbrev TImplements{..} = "<implements " ++ show _tInterfaceName ++ ">"
 
 
 

--- a/tests/pact/meta.repl
+++ b/tests/pact/meta.repl
@@ -12,6 +12,16 @@
     "docstrings work without @doc"
     2)
 
+  (defun docmodel ()
+    @doc "stuff"
+    @model [(property stuff)]
+    3)
+
+  (defun modeldoc ()
+    @model [(property stuff)]
+    @doc "stuff"
+    4)
+
   (defconst BAR 1 @doc "barring disbelief")
 
   (defconst BAZ 2 "docstrings work without @doc")


### PR DESCRIPTION
[more ambitious version of #310, I'll close that]
- move away from monolithic term to context-specific productions. ~This is the first step toward getting rid of TBless, TImplements and handling use better~
- **get rid of TBless, TImplements and handle Use better**
- new type Reserved to enumerate reserved words and to eliminate bare strings from code
- fix bug in meta parser, which only recognizes @doc -> @model (not the reverse)
- above bug was found by unifying parsing for interface, which added an eof, which revealed that a @doc pair was being silently ignored in signatures.repl
