### PR TITLE
Pact guards and capabilities

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1197,6 +1197,30 @@ Read KEY from message data body as keyset ({ "keys": KEYLIST, "pred": PREDFUN })
 
 ## Capabilities {#Capabilities}
 
+### create-module-guard {#create-module-guard}
+
+*name*&nbsp;`string` *&rarr;*&nbsp;`guard`
+
+
+Defines a guard by NAME that enforces the current module admin predicate.
+
+
+### create-pact-guard {#create-pact-guard}
+
+*name*&nbsp;`string` *&rarr;*&nbsp;`guard`
+
+
+Defines a guard predicate by NAME that captures the results of 'pact-id'. At enforcement time, the success condition is that at that time 'pact-id' must return the same value. In effect this ensures that the guard will only succeed within the multi-transaction identified by the pact id.
+
+
+### create-user-guard {#create-user-guard}
+
+*data*&nbsp;`<a>` *predfun*&nbsp;`string` *&rarr;*&nbsp;`guard`
+
+
+Defines a custom guard predicate, where DATA will be passed to PREDFUN at time of enforcement. PREDFUN is a valid name in the declaring environment. PREDFUN must refer to a pure function or enforcement will fail at runtime.
+
+
 ### enforce-guard {#enforce-guard}
 
 *guard*&nbsp;`guard` *&rarr;*&nbsp;`bool`
@@ -1209,6 +1233,14 @@ Execute GUARD, or defined keyset KEYSETNAME, to enforce desired predicate logic.
 (enforce-guard 'admin-keyset)
 (enforce-guard row-guard)
 ```
+
+
+### keyset-ref-guard {#keyset-ref-guard}
+
+*keyset-ref*&nbsp;`string` *&rarr;*&nbsp;`guard`
+
+
+Creates a guard for the keyset registered as KEYSET-REF with 'define-keyset'. Concrete keysets are themselves guard types; this function is specifically to store references alongside other guards in the database, etc.
 
 
 ### require-capability {#require-capability}
@@ -1354,6 +1386,16 @@ Set transaction signature KEYS.
 pact> (env-keys ["my-key" "admin-key"])
 "Setting transaction keys"
 ```
+
+
+### env-pactid {#env-pactid}
+
+ *&rarr;*&nbsp;`string`
+
+*id*&nbsp;`string` *&rarr;*&nbsp;`string`
+
+
+Query, or set with ID, pact state pact id.
 
 
 ### env-step {#env-step}

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1211,12 +1211,23 @@ Execute GUARD, or defined keyset KEYSETNAME, to enforce desired predicate logic.
 ```
 
 
+### require-capability {#require-capability}
+
+*capability*&nbsp;`( -> bool)` *&rarr;*&nbsp;`bool`
+
+
+Specifies and tests for existing grant of CAPABILITY, failing if not found in environment. 
+```lisp
+(require-capability (TRANSFER src dest))
+```
+
+
 ### with-capability {#with-capability}
 
 *capability*&nbsp;`( -> bool)` *body*&nbsp;`list` *&rarr;*&nbsp;`<a>`
 
 
-Specifies and requests grant of CAPABILITY which is an application of a 'defcap' production; given the unique token specified by this application, ensure that the token is granted in the environment during execution of BODY. If token is not present, the CAPABILITY is applied, with successful completion resulting in the installation/granting of the token, which will then be revoked upon completion of BODY. Nested 'with-capability' calls for the same token will detect the presence of the token, and will not re-apply CAPABILITY, but simply execute BODY. 
+Specifies and requests grant of CAPABILITY which is an application of a 'defcap' production. Given the unique token specified by this application, ensure that the token is granted in the environment during execution of BODY. 'with-capability' can only be called in the same module that declares the corresponding 'defcap', otherwise module-admin rights are required. If token is not present, the CAPABILITY is applied, with successful completion resulting in the installation/granting of the token, which will then be revoked upon completion of BODY. Nested 'with-capability' calls for the same token will detect the presence of the token, and will not re-apply CAPABILITY, but simply execute BODY. 
 ```lisp
 (with capability (update-users id) (update users id { salary: new-salary }))
 ```

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1191,6 +1191,17 @@ Read KEY from message data body as keyset ({ "keys": KEYLIST, "pred": PREDFUN })
 (read-keyset "admin-keyset")
 ```
 
+
+### with-capability {#with-capability}
+
+*capability*&nbsp;`( -> bool)` *body*&nbsp;`list` *&rarr;*&nbsp;`<a>`
+
+
+Specifies and requests grant of CAPABILITY which is an application of a 'defcap' production; given the unique token specified by this application, ensure that the token is granted in the environment during execution of BODY. If token is not present, the CAPABILITY is applied, with successful completion resulting in the installation/granting of the token, which will then be revoked upon completion of BODY. Nested 'with-capability' calls for the same token will detect the presence of the token, and will not re-apply CAPABILITY, but simply execute BODY. 
+```lisp
+(with capability (update-users id) (update users id { salary: new-salary }))
+```
+
 ## REPL-only functions {#repl-lib}
 
 The following functions are loaded automatically into the interactive REPL, or within script files with a `.repl` extension. They are not available for blockchain-based execution.

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1137,13 +1137,15 @@ Top level only: this function will fail if used in module code.
 
 ### enforce-keyset {#enforce-keyset}
 
-*keyset-or-name*&nbsp;`<k[string,keyset]>` *&rarr;*&nbsp;`bool`
+*guard*&nbsp;`guard` *&rarr;*&nbsp;`bool`
+
+*keysetname*&nbsp;`string` *&rarr;*&nbsp;`bool`
 
 
-Special form to enforce KEYSET-OR-NAME against message keys before running BODY. KEYSET-OR-NAME can be a symbol of a keyset name or a keyset object. 
+Execute GUARD, or defined keyset KEYSETNAME, to enforce desired predicate logic. 
 ```lisp
-(with-keyset 'admin-keyset ...)
-(with-keyset (read-keyset "keyset") ...)
+(enforce-keyset 'admin-keyset)
+(enforce-keyset row-guard)
 ```
 
 
@@ -1199,8 +1201,14 @@ Read KEY from message data body as keyset ({ "keys": KEYLIST, "pred": PREDFUN })
 
 *guard*&nbsp;`guard` *&rarr;*&nbsp;`bool`
 
+*keysetname*&nbsp;`string` *&rarr;*&nbsp;`bool`
 
-Execute GUARD to enforce whatever predicate is modeled. Failure will fail the transaction.
+
+Execute GUARD, or defined keyset KEYSETNAME, to enforce desired predicate logic. 
+```lisp
+(enforce-guard 'admin-keyset)
+(enforce-guard row-guard)
+```
 
 
 ### with-capability {#with-capability}

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1193,18 +1193,15 @@ Read KEY from message data body as keyset ({ "keys": KEYLIST, "pred": PREDFUN })
 (read-keyset "admin-keyset")
 ```
 
-
-### with-capability {#with-capability}
-
-*capability*&nbsp;`( -> bool)` *body*&nbsp;`list` *&rarr;*&nbsp;`<a>`
-
-
-Specifies and requests grant of CAPABILITY which is an application of a 'defcap' production; given the unique token specified by this application, ensure that the token is granted in the environment during execution of BODY. If token is not present, the CAPABILITY is applied, with successful completion resulting in the installation/granting of the token, which will then be revoked upon completion of BODY. Nested 'with-capability' calls for the same token will detect the presence of the token, and will not re-apply CAPABILITY, but simply execute BODY. 
-```lisp
-(with capability (update-users id) (update users id { salary: new-salary }))
-```
-
 ## Capabilities {#Capabilities}
+
+### enforce-guard {#enforce-guard}
+
+*guard*&nbsp;`guard` *&rarr;*&nbsp;`bool`
+
+
+Execute GUARD to enforce whatever predicate is modeled. Failure will fail the transaction.
+
 
 ### with-capability {#with-capability}
 

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1395,7 +1395,7 @@ pact> (env-keys ["my-key" "admin-key"])
 *id*&nbsp;`string` *&rarr;*&nbsp;`string`
 
 
-Query, or set with ID, pact state pact id.
+Query environment pact id, or set to ID.
 
 
 ### env-step {#env-step}

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1261,7 +1261,7 @@ Specifies and tests for existing grant of CAPABILITY, failing if not found in en
 
 Specifies and requests grant of CAPABILITY which is an application of a 'defcap' production. Given the unique token specified by this application, ensure that the token is granted in the environment during execution of BODY. 'with-capability' can only be called in the same module that declares the corresponding 'defcap', otherwise module-admin rights are required. If token is not present, the CAPABILITY is applied, with successful completion resulting in the installation/granting of the token, which will then be revoked upon completion of BODY. Nested 'with-capability' calls for the same token will detect the presence of the token, and will not re-apply CAPABILITY, but simply execute BODY. 
 ```lisp
-(with capability (update-users id) (update users id { salary: new-salary }))
+(with-capability (update-users id) (update users id { salary: new-salary }))
 ```
 
 ## REPL-only functions {#repl-lib}

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1124,8 +1124,10 @@ pact> (sqrt 25)
 
 *name*&nbsp;`string` *keyset*&nbsp;`string` *&rarr;*&nbsp;`string`
 
+*name*&nbsp;`string` *&rarr;*&nbsp;`string`
 
-Define keyset as NAME with KEYSET. If keyset NAME already exists, keyset will be enforced before updating to new value.
+
+Define keyset as NAME with KEYSET, or if unspecified, read NAME from message payload as keyset, similarly to 'read-keyset'. If keyset NAME already exists, keyset will be enforced before updating to new value.
 ```lisp
 (define-keyset 'admin-keyset (read-keyset "keyset"))
 ```
@@ -1191,6 +1193,18 @@ Read KEY from message data body as keyset ({ "keys": KEYLIST, "pred": PREDFUN })
 (read-keyset "admin-keyset")
 ```
 
+
+### with-capability {#with-capability}
+
+*capability*&nbsp;`( -> bool)` *body*&nbsp;`list` *&rarr;*&nbsp;`<a>`
+
+
+Specifies and requests grant of CAPABILITY which is an application of a 'defcap' production; given the unique token specified by this application, ensure that the token is granted in the environment during execution of BODY. If token is not present, the CAPABILITY is applied, with successful completion resulting in the installation/granting of the token, which will then be revoked upon completion of BODY. Nested 'with-capability' calls for the same token will detect the presence of the token, and will not re-apply CAPABILITY, but simply execute BODY. 
+```lisp
+(with capability (update-users id) (update users id { salary: new-salary }))
+```
+
+## Capabilities {#Capabilities}
 
 ### with-capability {#with-capability}
 

--- a/examples/accounts/accounts.pact
+++ b/examples/accounts/accounts.pact
@@ -18,8 +18,7 @@
      balance:decimal
      amount:decimal
      ccy:string
-     keyset:keyset
-     auth:string     ;; AUTH_KEYSET for keysets, pact id for pacts
+     rowguard:guard
      date:time
      data
      )
@@ -27,120 +26,121 @@
   (deftable accounts:{account}
     "Main table for accounts module.")
 
-  (defconst AUTH_KEYSET 'K
-    "Indicates keyset-governed account")
+  (defcap USER_GUARD (id)
+    (with-read accounts id { "rowguard" := g }
+               (enforce-guard g)))
 
-  (defconst ADMIN_KEYSET (read-keyset "accounts-admin-keyset"))
+  (defcap TRANSFER () true)
 
+  (defcap ADMIN ()
+    (enforce-keyset 'accounts-admin-keyset))
 
-  (defun create-account (address keyset ccy date)
-    (insert accounts address
+  (defun create-account (address guard ccy date)
+    (with-capability (ADMIN)
+      (insert accounts address
       { "balance": 0.0
       , "amount": 0.0
       , "ccy": ccy
-      , "keyset": keyset
-      , "auth": AUTH_KEYSET
+      , "rowguard": guard
       , "date": date
       , "data": "Created account"
       }
-    ))
+    )))
 
   (defun transfer (src dest amount date)
     "transfer AMOUNT from SRC to DEST"
-    (debit src amount date { "transfer-to": dest })
-    (credit dest amount date { "transfer-from": src }))
+    (with-capability (TRANSFER)
+      (debit src amount date { "transfer-to": dest })
+      (credit dest amount date { "transfer-from": src })))
 
   (defun read-account-user (id)
     "Read data for account ID"
-    (with-read accounts id
-              { "balance":= b
-              , "ccy":= c
-              , "keyset" := ks
-              , "auth" := auth }
-      (enforce-auth ks auth)
-      { "balance": b, "ccy": c }
-      ))
+    (with-capability (USER_GUARD id)
+      (with-read accounts id
+                { "balance":= b
+                , "ccy":= c }
+        { "balance": b, "ccy": c })))
+
 
   (defun read-account-admin (id)
     "Read data for account ID, admin version"
-    (enforce-keyset 'accounts-admin-keyset)
-    (read accounts id ['balance 'ccy 'keyset 'data 'date 'amount]))
+    (with-capability (ADMIN)
+      (read accounts id ['balance 'ccy 'guard 'data 'date 'amount])))
 
 
   (defun account-keys ()
     "Get all account keys"
-    (enforce-keyset 'accounts-admin-keyset)
-    (keys accounts))
+    (with-capability (ADMIN)
+      (keys accounts)))
 
   (defun check-balance (balance amount)
     (enforce (<= amount balance) "Insufficient funds"))
 
   (defun fund-account (address amount date)
-    (enforce-keyset 'accounts-admin-keyset)
-    (update accounts address
-            { "balance": amount
-            , "amount": amount
-            , "date": date
-            , "data": "Admin account funding" }
-      ))
+    (with-capability (ADMIN)
+      (update accounts address
+              { "balance": amount
+              , "amount": amount
+              , "date": date
+              , "data": "Admin account funding" }
+      )))
 
   (defun read-all ()
-    (map (read-account-admin) (keys accounts)))
+    (with-capability (ADMIN)
+      (map (read-account-admin) (keys accounts))))
 
   (defpact payment (payer payer-entity payee payee-entity amount date)
     "Debit PAYER at PAYER-ENTITY then credit PAYEE at PAYEE-ENTITY for AMOUNT on DATE"
     (step-with-rollback payer-entity
-      (debit payer amount date
+      (priv-debit payer amount date
             { "payee": payee
             , "payee-entity": payee-entity
             , PACT_REF: (pact-id)
             })
-      (credit payer amount date
+      (priv-credit payer amount date
            { PACT_REF: (pact-id), "note": "rollback" }))
 
     (step payee-entity
-      (credit payee amount date
+      (priv-credit payee amount date
             { "payer": payer
             , "payer-entity": payer-entity
             , PACT_REF: (pact-id)
             }
       )))
 
+  (defun priv-debit (id amt date note)
+    (with-capability (TRANSFER) (debit id amt date note)))
 
-  (defun enforce-auth (keyset:keyset auth)
-    (if (= auth AUTH_KEYSET)
-      (enforce-keyset keyset)
-      (enforce (= auth (format "%s" [(pact-id)]))
-        "Invalid access of pact account")))
-
+  (defun priv-credit (id amt date note)
+    (with-capability (TRANSFER) (credit id amt date note)))
 
   (defun debit (acct amount date data)
     "Debit AMOUNT from ACCT balance recording DATE and DATA"
-    (with-read accounts acct
-              { "balance":= balance
-              , "keyset" := ks
-              , "auth" := auth
-              }
-      (check-balance balance amount)
-      (enforce-auth ks auth)
-      (update accounts acct
+    (require-capability (TRANSFER))
+    (with-capability (USER_GUARD acct)
+      (with-read accounts acct
+                { "balance":= balance
+                }
+        (check-balance balance amount)
+        (update accounts acct
                 { "balance": (- balance amount)
                 , "amount": (- amount)
                 , "date": date
                 , "data": data
                 }
-          )))
+          ))))
 
  (defun credit (acct amount date data)
    "Credit AMOUNT to ACCT balance recording DATE and DATA"
-   (with-read accounts acct
-              { "balance":= balance }
-     (update accounts acct
-            { "balance": (+ balance amount)
-            , "amount": amount
-            , "date": date
-            , "data": data
-            }
+   (require-capability (TRANSFER))
+     (with-read accounts acct
+                { "balance":= balance }
+       (update accounts acct
+              { "balance": (+ balance amount)
+              , "amount": amount
+              , "date": date
+              , "data": data
+              }
       )))
 
   (defconst PACT_REF "ref")
@@ -161,44 +161,39 @@
       (finish-escrow deb-acct cred-acct
                      escrow-amount)))
 
-  (defun get-acct-keyset (acct)
-    ( with-read accounts acct { 'keyset := k } k))
-
-  (defun enforce-acct-keyset (acct)
-    (let ((k (get-acct-keyset acct)))
-      (enforce-keyset k)))
 
   (defun init-escrow (deb-acct amount)
     ;; transfer will handle deb-keyset enforce
-    (with-read accounts deb-acct { 'ccy:= ccy, 'keyset:= k }
-      (let ((pact-acct (new-pact-account ESCROW_ACCT ccy k)))
-        (transfer deb-acct pact-acct amount (get-system-time)))))
+    (with-capability (USER_GUARD deb-acct)
+      (with-read accounts deb-acct { 'ccy:= ccy }
+        (let ((pact-acct (new-pact-account ESCROW_ACCT ccy)))
+          (transfer deb-acct pact-acct amount (get-system-time))))))
 
   (defun cancel-escrow (timeout deb-acct cred-acct amount)
-    (let ((dk (get-acct-keyset deb-acct))
-          (ck (get-acct-keyset cred-acct))
-          (systime (get-system-time)))
+    (let ((systime (get-system-time)))
       (enforce-one
         "Cancel can only be effected by creditor, or debitor after timeout"
-        [(enforce-keyset ck)
-         (and (enforce (>= systime timeout) "Timeout expired")
-              (enforce-keyset dk))])
+        [(with-capability (USER_GUARD cred-acct) true)
+         (with-capability (USER_GUARD deb-acct)
+           (enforce (>= systime timeout) "Timeout expired"))
+        ])
       (transfer (get-pact-account ESCROW_ACCT) deb-acct amount (get-system-time))))
 
 
   (defun finish-escrow (deb-acct cred-acct
                         escrow-amount:decimal)
-    (enforce-acct-keyset deb-acct)
-    (enforce-acct-keyset cred-acct)
-    (let* ((price (read-decimal "final-price"))
-           (delta (- escrow-amount price))
-           (escrow-acct (get-pact-account ESCROW_ACCT)))
-      (enforce (>= escrow-amount price) "Price cannot negotiate up")
-      (transfer escrow-acct cred-acct price (get-system-time))
-      (if (> delta 0.0)
-        (transfer escrow-acct deb-acct delta (get-system-time))
-        "noop")
-      (format "Escrow completed with {} paid and {} refunded" [price delta])))
+    (with-capability (USER_GUARD deb-acct)
+      (with-capability (USER_GUARD cred-acct)
+        (let* ((price (read-decimal "final-price"))
+               (delta (- escrow-amount price))
+               (escrow-acct (get-pact-account ESCROW_ACCT)))
+          (enforce (>= escrow-amount price) "Price cannot negotiate up")
+          (transfer escrow-acct cred-acct price (get-system-time))
+          (if (> delta 0.0)
+            (transfer escrow-acct deb-acct delta (get-system-time))
+            "noop")
+          (format "Escrow completed with {} paid and {} refunded" [price delta])
+          ))))
 
 
   (defun get-pact-account (pfx:string) (format "{}-{}" [pfx (pact-id)]))
@@ -209,8 +204,7 @@
         { "balance": 0.0
         , "amount": 0.0
         , "ccy": ccy
-        , "keyset": ADMIN_KEYSET
-        , "auth": (format "%s" [(pact-id)])
+        , "rowguard": (create-pact-guard pfx)
         , "date": (get-system-time)
         , "data": "Created pact account"
         }

--- a/examples/accounts/accounts.pact
+++ b/examples/accounts/accounts.pact
@@ -65,7 +65,7 @@
   (defun read-account-admin (id)
     "Read data for account ID, admin version"
     (with-capability (ADMIN)
-      (read accounts id ['balance 'ccy 'guard 'data 'date 'amount])))
+      (read accounts id ['balance 'ccy 'rowguard 'data 'date 'amount])))
 
 
   (defun account-keys ()

--- a/examples/accounts/accounts.repl
+++ b/examples/accounts/accounts.repl
@@ -14,7 +14,7 @@
 (begin-tx)
 (load "accounts.pact")
 (commit-tx)
-;(verify 'accounts)
+(verify 'accounts)
 (expect "test const evaluation" "ref" accounts.PACT_REF)
 (env-data { "123-keyset": { "keys" : ["user123"], "pred": "keys-all" },
              "456-keyset": { "keys": ["user456"], "pred": "keys-any" } })

--- a/examples/accounts/accounts.repl
+++ b/examples/accounts/accounts.repl
@@ -30,9 +30,12 @@
 (commit-tx)
 (begin-tx)
 (use 'accounts)
+;;admin reads
 (expect "balance of 123 after transfer" 229.0 (with-read accounts "123" { "balance" := b } b))
 (expect "balance of 456 after transfer" 5.0 (with-read accounts "456" { "balance" := b } b))
-
+(commit-tx)
+(begin-tx)
+(use 'accounts)
 (env-keys ["user123" "user456"])
 (expect-failure "should not allow read" (with-read accounts "123" { "balance" := b } b))
 

--- a/examples/accounts/accounts.repl
+++ b/examples/accounts/accounts.repl
@@ -14,7 +14,7 @@
 (begin-tx)
 (load "accounts.pact")
 (commit-tx)
-(verify 'accounts)
+;(verify 'accounts)
 (expect "test const evaluation" "ref" accounts.PACT_REF)
 (env-data { "123-keyset": { "keys" : ["user123"], "pred": "keys-all" },
              "456-keyset": { "keys": ["user456"], "pred": "keys-any" } })

--- a/pact.cabal
+++ b/pact.cabal
@@ -24,6 +24,7 @@ library
                      , Pact.Eval
                      , Pact.Gas
                      , Pact.Native
+                     , Pact.Native.Capabilities
                      , Pact.Native.Db
                      , Pact.Native.Internal
                      , Pact.Native.Time

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -67,7 +67,7 @@ import           Pact.Types.Runtime   (Exp, ModuleData(..), ModuleName,
                                        Term (TConst, TDef, TSchema, TTable),
                                        asString, getInfo, tShow)
 import qualified Pact.Types.Runtime   as Pact
-import           Pact.Types.Term      (Module(..))
+import           Pact.Types.Term      (Module(..),DefName(..))
 import           Pact.Types.Typecheck (AST,
                                        Fun (FDefun, _fArgs, _fBody, _fInfo),
                                        Named, Node, TcId (_tiInfo),
@@ -435,8 +435,8 @@ data ModuleProperty = ModuleProperty
   }
 
 -- Does this (module-scoped) property apply to this function?
-applicableCheck :: Text -> ModuleProperty -> Bool
-applicableCheck funName (ModuleProperty _ propScope) = case propScope of
+applicableCheck :: DefName -> ModuleProperty -> Bool
+applicableCheck (DefName funName) (ModuleProperty _ propScope) = case propScope of
   Everywhere      -> True
   Excluding names -> funName `Set.notMember` names
   Including names -> funName `Set.member`    names

--- a/src/Pact/Analyze/Parse/Invariant.hs
+++ b/src/Pact/Analyze/Parse/Invariant.hs
@@ -12,7 +12,7 @@ import qualified Data.Text                as T
 import           Prelude                  hiding (exp)
 
 import           Pact.Types.Lang          hiding (KeySet, KeySetName, SchemaVar,
-                                           TKeySet, TableName, Type)
+                                           TableName, Type)
 import qualified Pact.Types.Lang          as Pact
 import           Pact.Types.Util          (tShow)
 
@@ -32,7 +32,7 @@ expToInvariant ty exp = case (ty, exp) of
         (TTime,    TyTime)    -> pure (CoreInvariant (Var vid varName))
         (TStr,     TyString)  -> pure (CoreInvariant (Var vid varName))
         (TBool,    TyBool)    -> pure (CoreInvariant (Var vid varName))
-        (TKeySet,  TyKeySet)  -> pure (CoreInvariant (Var vid varName))
+        (TKeySet,  (TyGuard GTyKeySet))  -> pure (CoreInvariant (Var vid varName))
         (_,        TyValue)   -> throwErrorIn exp
           "Invariants can't constrain opaque values"
         (_,        _)         -> throwErrorIn exp $

--- a/src/Pact/Analyze/Parse/Invariant.hs
+++ b/src/Pact/Analyze/Parse/Invariant.hs
@@ -32,7 +32,7 @@ expToInvariant ty exp = case (ty, exp) of
         (TTime,    TyTime)    -> pure (CoreInvariant (Var vid varName))
         (TStr,     TyString)  -> pure (CoreInvariant (Var vid varName))
         (TBool,    TyBool)    -> pure (CoreInvariant (Var vid varName))
-        (TKeySet,  (TyGuard GTyKeySet))  -> pure (CoreInvariant (Var vid varName))
+        (TKeySet,  (TyGuard (Just GTyKeySet)))  -> pure (CoreInvariant (Var vid varName))
         (_,        TyValue)   -> throwErrorIn exp
           "Invariants can't constrain opaque values"
         (_,        _)         -> throwErrorIn exp $

--- a/src/Pact/Analyze/Parse/Prop.hs
+++ b/src/Pact/Analyze/Parse/Prop.hs
@@ -53,7 +53,7 @@ import           Data.Type.Equality           ((:~:) (Refl))
 import           Prelude                      hiding (exp)
 
 import           Pact.Types.Lang              hiding (KeySet, KeySetName,
-                                               SchemaVar, TKeySet, TableName,
+                                               SchemaVar, TableName,
                                                Type)
 import           Pact.Types.Util              (tShow)
 

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -362,7 +362,7 @@ maybeTranslateType' f = \case
   TyPrim TyInteger -> pure $ EType TInt
   TyPrim TyString  -> pure $ EType TStr
   TyPrim TyTime    -> pure $ EType TTime
-  TyPrim (TyGuard GTyKeySet)  -> pure $ EType TKeySet
+  TyPrim (TyGuard (Just GTyKeySet))  -> pure $ EType TKeySet
 
   -- Pretend any and an unknown var are the same -- we can't analyze either of
   -- them.
@@ -657,7 +657,7 @@ translateNode astNode = withAstContext astNode $ case astNode of
       return $ ESimple TBool $ Enforce Nothing $ NameAuthorized tid ksnT
 
   AST_EnforceKeyset ksA
-    | ksA ^? aNode.aTy == Just (TyPrim (TyGuard GTyKeySet))
+    | ksA ^? aNode.aTy == Just (TyPrim (TyGuard $ Just GTyKeySet))
     -> do
       ESimple TKeySet ksT <- translateNode ksA
       tid <- tagAuth $ ksA ^. aNode

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -35,7 +35,8 @@ import           Data.Traversable             (for)
 import           GHC.Generics                 (Generic)
 
 import           Pact.Types.Lang              (Info)
-import           Pact.Types.Runtime           (PrimType (TyBool, TyDecimal, TyInteger, TyKeySet, TyString, TyTime),
+import           Pact.Types.Runtime           (PrimType (TyBool, TyDecimal, TyInteger, TyGuard, TyString, TyTime),
+                                               GuardType (GTyKeySet),
                                                Type (TyPrim))
 import qualified Pact.Types.Runtime           as Pact
 import qualified Pact.Types.Typecheck         as Pact
@@ -285,7 +286,7 @@ mkInitialAnalyzeState tables = AnalyzeState
     intColumnDeltas = mkTableColumnMap (== TyPrim TyInteger) 0
     decColumnDeltas = mkTableColumnMap (== TyPrim TyDecimal) (fromInteger 0)
     cellsEnforced
-      = mkTableColumnMap (== TyPrim TyKeySet) (mkSFunArray (const false))
+      = mkTableColumnMap (== TyPrim (TyGuard GTyKeySet)) (mkSFunArray (const false))
     cellsWritten = mkTableColumnMap (const True) (mkSFunArray (const false))
 
     mkTableColumnMap
@@ -337,7 +338,7 @@ mkSymbolicCells tables = TableMap $ Map.fromList cellsList
              TyPrim TyDecimal -> scDecimalValues.at col ?~ mkArray
              TyPrim TyTime    -> scTimeValues.at col    ?~ mkArray
              TyPrim TyString  -> scStringValues.at col  ?~ mkArray
-             TyPrim TyKeySet  -> scKsValues.at col      ?~ mkArray
+             TyPrim (TyGuard GTyKeySet)  -> scKsValues.at col      ?~ mkArray
              --
              -- TODO: we should Left here. this means that mkSymbolicCells and
              --       mkInitialAnalyzeState should both return Either.

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -286,7 +286,7 @@ mkInitialAnalyzeState tables = AnalyzeState
     intColumnDeltas = mkTableColumnMap (== TyPrim TyInteger) 0
     decColumnDeltas = mkTableColumnMap (== TyPrim TyDecimal) (fromInteger 0)
     cellsEnforced
-      = mkTableColumnMap (== TyPrim (TyGuard GTyKeySet)) (mkSFunArray (const false))
+      = mkTableColumnMap (== TyPrim (TyGuard $ Just GTyKeySet)) (mkSFunArray (const false))
     cellsWritten = mkTableColumnMap (const True) (mkSFunArray (const false))
 
     mkTableColumnMap
@@ -338,7 +338,7 @@ mkSymbolicCells tables = TableMap $ Map.fromList cellsList
              TyPrim TyDecimal -> scDecimalValues.at col ?~ mkArray
              TyPrim TyTime    -> scTimeValues.at col    ?~ mkArray
              TyPrim TyString  -> scStringValues.at col  ?~ mkArray
-             TyPrim (TyGuard GTyKeySet)  -> scKsValues.at col      ?~ mkArray
+             TyPrim (TyGuard (Just GTyKeySet))  -> scKsValues.at col      ?~ mkArray
              --
              -- TODO: we should Left here. this means that mkSymbolicCells and
              --       mkInitialAnalyzeState should both return Either.

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -377,8 +377,12 @@ defun = do
   (defname,returnTy) <- first _atomAtom <$> typedAtom
   args <- withList' Parens $ many arg
   m <- meta ModelAllowed
-  TDef (DefName defname) modName Defun (FunType args returnTy)
-    <$> abstractBody valueLevel args <*> pure m <*> contextInfo
+  b <- abstractBody valueLevel args
+  i <- contextInfo
+  return $ (`TDef` i) $
+    Def (DefName defname) modName Defun (FunType args returnTy)
+      b m i
+
 
 defpact :: Compile (Term Name)
 defpact = do
@@ -390,8 +394,9 @@ defpact = do
     RStep -> return step
     RStepWithRollback -> return stepWithRollback
     _ -> expected "step or step-with-rollback"
-  TDef (DefName defname) modName Defpact (FunType args returnTy)
-    (abstractBody' args (TList body TyAny bi)) m <$> contextInfo
+  i <- contextInfo
+  return $ TDef (Def (DefName defname) modName Defpact (FunType args returnTy)
+                  (abstractBody' args (TList body TyAny bi)) m i) i
 
 moduleForm :: Compile (Term Name)
 moduleForm = do
@@ -448,8 +453,8 @@ emptyDef = do
   args <- withList' Parens $ many arg
   m <- meta ModelAllowed
   info <- contextInfo
-  return $
-    TDef (DefName defName) modName Defun
+  return $ (`TDef` info) $
+    Def (DefName defName) modName Defun
     (FunType args returnTy) (abstract (const Nothing) (TList [] TyAny info)) m info
 
 

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -24,6 +24,7 @@ module Pact.Compile
     (
      compile,compileExps
     ,MkInfo,mkEmptyInfo,mkStringInfo,mkTextInfo
+    ,Reserved(..)
     )
 
 where

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -528,7 +528,7 @@ parseType = msum
   , TyPrim TyString  <$ symbol tyString
   , TyList TyAny     <$ symbol tyList
   , TyPrim TyValue   <$ symbol tyValue
-  , TyPrim TyKeySet  <$ symbol tyKeySet
+  , TyPrim (TyGuard GTyKeySet)  <$ symbol tyKeySet
   ]
 
 parseListType :: Compile (Type (Term Name))

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -552,7 +552,8 @@ parseType = msum
   , TyPrim TyString  <$ symbol tyString
   , TyList TyAny     <$ symbol tyList
   , TyPrim TyValue   <$ symbol tyValue
-  , TyPrim (TyGuard GTyKeySet)  <$ symbol tyKeySet
+  , TyPrim (TyGuard $ Just GTyKeySet)  <$ symbol tyKeySet
+  , TyPrim (TyGuard Nothing) <$ symbol tyGuard
   ]
 
 parseListType :: Compile (Type (Term Name))

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -361,7 +361,7 @@ defun = do
   (defname,returnTy) <- first _atomAtom <$> typedAtom
   args <- withList' Parens $ many arg
   m <- meta ModelAllowed
-  TDef defname modName Defun (FunType args returnTy)
+  TDef (DefName defname) modName Defun (FunType args returnTy)
     <$> abstractBody valueLevel args <*> pure m <*> contextInfo
 
 defpact :: Compile (Term Name)
@@ -374,7 +374,7 @@ defpact = do
     RStep -> return step
     RStepWithRollback -> return stepWithRollback
     _ -> expected "step or step-with-rollback"
-  TDef defname modName Defpact (FunType args returnTy)
+  TDef (DefName defname) modName Defpact (FunType args returnTy)
     (abstractBody' args (TList body TyAny bi)) m <$> contextInfo
 
 moduleForm :: Compile (Term Name)
@@ -433,7 +433,7 @@ emptyDef = do
   m <- meta ModelAllowed
   info <- contextInfo
   return $
-    TDef defName modName Defun
+    TDef (DefName defName) modName Defun
     (FunType args returnTy) (abstract (const Nothing) (TList [] TyAny info)) m info
 
 

--- a/src/Pact/Docgen.hs
+++ b/src/Pact/Docgen.hs
@@ -74,7 +74,7 @@ renderTerm h TNative {..} = do
   case parseString nativeDocParser mempty (unpack _tNativeDocs) of
     Success (t,es) -> do
          hPutStrLn h t
-         if null es then noexs else renderExamples h es
+         if null es then noexs else renderExamples h _tNativeName es
     _ -> hPutStrLn h (unpack _tNativeDocs) >> noexs
   when _tNativeTopLevelOnly $ do
     hPutStrLn h ""
@@ -82,8 +82,8 @@ renderTerm h TNative {..} = do
   hPutStrLn h ""
 renderTerm _ _ = return ()
 
-renderExamples :: Handle -> [String] -> IO ()
-renderExamples h es = do
+renderExamples :: Handle -> NativeDefName -> [String] -> IO ()
+renderExamples h f es = do
   hPutStrLn h "```lisp"
   forM_ es $ \e -> do
     let (et,e') = case head e of
@@ -98,7 +98,8 @@ renderExamples h es = do
         case (r,et) of
           (Right r',_)       -> hPrint h r'
           (Left err,ExecErr) -> hPutStrLn h err
-          (Left err,_)       -> throwM (userError err)
+          (Left err,_)       ->
+            throwM (userError $ "Error rendering example for fucntion " ++ show f ++ ": " ++ e ++ ": " ++ err)
   hPutStrLn h "```"
 
 renderProperties :: Handle -> IO ()

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -38,6 +38,7 @@ module Pact.Eval
     ,liftTerm,apply
     ,preGas
     ,acquireCapability,acquireModuleAdmin
+    ,capabilityGranted
     ,revokeCapability,revokeAllCapabilities
     ,computeUserAppGas,prepareUserAppArgs,evalUserAppBody
     ,enscopeApply
@@ -141,9 +142,12 @@ topLevelCall
 topLevelCall i name gasArgs action = call (StackFrame name i Nothing) $
   computeGas (Left (i,name)) gasArgs >>= action
 
+capabilityGranted :: Capability -> Eval e Bool
+capabilityGranted cap = (cap `elem`) <$> use evalCapabilities
+
 acquireCapability :: Capability -> Eval e () -> Eval e CapAcquireResult
 acquireCapability cap test = do
-  granted <- (cap `elem`) <$> use evalCapabilities
+  granted <- capabilityGranted cap
   if granted then return AlreadyAcquired else do
     test
     evalCapabilities %= (cap:)

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -378,7 +378,7 @@ reduce :: Term Ref ->  Eval e (Term Name)
 reduce (TApp f as ai) = reduceApp f as ai
 reduce (TVar t _) = deref t
 reduce t@TLiteral {} = unsafeReduce t
-reduce t@TKeySet {} = unsafeReduce t
+reduce t@TGuard {} = unsafeReduce t
 reduce t@TValue {} = unsafeReduce t
 reduce TList {..} = TList <$> mapM reduce _tList <*> traverse reduce _tListType <*> pure _tInfo
 reduce t@TDef {} = return $ toTerm $ pack $ show t
@@ -433,6 +433,7 @@ reduceApp TDef {..} as ai = do
     case _tDefType of
       Defun -> reduceBody bod'
       Defpact -> applyPact bod'
+      _ -> undefined --TODOOOOOOOOO
 reduceApp (TLitString errMsg) _ i = evalError i $ unpack errMsg
 reduceApp r _ ai = evalError ai $ "Expected def: " ++ show r
 

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -29,7 +29,7 @@ module Pact.Eval
     (eval
     ,evalBeginTx,evalRollbackTx,evalCommitTx
     ,reduce,reduceBody
-    ,resolveFreeVars,resolveArg
+    ,resolveFreeVars,resolveArg,resolveRef
     ,enforceKeySet,enforceKeySetName
     ,checkUserType
     ,deref
@@ -642,6 +642,10 @@ typecheckTerm i spec t = do
     -- check object
     (TySchema TyObject ospec,TySchema TyObject oty,TObject {..}) ->
       paramCheck ospec oty (checkUserType True i _tObject)
+    (TyPrim (TyGuard a),TyPrim (TyGuard b),_) -> case (a,b) of
+      (Nothing,Just _) -> tcOK
+      (Just _,Nothing) -> tcOK
+      (c,d) -> if c == d then tcOK else tcFail ty
     _ -> tcFail ty
 
 -- | check object args. Used in 'typecheckTerm' above and also in DB writes.

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -423,7 +423,7 @@ reduceApp :: Term Ref -> [Term Ref] -> Info ->  Eval e (Term Name)
 reduceApp (TVar (Direct t) _) as ai = reduceDirect t as ai
 reduceApp (TVar (Ref r) _) as ai = reduceApp r as ai
 reduceApp TDef {..} as ai = do
-  g <- computeGas (Left (_tInfo, asString _tDefName)) GUser
+  g <- computeGas (Left (_tInfo, asString _tDefName)) GUserApp
   as' <- mapM reduce as
   ft' <- traverse reduce _tFunType
   typecheck (zip (_ftArgs ft') as')

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -34,7 +34,7 @@ module Pact.Eval
     ,checkUserType
     ,deref
     ,installModule
-    ,runPure,runPureSys,Purity
+    ,runPure,runReadOnly,Purity
     ,liftTerm,apply
     ,preGas
     ,acquireCapability,acquireModuleAdmin
@@ -671,11 +671,11 @@ runPure action = ask >>= \env -> case _eePurity env of
   PNoDb -> unsafeCoerce action -- yuck. would love safer coercion here
   _ -> mkNoDbEnv env >>= runPure' action
 
-runPureSys :: Info -> Eval (EnvSysRead e) a -> Eval e a
-runPureSys i action = ask >>= \env -> case _eePurity env of
+runReadOnly :: Info -> Eval (EnvReadOnly e) a -> Eval e a
+runReadOnly i action = ask >>= \env -> case _eePurity env of
   PNoDb -> evalError i "internal error: attempting sysread in pure context"
-  PSysRead -> unsafeCoerce action -- yuck. would love safer coercion here
-  _ -> mkSysReadEnv env >>= runPure' action
+  PReadOnly -> unsafeCoerce action -- yuck. would love safer coercion here
+  _ -> mkReadOnlyEnv env >>= runPure' action
 
 runPure' :: Eval f b -> EvalEnv f -> Eval e b
 runPure' action pureEnv = do

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -536,7 +536,7 @@ sort' _ [TList{..}] = case nub (map typeof _tList) of
   [ty] -> case ty of
     Right rty@(TyPrim pty) -> case pty of
       TyValue -> badTy (show ty)
-      TyKeySet -> badTy (show ty)
+      TyGuard{} -> badTy (show ty)
       _ -> do
         sl <- forM _tList $ \e -> case firstOf tLiteral e of
           Nothing -> evalError _tInfo $ "Unexpected type error, expected literal: " ++ show e

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -60,6 +60,7 @@ import Pact.Native.Internal
 import Pact.Native.Time
 import Pact.Native.Ops
 import Pact.Native.Keysets
+import Pact.Native.Capabilities
 import Pact.Types.Runtime
 import Pact.Parse
 import Pact.Types.Version
@@ -72,7 +73,8 @@ natives = [
   dbDefs,
   timeDefs,
   opDefs,
-  keyDefs]
+  keyDefs,
+  capDefs]
 
 
 -- | Production native modules as a dispatch map.

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -118,7 +118,7 @@ enforceOneDef =
   where
 
     enforceOne :: NativeFun e
-    enforceOne i as@[msg,TList conds _ _] = runPureSys (_faInfo i) $
+    enforceOne i as@[msg,TList conds _ _] = runReadOnly (_faInfo i) $
       gasUnreduced i as $ do
         msg' <- reduce msg >>= \m -> case m of
           TLitString s -> return s

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -477,9 +477,7 @@ readInteger i as = argsError i as
 
 
 pactId :: RNativeFun e
-pactId i [] = use evalPactExec >>= \pe -> case pe of
-  Nothing -> evalError' i "pact-id: not in pact execution"
-  Just PactExec{..} -> return $ toTerm _pePactId
+pactId i [] = toTerm <$> getPactId i
 pactId i as = argsError i as
 
 bind :: NativeFun e

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      :  Pact.Native.Capabilities
+-- Copyright   :  (C) 2016 Stuart Popejoy
+-- License     :  BSD-style (see the file LICENSE)
+-- Maintainer  :  Stuart Popejoy <stuart@kadena.io>
+--
+-- Builtins for working with capabilities.
+--
+
+module Pact.Native.Capabilities (capDefs) where
+
+import Control.Monad (void)
+
+import Pact.Eval
+import Pact.Native.Internal
+import Pact.Types.Runtime
+
+
+capDefs :: NativeModule
+capDefs =
+  ("Capabilities",[
+     withCapabilityDef
+    ])
+
+tvA :: Type n
+tvA = mkTyVar "a" []
+
+
+withCapabilityDef :: NativeDef
+withCapabilityDef =
+  defNative "with-capability" withCapability
+  (funType tvA [("capability",TyFun $ funType' tTyBool []),("body",TyList TyAny)])
+  "Specifies and requests grant of CAPABILITY which is an application of a 'defcap' \
+   \production; given the unique token specified by this application, ensure \
+   \that the token is granted in the environment during execution of BODY. If token is not \
+   \present, the CAPABILITY is applied, with \
+   \successful completion resulting in the installation/granting of the token, which \
+   \will then be revoked upon completion of BODY. \
+   \Nested 'with-capability' calls for the same token will detect the presence of \
+   \the token, and will not re-apply CAPABILITY, but simply execute BODY. \
+   \`$(with capability (update-users id) (update users id { salary: new-salary }))`"
+  where
+    withCapability :: NativeFun e
+    withCapability i [c@TApp{},body@TList{}] = gasUnreduced i [] $ do
+      grantedCap <- evalCap (_tApp c)
+      r <- reduceBody body
+      mapM_ revokeCapability grantedCap
+      return r
+    withCapability i as = argsError' i as
+
+evalCap :: App (Term Ref) -> Eval e (Maybe Capability)
+evalCap App{..} = case _appFun of
+  (TVar (Ref (TDef d@Def{..} _)) _) -> case _dDefType of
+    Defcap -> do
+      prep@(args,_) <- prepareUserAppArgs d _appArgs
+      let cap = UserCapability _dDefName args
+      acquired <- acquireCapability cap $ do
+        g <- computeUserAppGas d _appInfo
+        void $ evalUserAppBody d prep _appInfo g reduceBody
+      return $ case acquired of
+        NewlyAcquired -> Just cap
+        AlreadyAcquired -> Nothing
+    _ -> evalError _appInfo $ "Can only apply defcap here, found: " ++ show _dDefType
+  t -> evalError (_tInfo t) $ "Attempting to apply non-def: " ++ show _appFun

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -23,6 +23,7 @@ capDefs =
   ("Capabilities",
    [ withCapability
    , enforceGuardDef "enforce-guard"
+   , requireCapability
    ])
 
 tvA :: Type n
@@ -34,13 +35,15 @@ withCapability =
   defNative "with-capability" withCapability'
   (funType tvA [("capability",TyFun $ funType' tTyBool []),("body",TyList TyAny)])
   "Specifies and requests grant of CAPABILITY which is an application of a 'defcap' \
-   \production; given the unique token specified by this application, ensure \
-   \that the token is granted in the environment during execution of BODY. If token is not \
-   \present, the CAPABILITY is applied, with \
-   \successful completion resulting in the installation/granting of the token, which \
-   \will then be revoked upon completion of BODY. \
-   \Nested 'with-capability' calls for the same token will detect the presence of \
-   \the token, and will not re-apply CAPABILITY, but simply execute BODY. \
+  \production. Given the unique token specified by this application, ensure \
+  \that the token is granted in the environment during execution of BODY. \
+  \'with-capability' can only be called in the same module that declares the \
+  \corresponding 'defcap', otherwise module-admin rights are required. \
+  \If token is not present, the CAPABILITY is applied, with successful completion \
+  \resulting in the installation/granting of the token, which will then be revoked \
+  \upon completion of BODY. Nested 'with-capability' calls for the same token \
+  \will detect the presence of the token, and will not re-apply CAPABILITY, \
+  \but simply execute BODY. \
    \`$(with capability (update-users id) (update users id { salary: new-salary }))`"
   where
     withCapability' :: NativeFun e
@@ -51,10 +54,11 @@ withCapability =
       return r
     withCapability' i as = argsError' i as
 
+-- | Given cap app, enforce in-module call, eval args to form capability,
+-- and attempt to acquire. Return capability if newly-granted.
 evalCap :: App (Term Ref) -> Eval e (Maybe Capability)
-evalCap App{..} = case _appFun of
-  (TVar (Ref (TDef d@Def{..} _)) _) -> case _dDefType of
-    Defcap -> do
+evalCap a@App{..} = requireDefcap a >>= \d@Def{..} -> do
+      guardForModuleCall _appInfo _dModule $ return ()
       prep@(args,_) <- prepareUserAppArgs d _appArgs
       let cap = UserCapability _dDefName args
       acquired <- acquireCapability cap $ do
@@ -63,5 +67,26 @@ evalCap App{..} = case _appFun of
       return $ case acquired of
         NewlyAcquired -> Just cap
         AlreadyAcquired -> Nothing
+
+requireDefcap :: App (Term Ref) -> Eval e (Def Term Ref)
+requireDefcap App{..} = case _appFun of
+  (TVar (Ref (TDef d@Def{..} _)) _) -> case _dDefType of
+    Defcap -> return d
     _ -> evalError _appInfo $ "Can only apply defcap here, found: " ++ show _dDefType
   t -> evalError (_tInfo t) $ "Attempting to apply non-def: " ++ show _appFun
+
+requireCapability :: NativeDef
+requireCapability =
+  defNative "require-capability" requireCapability'
+  (funType tTyBool [("capability",TyFun $ funType' tTyBool [])])
+  "Specifies and tests for existing grant of CAPABILITY, failing if not found in environment. \
+  \`$(require-capability (TRANSFER src dest))`"
+  where
+    requireCapability' :: NativeFun e
+    requireCapability' i [TApp a@App{..} _] = gasUnreduced i [] $ requireDefcap a >>= \d@Def{..} -> do
+      (args,_) <- prepareUserAppArgs d _appArgs
+      let cap = UserCapability _dDefName args
+      granted <- capabilityGranted cap
+      unless granted $ evalError' i $ "require-capability: not granted: " ++ show cap
+      return $ toTerm True
+    requireCapability' i as = argsError' i as

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -36,7 +36,7 @@ tvA = mkTyVar "a" []
 
 withCapability :: NativeDef
 withCapability =
-  defNative "with-capability" withCapability'
+  defNative (specialForm WithCapability) withCapability'
   (funType tvA [("capability",TyFun $ funType' tTyBool []),("body",TyList TyAny)])
   "Specifies and requests grant of CAPABILITY which is an application of a 'defcap' \
   \production. Given the unique token specified by this application, ensure \
@@ -100,8 +100,8 @@ createPactGuard :: NativeDef
 createPactGuard =
   defRNative "create-pact-guard" createPactGuard'
   (funType (tTyGuard (Just GTyPact)) [("name",tTyString)])
-  "Defines a guard predicate by NAME that captures the results of `pact-id`. \
-  \At enforcement time, the success condition is that at that time `pact-id` must \
+  "Defines a guard predicate by NAME that captures the results of 'pact-id'. \
+  \At enforcement time, the success condition is that at that time 'pact-id' must \
   \return the same value. In effect this ensures that the guard will only succeed \
   \within the multi-transaction identified by the pact id."
   where

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -48,7 +48,7 @@ withCapability =
   \upon completion of BODY. Nested 'with-capability' calls for the same token \
   \will detect the presence of the token, and will not re-apply CAPABILITY, \
   \but simply execute BODY. \
-   \`$(with capability (update-users id) (update users id { salary: new-salary }))`"
+   \`$(with-capability (update-users id) (update users id { salary: new-salary }))`"
   where
     withCapability' :: NativeFun e
     withCapability' i [c@TApp{},body@TList{}] = gasUnreduced i [] $ do
@@ -72,7 +72,7 @@ evalCap a@App{..} = requireDefcap a >>= \d@Def{..} -> do
         NewlyAcquired -> Just cap
         AlreadyAcquired -> Nothing
 
-requireDefcap :: App (Term Ref) -> Eval e (Def Term Ref)
+requireDefcap :: App (Term Ref) -> Eval e (Def Ref)
 requireDefcap App{..} = case _appFun of
   (TVar (Ref (TDef d@Def{..} _)) _) -> case _dDefType of
     Defcap -> return d

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -350,15 +350,8 @@ createTable' i [t@TTable {..}] = do
 createTable' i as = argsError i as
 
 guardTable :: Show n => FunApp -> Term n -> Eval e ()
-guardTable i TTable {..} = do
-  let findMod _ r@Just {} = r
-      findMod sf _ = firstOf (sfApp . _Just . _1 . faModule . _Just) sf
-  r <- foldr findMod Nothing . reverse <$> use evalCallStack
-  case r of
-    (Just mn) | mn == _tModule -> enforceBlessedHashes i _tModule _tHash
-    _ -> do
-      m <- getModule (_faInfo i) _tModule
-      void $ acquireModuleAdmin (_faInfo i) (_mName m) (_mKeySet m)
+guardTable i TTable {..} = guardForModuleCall (_faInfo i) _tModule $
+  enforceBlessedHashes i _tModule _tHash
 guardTable i t = evalError' i $ "Internal error: guardTable called with non-table term: " ++ show t
 
 enforceBlessedHashes :: FunApp -> ModuleName -> Hash -> Eval e ()

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -358,7 +358,7 @@ guardTable i TTable {..} = do
     (Just mn) | mn == _tModule -> enforceBlessedHashes i _tModule _tHash
     _ -> do
       m <- getModule (_faInfo i) _tModule
-      enforceKeySetName (_faInfo i) (_mKeySet m)
+      acquireModuleAdmin (_faInfo i) (_mName m) (_mKeySet m)
 guardTable i t = evalError' i $ "Internal error: guardTable called with non-table term: " ++ show t
 
 enforceBlessedHashes :: FunApp -> ModuleName -> Hash -> Eval e ()

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -244,7 +244,7 @@ select' i _ cols' app@TApp{} tbl@TTable{} = do
         Just row -> do
           g <- gasPostRead i gPrev row
           let obj = columnsToObject tblTy row
-          result <- apply' app [obj]
+          result <- apply (_tApp app) [obj]
           fmap (g,) $ case result of
             (TLiteral (LBool include) _)
               | include -> case cols' of
@@ -358,7 +358,7 @@ guardTable i TTable {..} = do
     (Just mn) | mn == _tModule -> enforceBlessedHashes i _tModule _tHash
     _ -> do
       m <- getModule (_faInfo i) _tModule
-      acquireModuleAdmin (_faInfo i) (_mName m) (_mKeySet m)
+      void $ acquireModuleAdmin (_faInfo i) (_mName m) (_mKeySet m)
 guardTable i t = evalError' i $ "Internal error: guardTable called with non-table term: " ++ show t
 
 enforceBlessedHashes :: FunApp -> ModuleName -> Hash -> Eval e ()

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -169,7 +169,7 @@ enforceGuardDef dn =
               Module{..} -> enforceKeySetName (_faInfo i) _mKeySet
               Interface{} -> evalError' i $ "ModuleGuard not allowed on interface: " ++ show mg
           GUser UserGuard{..} -> do
-            void $ runPureSys (_faInfo i) $
+            void $ runReadOnly (_faInfo i) $
               enscopeApply $ App (TVar _ugPredFun def) [_ugData] (_faInfo i)
 
 findCallingModule :: Eval e (Maybe ModuleName)

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -24,10 +24,12 @@ module Pact.Native.Internal
   ,funType,funType'
   ,getModule
   ,module Pact.Types.Native
-  ,tTyInteger,tTyDecimal,tTyTime,tTyBool,tTyString,tTyValue,tTyKeySet,tTyObject
+  ,tTyInteger,tTyDecimal,tTyTime,tTyBool
+  ,tTyString,tTyValue,tTyKeySet,tTyObject,tTyGuard
   ,colsToList
   ,module Pact.Gas
   ,(<>)
+  ,getPactId
   ) where
 
 import Control.Monad
@@ -128,5 +130,11 @@ tTyTime :: Type n; tTyTime = TyPrim TyTime
 tTyBool :: Type n; tTyBool = TyPrim TyBool
 tTyString :: Type n; tTyString = TyPrim TyString
 tTyValue :: Type n; tTyValue = TyPrim TyValue
-tTyKeySet :: Type n; tTyKeySet = TyPrim (TyGuard GTyKeySet)
+tTyKeySet :: Type n; tTyKeySet = TyPrim (TyGuard $ Just GTyKeySet)
 tTyObject :: Type n -> Type n; tTyObject o = TySchema TyObject o
+tTyGuard :: Maybe GuardType -> Type n; tTyGuard gt = TyPrim (TyGuard gt)
+
+getPactId :: FunApp -> Eval e PactId
+getPactId i = use evalPactExec >>= \pe -> case pe of
+  Nothing -> evalError' i "pact-id: not in pact execution"
+  Just PactExec{..} -> return _pePactId

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -128,5 +128,5 @@ tTyTime :: Type n; tTyTime = TyPrim TyTime
 tTyBool :: Type n; tTyBool = TyPrim TyBool
 tTyString :: Type n; tTyString = TyPrim TyString
 tTyValue :: Type n; tTyValue = TyPrim TyValue
-tTyKeySet :: Type n; tTyKeySet = TyPrim TyKeySet
+tTyKeySet :: Type n; tTyKeySet = TyPrim (TyGuard GTyKeySet)
 tTyObject :: Type n -> Type n; tTyObject o = TySchema TyObject o

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -29,7 +29,7 @@ module Pact.Native.Internal
   ,colsToList
   ,module Pact.Gas
   ,(<>)
-  ,getPactId
+  ,getPactId,enforceGuardDef
   ) where
 
 import Control.Monad
@@ -138,3 +138,34 @@ getPactId :: FunApp -> Eval e PactId
 getPactId i = use evalPactExec >>= \pe -> case pe of
   Nothing -> evalError' i "pact-id: not in pact execution"
   Just PactExec{..} -> return _pePactId
+
+enforceGuardDef :: NativeDefName -> NativeDef
+enforceGuardDef dn =
+  defRNative dn enforceGuard'
+  (funType tTyBool [("guard",tTyGuard Nothing)] <>
+   funType tTyBool [("keysetname",tTyString)])
+  ("Execute GUARD, or defined keyset KEYSETNAME, to enforce desired predicate logic. " <>
+   "`$(" <> asString dn <> " 'admin-keyset)` `$(" <> asString dn <> " row-guard)`")
+  where
+    enforceGuard' :: RNativeFun e
+    enforceGuard' i as = case as of
+      [TGuard g _] -> go g
+      [TLitString k] -> go (GKeySetRef (KeySetName k))
+      _ -> argsError i as
+      where
+        go g = runGuard g >> return (toTerm True)
+        runGuard g = case g of
+          GKeySet k -> runPure $ enforceKeySet (_faInfo i) Nothing k
+          GKeySetRef n -> enforceKeySetName (_faInfo i) n
+          GPact PactGuard{..} -> do
+            pid <- getPactId i
+            unless (pid == _pgPactId) $
+              evalError' i $
+                "Pact guard failed, intended: " ++ show _pgPactId ++ ", active: " ++ show pid
+          GModule mg@ModuleGuard{..} -> do
+            m <- getModule (_faInfo i) _mgModuleName
+            case m of
+              Module{..} -> enforceKeySetName (_faInfo i) _mKeySet
+              Interface{} -> evalError' i $ "ModuleGuard not allowed on interface: " ++ show mg
+          GUser UserGuard{..} -> do
+            void $ enscopeApply $ App (TVar _ugPredFun def) [_ugData] (_faInfo i)

--- a/src/Pact/Native/Keysets.hs
+++ b/src/Pact/Native/Keysets.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- |
@@ -69,13 +68,13 @@ withCapabilityDef :: NativeDef
 withCapabilityDef =
   defNative "with-capability" withCapability
   (funType tvA [("capability",TyFun $ funType' tTyBool []),("body",TyList TyAny)])
-  "Specifies and requests grant of CAPABILITY which is an application of a `defcap` \
+  "Specifies and requests grant of CAPABILITY which is an application of a 'defcap' \
    \production; given the unique token specified by this application, ensure \
    \that the token is granted in the environment during execution of BODY. If token is not \
    \present, the CAPABILITY is applied, with \
    \successful completion resulting in the installation/granting of the token, which \
    \will then be revoked upon completion of BODY. \
-   \Nested `with-capability` calls for the same token will detect the presence of \
+   \Nested 'with-capability' calls for the same token will detect the presence of \
    \the token, and will not re-apply CAPABILITY, but simply execute BODY. \
    \`$(with capability (update-users id) (update users id { salary: new-salary }))`"
   where

--- a/src/Pact/Native/Keysets.hs
+++ b/src/Pact/Native/Keysets.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- |
@@ -47,10 +45,7 @@ keyDefs =
      \similarly to 'read-keyset'. \
      \If keyset NAME already exists, keyset will be enforced before updating to new value.\
      \`$(define-keyset 'admin-keyset (read-keyset \"keyset\"))`"
-    ,defRNative "enforce-keyset" enforceKeyset' (funType tTyBool [("keyset-or-name",mkTyVar "k" [tTyString,tTyKeySet])])
-     "Special form to enforce KEYSET-OR-NAME against message keys before running BODY. \
-     \KEYSET-OR-NAME can be a symbol of a keyset name or a keyset object. \
-     \`$(with-keyset 'admin-keyset ...)` `$(with-keyset (read-keyset \"keyset\") ...)`"
+    ,enforceGuardDef "enforce-keyset"
     ,defKeyPred KeysAll (==)
      "Keyset predicate function to match all keys in keyset. `(keys-all 3 3)`"
     ,defKeyPred KeysAny (keysN 1)
@@ -78,19 +73,6 @@ defineKeyset fi as = case as of
         Just oldKs -> do
           runPure $ enforceKeySet i (Just ksn) oldKs
           writeRow i Write KeySets ksn ks & success "Keyset defined"
-
-
-
-enforceKeyset' :: RNativeFun e
-enforceKeyset' i as = do
-  case as of
-    [TLitString name] ->
-      enforceKeySetName (_faInfo i) (KeySetName name)
-    [TGuard (GKeySet ks) _] ->
-      runPure $ enforceKeySet (_faInfo i) Nothing ks
-    _ -> argsError i as
-  return $ toTerm True
-
 
 keyPred :: (Integer -> Integer -> Bool) -> RNativeFun e
 keyPred predfun _ [TLitInteger count,TLitInteger matched] =

--- a/src/Pact/Native/Keysets.hs
+++ b/src/Pact/Native/Keysets.hs
@@ -29,7 +29,7 @@ readKeysetDef =
 
     readKeySet :: RNativeFun e
     readKeySet i [TLitString key]
-      = ((`TGuard` def) . GKeySet . KGKeySet) <$> parseMsgKey i "read-keyset" key
+      = ((`TGuard` def) . GKeySet) <$> parseMsgKey i "read-keyset" key
     readKeySet i as = argsError i as
 
 keyDefs :: NativeModule
@@ -61,7 +61,7 @@ keyDefs =
 
 
 defineKeyset :: RNativeFun e
-defineKeyset fi [TLitString name,TGuard (GKeySet (KGKeySet ks)) _] = do
+defineKeyset fi [TLitString name,TGuard (GKeySet ks) _] = do
   let ksn = KeySetName name
       i = _faInfo fi
   old <- readRow i KeySets ksn
@@ -82,7 +82,7 @@ enforceKeyset' i [t] = do
       case ksm of
         Nothing -> evalError' i $ "Keyset not found: " ++ show name
         Just ks -> return (Just ksn,ks)
-    TGuard (GKeySet (KGKeySet ks)) _ -> return (Nothing,ks)
+    TGuard (GKeySet ks) _ -> return (Nothing,ks)
     _ -> argsError i [t,toTerm ("[body...]" :: Text)]
   runPure $ enforceKeySet (_faInfo i) ksn ks
   return $ toTerm True

--- a/src/Pact/Native/Keysets.hs
+++ b/src/Pact/Native/Keysets.hs
@@ -29,7 +29,7 @@ readKeysetDef =
 
     readKeySet :: RNativeFun e
     readKeySet i [TLitString key]
-      = (`TKeySet` def) <$> parseMsgKey i "read-keyset" key
+      = ((`TGuard` def) . GKeySet . KGKeySet) <$> parseMsgKey i "read-keyset" key
     readKeySet i as = argsError i as
 
 keyDefs :: NativeModule
@@ -61,7 +61,7 @@ keyDefs =
 
 
 defineKeyset :: RNativeFun e
-defineKeyset fi [TLitString name,TKeySet ks _] = do
+defineKeyset fi [TLitString name,TGuard (GKeySet (KGKeySet ks)) _] = do
   let ksn = KeySetName name
       i = _faInfo fi
   old <- readRow i KeySets ksn
@@ -82,7 +82,7 @@ enforceKeyset' i [t] = do
       case ksm of
         Nothing -> evalError' i $ "Keyset not found: " ++ show name
         Just ks -> return (Just ksn,ks)
-    TKeySet ks _ -> return (Nothing,ks)
+    TGuard (GKeySet (KGKeySet ks)) _ -> return (Nothing,ks)
     _ -> argsError i [t,toTerm ("[body...]" :: Text)]
   runPure $ enforceKeySet (_faInfo i) ksn ks
   return $ toTerm True

--- a/src/Pact/Native/Ops.hs
+++ b/src/Pact/Native/Ops.hs
@@ -246,12 +246,12 @@ liftLogic n bop desc shortCircuit =
   where
     r = mkTyVar "r" []
     fun i as@[a@TApp{},b@TApp{},v'] = gasUnreduced i as $ reduce v' >>= \v -> do
-      ar <- apply' a [v]
+      ar <- apply (_tApp a) [v]
       case ar of
         TLitBool ab
           | ab == shortCircuit -> return $ toTerm shortCircuit
           | otherwise -> do
-              br <- apply' b [v]
+              br <- apply (_tApp b) [v]
               case br of
                 TLitBool bb -> return $ toTerm $ bop ab bb
                 _ -> delegateError (show n) b br
@@ -259,7 +259,7 @@ liftLogic n bop desc shortCircuit =
     fun i as = argsError' i as
 
 liftNot :: NativeFun e
-liftNot i as@[app@TApp{},v'] = gasUnreduced i as $ reduce v' >>= \v -> apply' app [v] >>= \r -> case r of
+liftNot i as@[app@TApp{},v'] = gasUnreduced i as $ reduce v' >>= \v -> apply (_tApp app) [v] >>= \r -> case r of
   TLitBool b -> return $ toTerm $ not b
   _ -> delegateError "not?" app r
 liftNot i as = argsError' i as

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -99,7 +99,7 @@ replDefs = ("Repl",
      ,defZRNative "env-pactid" envPactId
       (funType tTyString [] <>
        funType tTyString [("id",tTyString)])
-       "Query, or set with ID, pact state pact id."
+       "Query environment pact id, or set to ID."
      ,defZRNative "pact-state" pactState (funType (tTyObject TyAny) [])
       ("Inspect state from previous pact execution. Returns object with fields " <>
       "'yield': yield result or 'false' if none; 'step': executed step; " <>

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -96,6 +96,10 @@ replDefs = ("Repl",
       ("Set pact step state. With no arguments, unset step. With STEP-IDX, set step index to execute. " <>
        "ROLLBACK instructs to execute rollback expression, if any. RESUME sets a value to be read via 'resume'." <>
        "Clears any previous pact execution state. `$(env-step 1)` `$(env-step 0 true)`")
+     ,defZRNative "env-pactid" envPactId
+      (funType tTyString [] <>
+       funType tTyString [("id",tTyString)])
+       "Query, or set with ID, pact state pact id."
      ,defZRNative "pact-state" pactState (funType (tTyObject TyAny) [])
       ("Inspect state from previous pact execution. Returns object with fields " <>
       "'yield': yield result or 'false' if none; 'step': executed step; " <>
@@ -186,6 +190,10 @@ setop v = setLibState $ set rlsOp v
 setenv :: Setter' (EvalEnv LibState) a -> a -> Eval LibState ()
 setenv l v = setop $ UpdateEnv $ Endo (set l v)
 
+{-
+overenv :: Setter' (EvalEnv LibState) a -> (a -> a) -> Eval LibState ()
+overenv l f = setop $ UpdateEnv $ Endo (over l f)
+-}
 
 setsigs :: RNativeFun LibState
 setsigs i [TList ts _ _] = do
@@ -222,6 +230,16 @@ setstep i as = case as of
     setstep' s = do
       setenv eePactStep s
       evalPactExec .= Nothing
+
+envPactId :: RNativeFun LibState
+envPactId i as = view eePactStep >>= \psm -> case psm of
+  Nothing -> evalError' i "no pact state set currently"
+  Just ps@PactStep{..} -> case as of
+    [] -> return $ toTerm _psPactId
+    [TLitString pid] -> do
+      setenv eePactStep $ Just $ set psPactId (PactId pid) ps
+      return $ tStr $ "Setting pact id to " <> tShow pid
+    _ -> argsError i as
 
 setentity :: RNativeFun LibState
 setentity i as = case as of

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -760,7 +760,7 @@ toAST TObject {..} = do
   Object <$> (trackNode ty =<< freshId _tInfo "object")
     <*> mapM (\(k,v) -> (,) <$> toAST k <*> toAST v) _tObject
 toAST TConst {..} = toAST (_cvRaw _tConstVal) -- TODO typecheck here
-toAST TGuard {..} = trackPrim _tInfo (TyGuard $ guardTypeOf _tGuard) (PrimGuard _tGuard)
+toAST TGuard {..} = trackPrim _tInfo (TyGuard $ Just $ guardTypeOf _tGuard) (PrimGuard _tGuard)
 toAST TValue {..} = trackPrim _tInfo TyValue (PrimValue _tValue)
 toAST TLiteral {..} = trackPrim _tInfo (litToPrim _tLiteral) (PrimLit _tLiteral)
 toAST TTable {..} = do

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -345,6 +345,9 @@ processNatives Pre a@(App i FNative {..} argASTs) = do
               assocAstTy bn $ _ftReturn mangledFunType
               -- assoc schema with last ft arg
               assocAstTy sn (_aType (last (toList $ _ftArgs mangledFunType)))
+            (List _ln ll) -> do -- TODO, for with-capability
+              -- assoc app return with last of body
+              assocAstTy (_aNode $ last ll) $ _ftReturn mangledFunType
             sb -> die _fInfo $ "Invalid special form, expected binding: " ++ show sb
           -- TODO the following is dodgy, schema may not be resolved.
           ((Where,_),[(field,_),(partialAst,_),(_,TySchema TyObject uty)]) -> asPrimString field >>= \fld -> case uty of
@@ -732,6 +735,7 @@ toAST (TApp Term.App{..} _) = do
             Bind -> specialBind
             WithRead -> specialBind
             WithDefaultRead -> specialBind
+            WithCapability -> specialBind
             _ -> mkApp fun' args'
 
 toAST TBinding {..} = do

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -759,7 +759,7 @@ toAST TObject {..} = do
   Object <$> (trackNode ty =<< freshId _tInfo "object")
     <*> mapM (\(k,v) -> (,) <$> toAST k <*> toAST v) _tObject
 toAST TConst {..} = toAST (_cvRaw _tConstVal) -- TODO typecheck here
-toAST TKeySet {..} = trackPrim _tInfo TyKeySet (PrimKeySet _tKeySet)
+toAST TGuard {..} = trackPrim _tInfo (TyGuard $ guardTypeOf _tGuard) (PrimGuard _tGuard)
 toAST TValue {..} = trackPrim _tInfo TyValue (PrimValue _tValue)
 toAST TLiteral {..} = trackPrim _tInfo (litToPrim _tLiteral) (PrimLit _tLiteral)
 toAST TTable {..} = do

--- a/src/Pact/Types/Gas.hs
+++ b/src/Pact/Types/Gas.hs
@@ -46,7 +46,7 @@ data GasArgs
   | GModule Module
   | GInterface Module
   | GModuleMember Module
-  | GUser
+  | GUserApp
 
 
 newtype GasLimit = GasLimit Word64

--- a/src/Pact/Types/Gas.hs
+++ b/src/Pact/Types/Gas.hs
@@ -43,8 +43,8 @@ data GasArgs
   | GUnreduced [Term Ref]
   | GReduced [Term Name]
   | GUse ModuleName (Maybe Hash)
-  | GModule Module
-  | GInterface Module
+  | GModuleDecl Module
+  | GInterfaceDecl Module
   | GModuleMember Module
   | GUserApp
 

--- a/src/Pact/Types/Native.hs
+++ b/src/Pact/Types/Native.hs
@@ -34,14 +34,13 @@ isSpecialForm :: NativeDefName -> Maybe SpecialForm
 isSpecialForm = (`M.lookup` sfLookup)
 
 
--- | Native function with un-reduced arguments that computes gas. Must fire call stack.
+-- | Native function with un-reduced arguments that computes gas.
 type NativeFun e = FunApp -> [Term Ref] -> Eval e (Gas,Term Name)
 
 -- | Native function with reduced arguments, initial gas pre-compute that computes final gas.
--- Call stack fired.
 type GasRNativeFun e = Gas -> FunApp -> [Term Name] -> Eval e (Gas,Term Name)
 
--- | Native function with reduced arguments, final gas pre-compute, call stack fired.
+-- | Native function with reduced arguments, final gas pre-compute.
 type RNativeFun e = FunApp -> [Term Name] -> Eval e (Term Name)
 
 type NativeDef = (NativeDefName,Term Name)

--- a/src/Pact/Types/Native.hs
+++ b/src/Pact/Types/Native.hs
@@ -4,6 +4,7 @@ module Pact.Types.Native where
 
 import Pact.Types.Util
 import Pact.Types.Runtime
+import Pact.Compile (Reserved(RWithCapability))
 import qualified Data.Map.Strict as M
 import Control.Arrow
 
@@ -12,7 +13,8 @@ data SpecialForm =
   WithDefaultRead |
   Bind |
   Select |
-  Where
+  Where |
+  WithCapability
   deriving (Eq,Enum,Ord,Bounded)
 
 instance AsString SpecialForm where
@@ -21,6 +23,7 @@ instance AsString SpecialForm where
   asString Bind = "bind"
   asString Select = "select"
   asString Where = "where"
+  asString WithCapability = asString RWithCapability
 
 instance Show SpecialForm where show = show . asString
 

--- a/src/Pact/Types/Persistence.hs
+++ b/src/Pact/Types/Persistence.hs
@@ -126,9 +126,8 @@ valueCodec = Codec enc dec
 guardCodec :: Codec Guard
 guardCodec = Codec enc dec
   where
-    enc (GKeySet k) = case k of
-      KGKeySet (KeySet ks p) -> object [ keyf .= ks, predf .= p ]
-      KGName n -> object [ keyNamef .= n ]
+    enc (GKeySet (KeySet ks p)) = object [ keyf .= ks, predf .= p ]
+    enc (GKeySetRef n) = object [ keyNamef .= n ]
     enc (GPact (PactGuard{..})) =
       object [ pactNamef .= _pgName, pactIdf .= _pgPactId ]
     enc (GUser (UserGuard{..})) =
@@ -136,8 +135,8 @@ guardCodec = Codec enc dec
       -- TODO ^^^ is too loose, needs better object type of only persistables
     {-# INLINE enc #-}
     dec = withObject "Guard" $ \o ->
-      (GKeySet . KGKeySet <$> (KeySet <$> o .: keyf <*> o .: predf)) <|>
-      (GKeySet . KGName <$> o .: keyNamef) <|>
+      (GKeySet <$> (KeySet <$> o .: keyf <*> o .: predf)) <|>
+      (GKeySetRef <$> o .: keyNamef) <|>
       (GPact <$> (PactGuard <$> o .: pactIdf <*> o .: pactNamef)) <|>
       (GUser <$> (UserGuard <$> o .: userDataf <*> o .: userPredf))
     {-# INLINE dec #-}

--- a/src/Pact/Types/Persistence.hs
+++ b/src/Pact/Types/Persistence.hs
@@ -130,6 +130,8 @@ guardCodec = Codec enc dec
     enc (GKeySetRef n) = object [ keyNamef .= n ]
     enc (GPact (PactGuard{..})) =
       object [ pactNamef .= _pgName, pactIdf .= _pgPactId ]
+    enc (GModule (ModuleGuard{..})) =
+      object [ modModNamef .= _mgModuleName, modNamef .= _mgName ]
     enc (GUser (UserGuard{..})) =
       object [ userDataf .= _ugData, userPredf .= _ugPredFun ]
       -- TODO ^^^ is too loose, needs better object type of only persistables
@@ -138,6 +140,7 @@ guardCodec = Codec enc dec
       (GKeySet <$> (KeySet <$> o .: keyf <*> o .: predf)) <|>
       (GKeySetRef <$> o .: keyNamef) <|>
       (GPact <$> (PactGuard <$> o .: pactIdf <*> o .: pactNamef)) <|>
+      (GModule <$> (ModuleGuard <$> o .: modModNamef <*> o .: modNamef)) <|>
       (GUser <$> (UserGuard <$> o .: userDataf <*> o .: userPredf))
     {-# INLINE dec #-}
     keyf = "_P_keys"
@@ -145,6 +148,8 @@ guardCodec = Codec enc dec
     keyNamef = "_P_ksn"
     pactNamef = "_P_gpn"
     pactIdf = "_P_gpi"
+    modModNamef = "_P_mmn"
+    modNamef = "_P_mn"
     userDataf = "_P_gud"
     userPredf = "_P_gup"
 

--- a/src/Pact/Types/Persistence.hs
+++ b/src/Pact/Types/Persistence.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
@@ -122,30 +123,46 @@ valueCodec = Codec enc dec
     {-# INLINE dec #-}
     field = "_P_val"
 
-keysetCodec :: Codec KeySet
-keysetCodec = Codec enc dec
+guardCodec :: Codec Guard
+guardCodec = Codec enc dec
   where
-    enc (KeySet ks p) = object [ keyf .= ks, predf .= p ]
+    enc (GKeySet k) = case k of
+      KGKeySet (KeySet ks p) -> object [ keyf .= ks, predf .= p ]
+      KGName n -> object [ keyNamef .= n ]
+    enc (GPact (PactGuard{..})) =
+      object [ pactNamef .= _pgName, pactIdf .= _pgPactId ]
+    enc (GUser (UserGuard{..})) =
+      object [ userDataf .= _ugData, userPredf .= _ugPredFun ]
+      -- TODO ^^^ is too loose, needs better object type of only persistables
     {-# INLINE enc #-}
-    dec  = withObject "KeySet" $ \o -> KeySet <$> o .: keyf <*> o .: predf
+    dec = withObject "Guard" $ \o ->
+      (GKeySet . KGKeySet <$> (KeySet <$> o .: keyf <*> o .: predf)) <|>
+      (GKeySet . KGName <$> o .: keyNamef) <|>
+      (GPact <$> (PactGuard <$> o .: pactIdf <*> o .: pactNamef)) <|>
+      (GUser <$> (UserGuard <$> o .: userDataf <*> o .: userPredf))
     {-# INLINE dec #-}
     keyf = "_P_keys"
     predf = "_P_pred"
+    keyNamef = "_P_ksn"
+    pactNamef = "_P_gpn"
+    pactIdf = "_P_gpi"
+    userDataf = "_P_gud"
+    userPredf = "_P_gup"
 
 
 -- | Represent Pact 'Term' values that can be stored in a database.
 data Persistable =
     PLiteral Literal |
-    PKeySet KeySet |
+    PGuard Guard |
     PValue Value
     deriving (Eq,Generic)
 instance Show Persistable where
     show (PLiteral l) = show l
-    show (PKeySet k) = show k
+    show (PGuard k) = show k
     show (PValue v) = BSL.toString $ encode v
 instance ToTerm Persistable where
     toTerm (PLiteral l) = toTerm l
-    toTerm (PKeySet k) = toTerm k
+    toTerm (PGuard k) = toTerm k
     toTerm (PValue v) = toTerm v
 instance ToJSON Persistable where
     toJSON (PLiteral (LString s)) = String s
@@ -153,7 +170,7 @@ instance ToJSON Persistable where
     toJSON (PLiteral (LInteger n)) = encoder integerCodec n
     toJSON (PLiteral (LDecimal d)) = encoder decimalCodec d
     toJSON (PLiteral (LTime t)) = encoder timeCodec t
-    toJSON (PKeySet k) = encoder keysetCodec k
+    toJSON (PGuard k) = encoder guardCodec k
     toJSON (PValue v) = encoder valueCodec v
 instance FromJSON Persistable where
     parseJSON (String s) = return (PLiteral (LString s))
@@ -163,18 +180,18 @@ instance FromJSON Persistable where
                             (PLiteral . LDecimal <$> decoder decimalCodec v) <|>
                             (PLiteral . LTime <$> decoder timeCodec v) <|>
                             (PValue <$> decoder valueCodec v) <|>
-                            (PKeySet <$> decoder keysetCodec v)
+                            (PGuard <$> decoder guardCodec v)
     parseJSON Null = return (PValue Null)
     parseJSON va@Array {} = return (PValue va)
 
 class ToPersistable t where
   toPersistable :: t -> Persistable
 instance ToPersistable Literal where toPersistable = PLiteral
-instance ToPersistable KeySet where toPersistable = PKeySet
+instance ToPersistable Guard where toPersistable = PGuard
 instance ToPersistable Value where toPersistable = PValue
 instance Show n => ToPersistable (Term n) where
   toPersistable (TLiteral v _) = toPersistable v
-  toPersistable (TKeySet ks _) = toPersistable ks
+  toPersistable (TGuard ks _) = toPersistable ks
   toPersistable (TValue v _) = toPersistable v
   toPersistable t = toPersistable (toJSON t)
 

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -33,7 +33,7 @@ module Pact.Types.Runtime
    call,method,
    readRow,writeRow,keys,txids,createUserTable,getUserTableInfo,beginTx,commitTx,rollbackTx,getTxLog,
    KeyPredBuiltins(..),keyPredBuiltins,
-   Capability(..),
+   Capability(..),CapAcquireResult(..),
    module Pact.Types.Lang,
    module Pact.Types.Util,
    module Pact.Types.Persistence,
@@ -68,6 +68,9 @@ import Pact.Types.Util
 data Capability
   = ModuleAdminCapability ModuleName
   | UserCapability DefName [Term Name]
+  deriving (Eq,Show)
+
+data CapAcquireResult = NewlyAcquired|AlreadyAcquired
   deriving (Eq,Show)
 
 data StackFrame = StackFrame {

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -112,11 +112,6 @@ instance AsString KeyPredBuiltins where
 keyPredBuiltins :: M.Map Name KeyPredBuiltins
 keyPredBuiltins = M.fromList $ map ((`Name` def) . asString &&& id) [minBound .. maxBound]
 
-
-newtype PactId = PactId Text
-    deriving (Eq,Ord,IsString,ToTerm,AsString,ToJSON,FromJSON,Default)
-instance Show PactId where show (PactId s) = show s
-
 -- | Environment setup for pact execution.
 data PactStep = PactStep {
       _psStep :: !Int

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -28,11 +28,12 @@ module Pact.Types.Runtime
    StackFrame(..),sfName,sfLoc,sfApp,
    PactExec(..),peStepCount,peYield,peExecuted,pePactId,peStep,
    RefState(..),rsLoaded,rsLoadedModules,rsNewModules,
-   EvalState(..),evalRefs,evalCallStack,evalPactExec,evalGas,
+   EvalState(..),evalRefs,evalCallStack,evalPactExec,evalGas,evalCapabilities,
    Eval(..),runEval,runEval',
    call,method,
    readRow,writeRow,keys,txids,createUserTable,getUserTableInfo,beginTx,commitTx,rollbackTx,getTxLog,
    KeyPredBuiltins(..),keyPredBuiltins,
+   Capability(..),
    module Pact.Types.Lang,
    module Pact.Types.Util,
    module Pact.Types.Persistence,
@@ -40,7 +41,7 @@ module Pact.Types.Runtime
    ) where
 
 import Control.Arrow ((&&&))
-import Control.Lens hiding ((.=))
+import Control.Lens hiding ((.=),DefName)
 import Control.DeepSeq
 import Data.List
 import Control.Monad.Except
@@ -63,6 +64,11 @@ import Pact.Types.Orphans ()
 import Pact.Types.Persistence
 import Pact.Types.Util
 
+
+data Capability
+  = ModuleAdminCapability ModuleName
+  | UserCapability DefName [Term Name]
+  deriving (Eq,Show)
 
 data StackFrame = StackFrame {
       _sfName :: !Text
@@ -226,9 +232,11 @@ data EvalState = EvalState {
     , _evalPactExec :: !(Maybe PactExec)
       -- | Gas tally
     , _evalGas :: Gas
+      -- | Capability list
+    , _evalCapabilities :: [Capability]
     } deriving (Show)
 makeLenses ''EvalState
-instance Default EvalState where def = EvalState def def def 0
+instance Default EvalState where def = EvalState def def def 0 def
 
 -- | Interpreter monad, parameterized over back-end MVar state type.
 newtype Eval e a =

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -34,7 +34,7 @@ module Pact.Types.Term
    Guard(..),
    DefType(..),
    defTypeRep,
-   NativeDefName(..),
+   NativeDefName(..),DefName(..),
    FunApp(..),faDefType,faDocs,faInfo,faModule,faName,faTypes,
    Ref(..),
    NativeDFun(..),
@@ -302,6 +302,10 @@ newtype ModuleName = ModuleName Text
     deriving (Eq,Ord,IsString,ToJSON,FromJSON,AsString,Hashable,Pretty)
 instance Show ModuleName where show (ModuleName s) = show s
 
+newtype DefName = DefName Text
+    deriving (Eq,Ord,IsString,ToJSON,FromJSON,AsString,Hashable,Pretty)
+instance Show DefName where show (DefName s) = show s
+
 -- | A named reference from source.
 data Name =
     QName { _nQual :: ModuleName, _nName :: Text, _nInfo :: Info } |
@@ -426,7 +430,7 @@ data Term n =
     , _tInfo :: !Info
     } |
     TDef {
-      _tDefName :: !Text
+      _tDefName :: !DefName
     , _tModule :: !ModuleName
     , _tDefType :: !DefType
     , _tFunType :: !(FunType (Term n))
@@ -513,7 +517,7 @@ instance Show n => Show (Term n) where
       "(TModule " ++ show _tModuleDef ++ " " ++ show (unscope _tModuleBody) ++ ")"
     show (TList bs _ _) = "[" ++ unwords (map show bs) ++ "]"
     show TDef {..} =
-      "(TDef " ++ defTypeRep _tDefType ++ " " ++ asString' _tModule ++ "." ++ unpack _tDefName ++ " " ++
+      "(TDef " ++ defTypeRep _tDefType ++ " " ++ asString' _tModule ++ "." ++ asString' _tDefName ++ " " ++
       show _tFunType ++ " " ++ show _tMeta ++ ")"
     show TNative {..} =
       "(TNative " ++ asString' _tNativeName ++ " " ++ showFunTypes _tFunTypes ++ " " ++ unpack _tNativeDocs ++ ")"
@@ -719,7 +723,7 @@ abbrev (TModule m _ _) =
     Module{..} -> "<module " ++ asString' _mName ++ ">"
     Interface{..} -> "<interface " ++ asString' _interfaceName ++ ">"
 abbrev (TList bs tl _) = "<list(" ++ show (length bs) ++ ")" ++ showParamType tl ++ ">"
-abbrev TDef {..} = "<defun " ++ unpack _tDefName ++ ">"
+abbrev TDef {..} = "<defun " ++ asString' _tDefName ++ ">"
 abbrev TNative {..} = "<native " ++ asString' _tNativeName ++ ">"
 abbrev TConst {..} = "<defconst " ++ show _tConstArg ++ ">"
 abbrev t@TApp {} = "<app " ++ abbrev (_tAppFun t) ++ ">"

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -388,16 +388,16 @@ instance Show Module where
     Module{..} -> "(Module " ++ asString' _mName ++ " '" ++ asString' _mKeySet ++ " " ++ show _mHash ++ ")"
     Interface{..} -> "(Interface " ++ asString' _interfaceName ++ ")"
 
-data Def t n = Def
+data Def n = Def
   { _dDefName :: !DefName
   , _dModule :: !ModuleName
   , _dDefType :: !DefType
-  , _dFunType :: !(FunType (t n))
-  , _dDefBody :: !(Scope Int t n)
+  , _dFunType :: !(FunType (Term n))
+  , _dDefBody :: !(Scope Int Term n)
   , _dMeta :: !Meta
   , _dInfo :: !Info
   } deriving (Functor,Foldable,Traversable,Eq)
-instance (Show (t n)) => Show (Def t n) where
+instance (Show n) => Show (Def n) where
   show Def{..} = "(" ++ unwords
     [ defTypeRep _dDefType
     , asString' _dModule ++ "." ++ asString' _dDefName ++ ":" ++ show (_ftReturn _dFunType)
@@ -461,7 +461,7 @@ data Term n =
     , _tInfo :: !Info
     } |
     TDef {
-      _tDef :: Def Term n
+      _tDef :: Def n
     , _tInfo :: !Info
     } |
     TNative {

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -54,7 +54,7 @@ module Pact.Types.Term
    tStepEntity,tStepExec,tStepRollback,tTableName,tTableType,tValue,tVar,
    ToTerm(..),
    toTermList,toTObject,toTList,
-   typeof,typeof',
+   typeof,typeof',guardTypeOf,
    pattern TLitString,pattern TLitInteger,pattern TLitBool,
    tLit,tStr,termEq,abbrev,
    Gas(..)
@@ -646,7 +646,12 @@ toTList ty i vs = TList vs ty i
 toTermList :: (ToTerm a,Foldable f) => Type (Term b) -> f a -> Term b
 toTermList ty l = TList (map toTerm (toList l)) ty def
 
-
+guardTypeOf :: Guard -> GuardType
+guardTypeOf g = case g of
+  GKeySet KGKeySet{} -> GTyKeySet
+  GKeySet KGName{} -> GTyKeySetName
+  GPact {} -> GTyPact
+  GUser {} -> GTyUser
 
 -- | Return a Pact type, or a String description of non-value Terms.
 typeof :: Term a -> Either Text (Type (Term a))
@@ -663,7 +668,7 @@ typeof t = case t of
         BindLet -> Left "let"
         BindSchema bt -> Right $ TySchema TyBinding bt
       TObject {..} -> Right $ TySchema TyObject _tObjectType
-      TGuard {} -> Right $ TyPrim TyKeySet
+      TGuard {..} -> Right $ TyPrim $ TyGuard $ guardTypeOf _tGuard
       TUse {} -> Left "use"
       TValue {} -> Right $ TyPrim TyValue
       TStep {} -> Left "step"

--- a/src/Pact/Types/Type.hs
+++ b/src/Pact/Types/Type.hs
@@ -122,7 +122,7 @@ instance NFData PrimType
 
 
 tyInteger,tyDecimal,tyTime,tyBool,tyString,tyList,tyObject,tyValue,
-  tyKeySet,tyTable,tyKeySetNameGuard,tyPactGuard,tyUserGuard :: Text
+  tyKeySet,tyTable,tyGuard :: Text
 tyInteger = "integer"
 tyDecimal = "decimal"
 tyTime = "time"
@@ -132,9 +132,7 @@ tyList = "list"
 tyObject = "object"
 tyValue = "value"
 tyKeySet = "keyset"
-tyKeySetNameGuard = "keysetnameguard"
-tyPactGuard = "pactguard"
-tyUserGuard = "userguard"
+tyGuard = "guard"
 tyTable = "table"
 
 instance Show PrimType where
@@ -147,9 +145,7 @@ instance Show PrimType where
     TyValue -> tyValue
     TyGuard tg -> case tg of
       GTyKeySet -> tyKeySet
-      GTyKeySetName -> tyKeySetNameGuard
-      GTyPact -> tyPactGuard
-      GTyUser -> tyUserGuard
+      _ -> tyGuard
 instance Pretty PrimType where pretty = text . show
 
 data SchemaType =

--- a/src/Pact/Types/Type.hs
+++ b/src/Pact/Types/Type.hs
@@ -28,7 +28,7 @@ module Pact.Types.Type
    SchemaType(..),
    TypeVarName(..),typeVarName,
    TypeVar(..),tvName,tvConstraint,
-   Type(..),tyFunType,tyListType,tySchema,tySchemaType,tyUser,tyVar,
+   Type(..),tyFunType,tyListType,tySchema,tySchemaType,tyUser,tyVar,tyGuard,
    mkTyVar,mkTyVar',mkSchemaVar,
    isAnyTy,isVarTy,isUnconstrainedTy,canUnifyWith,
 
@@ -104,10 +104,13 @@ data GuardType
   | GTyKeySetName
   | GTyPact
   | GTyUser
+  | GTyModule
   deriving (Eq,Ord,Generic)
 
 instance NFData GuardType
 
+-- | Primitive/unvarying types.
+-- Guard is lame Maybe to allow "wildcards".
 data PrimType =
   TyInteger |
   TyDecimal |
@@ -115,7 +118,7 @@ data PrimType =
   TyBool |
   TyString |
   TyValue |
-  TyGuard GuardType
+  TyGuard (Maybe GuardType)
   deriving (Eq,Ord,Generic)
 
 instance NFData PrimType
@@ -144,7 +147,7 @@ instance Show PrimType where
     TyString -> tyString
     TyValue -> tyValue
     TyGuard tg -> case tg of
-      GTyKeySet -> tyKeySet
+      Just GTyKeySet -> tyKeySet
       _ -> tyGuard
 instance Pretty PrimType where pretty = text . show
 

--- a/src/Pact/Types/Type.hs
+++ b/src/Pact/Types/Type.hs
@@ -22,6 +22,7 @@ module Pact.Types.Type
    FunType(..),ftArgs,ftReturn,
    FunTypes,funTypes,showFunTypes,
    PrimType(..),
+   GuardType(..),
    tyInteger,tyDecimal,tyTime,tyBool,tyString,
    tyList,tyObject,tyValue,tyKeySet,tyTable,
    SchemaType(..),
@@ -98,6 +99,15 @@ showFunTypes :: Show o => FunTypes o -> String
 showFunTypes (t :| []) = show t
 showFunTypes ts = show (toList ts)
 
+data GuardType
+  = GTyKeySet
+  | GTyKeySetName
+  | GTyPact
+  | GTyUser
+  deriving (Eq,Ord,Generic)
+
+instance NFData GuardType
+
 data PrimType =
   TyInteger |
   TyDecimal |
@@ -105,13 +115,14 @@ data PrimType =
   TyBool |
   TyString |
   TyValue |
-  TyKeySet
+  TyGuard GuardType
   deriving (Eq,Ord,Generic)
 
 instance NFData PrimType
 
 
-tyInteger,tyDecimal,tyTime,tyBool,tyString,tyList,tyObject,tyValue,tyKeySet,tyTable :: Text
+tyInteger,tyDecimal,tyTime,tyBool,tyString,tyList,tyObject,tyValue,
+  tyKeySet,tyTable,tyKeySetNameGuard,tyPactGuard,tyUserGuard :: Text
 tyInteger = "integer"
 tyDecimal = "decimal"
 tyTime = "time"
@@ -121,16 +132,24 @@ tyList = "list"
 tyObject = "object"
 tyValue = "value"
 tyKeySet = "keyset"
+tyKeySetNameGuard = "keysetnameguard"
+tyPactGuard = "pactguard"
+tyUserGuard = "userguard"
 tyTable = "table"
 
 instance Show PrimType where
-  show TyInteger = unpack tyInteger
-  show TyDecimal = unpack tyDecimal
-  show TyTime = unpack tyTime
-  show TyBool = unpack tyBool
-  show TyString = unpack tyString
-  show TyValue = unpack tyValue
-  show TyKeySet = unpack tyKeySet
+  show t = unpack $ case t of
+    TyInteger -> tyInteger
+    TyDecimal -> tyDecimal
+    TyTime -> tyTime
+    TyBool -> tyBool
+    TyString -> tyString
+    TyValue -> tyValue
+    TyGuard tg -> case tg of
+      GTyKeySet -> tyKeySet
+      GTyKeySetName -> tyKeySetNameGuard
+      GTyPact -> tyPactGuard
+      GTyUser -> tyUserGuard
 instance Pretty PrimType where pretty = text . show
 
 data SchemaType =

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -26,7 +26,7 @@ module Pact.Types.Typecheck
     OverloadSpecial (..),
     Overload (..),oRoles,oTypes,oSolved,oSpecial,oFunName,
     Failure (..),prettyFails,
-    TcState (..),tcDebug,tcSupply,tcOverloads,tcFailures,tcAstToVar,tcVarToTypes,
+    TcState (..),tcDebug,tcSupply,tcOverloads,tcOverloadOrder,tcFailures,tcAstToVar,tcVarToTypes,
     TC (..), runTC,
     PrimValue (..),
     TopLevel (..),tlFun,tlInfo,tlName,tlType,tlConstVal,tlUserType,tlMeta,tlDoc,
@@ -118,6 +118,7 @@ data TcState = TcState {
   _tcSupply :: Int,
   -- | Maps native app AST to an overloaded function type, and stores result of solver.
   _tcOverloads :: M.Map TcId (Overload (AST Node)),
+  _tcOverloadOrder :: [TcId],
   _tcFailures :: S.Set Failure,
   -- | Maps ASTs to a type var.
   _tcAstToVar :: M.Map TcId (TypeVar UserType),
@@ -126,7 +127,7 @@ data TcState = TcState {
   } deriving (Eq,Show)
 
 mkTcState :: Int -> Bool -> TcState
-mkTcState sup dbg = TcState dbg sup def def def def
+mkTcState sup dbg = TcState dbg sup def def def def def
 
 instance Pretty TcState where
   pretty TcState {..} =

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -154,12 +154,12 @@ newtype TC a = TC { unTC :: StateT TcState IO a }
 -- | Storage for literal values.
 data PrimValue =
   PrimLit Literal |
-  PrimKeySet KeySet |
+  PrimGuard Guard |
   PrimValue Value
   deriving (Eq,Show)
 instance Pretty PrimValue where
   pretty (PrimLit l) = text (show l)
-  pretty (PrimKeySet k) = text (show k)
+  pretty (PrimGuard k) = text (show k)
   pretty (PrimValue v) = text (show v)
 
 

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -50,7 +50,7 @@ import Data.Foldable
 import Text.PrettyPrint.ANSI.Leijen hiding ((<$$>),(<>))
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
-import Pact.Types.Lang
+import Pact.Types.Lang hiding (App)
 import Pact.Types.Native
 
 

--- a/tests/Analyze/Translate.hs
+++ b/tests/Analyze/Translate.hs
@@ -117,7 +117,7 @@ toPactTm = \case
   ESimple TKeySet  (CoreTerm (Lit (KeySet x))) -> do
     keysets <- view (_1 . envKeysets)
     case keysets ^? ix (fromIntegral x) of
-      Just (ks, _) -> pure $ Pact.TGuard (Pact.GKeySet (Pact.KGKeySet ks)) dummyInfo
+      Just (ks, _) -> pure $ Pact.TGuard (Pact.GKeySet ks) dummyInfo
       Nothing      -> error $ "no keysets found at index " ++ show x
 
   -- term-specific terms:

--- a/tests/Analyze/Translate.hs
+++ b/tests/Analyze/Translate.hs
@@ -260,7 +260,7 @@ reverseTranslateType = \case
   TInt     -> Pact.TyPrim Pact.TyInteger
   TStr     -> Pact.TyPrim Pact.TyString
   TTime    -> Pact.TyPrim Pact.TyTime
-  TKeySet  -> Pact.TyPrim (Pact.TyGuard Pact.GTyKeySet)
+  TKeySet  -> Pact.TyPrim (Pact.TyGuard $ Just Pact.GTyKeySet)
   TAny     -> Pact.TyAny
 
 fromPactVal :: EType -> Pact.Term Pact.Ref -> IO (Maybe ETerm)

--- a/tests/Analyze/Translate.hs
+++ b/tests/Analyze/Translate.hs
@@ -27,7 +27,7 @@ import           Pact.Native.Time
 import           Pact.Typechecker           (typecheckTopLevel)
 import           Pact.Types.Exp             (Literal (..))
 import           Pact.Types.Native          (NativeDef)
-import           Pact.Types.Term            (Meta (Meta),
+import           Pact.Types.Term            (Meta (Meta), App(..),
                                              Term (TApp, TConst, TLiteral))
 import qualified Pact.Types.Term            as Pact
 import qualified Pact.Types.Type            as Pact
@@ -171,7 +171,7 @@ toPactTm = \case
       -> ReaderT (GenEnv, GenState) Maybe (Pact.Term Pact.Ref)
     mkApp (_, defTm) args = do
       args' <- traverse toPactTm args
-      pure $ TApp (liftTerm defTm) args' dummyInfo
+      pure $ TApp (App (liftTerm defTm) args' dummyInfo) dummyInfo
 
     -- Like mkApp but for functions that take two arguments, the second of
     -- which is a list. This pattern is used in `enforce-one` and `format`
@@ -183,7 +183,7 @@ toPactTm = \case
     mkApp' (_, defTm) arg argList = do
       arg'     <- toPactTm arg
       argList' <- traverse toPactTm argList
-      pure $ TApp (liftTerm defTm)
+      pure $ (`TApp` dummyInfo) $ App (liftTerm defTm)
         [arg', Pact.TList argList' (Pact.TyList Pact.TyAny) dummyInfo]
         dummyInfo
 

--- a/tests/Analyze/Translate.hs
+++ b/tests/Analyze/Translate.hs
@@ -117,7 +117,7 @@ toPactTm = \case
   ESimple TKeySet  (CoreTerm (Lit (KeySet x))) -> do
     keysets <- view (_1 . envKeysets)
     case keysets ^? ix (fromIntegral x) of
-      Just (ks, _) -> pure $ Pact.TKeySet ks dummyInfo
+      Just (ks, _) -> pure $ Pact.TGuard (Pact.GKeySet (Pact.KGKeySet ks)) dummyInfo
       Nothing      -> error $ "no keysets found at index " ++ show x
 
   -- term-specific terms:
@@ -260,7 +260,7 @@ reverseTranslateType = \case
   TInt     -> Pact.TyPrim Pact.TyInteger
   TStr     -> Pact.TyPrim Pact.TyString
   TTime    -> Pact.TyPrim Pact.TyTime
-  TKeySet  -> Pact.TyPrim Pact.TyKeySet
+  TKeySet  -> Pact.TyPrim (Pact.TyGuard Pact.GTyKeySet)
   TAny     -> Pact.TyAny
 
 fromPactVal :: EType -> Pact.Term Pact.Ref -> IO (Maybe ETerm)

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -505,9 +505,9 @@ testFinishAlone opts = do
   let allCmds = [tryCredAloneCmd, tryDebAloneCmd]
 
   let tryCredAloneCheck = makeCheck tryCredAloneCmd True
-                          (Just "(enforce-keyset k): Failure: Tx Failed: Keyset failure (keys-all)")
+                          (Just "(enforce-guard g): Failure: Tx Failed: Keyset failure (keys-all)")
       tryDebAloneCheck  = makeCheck tryDebAloneCmd True
-                          (Just "(enforce-keyset k): Failure: Tx Failed: Keyset failure (keys-all)")
+                          (Just "(enforce-guard g): Failure: Tx Failed: Keyset failure (keys-all)")
       allChecks         = [tryCredAloneCheck, tryDebAloneCheck]
 
   twoPartyEscrow allCmds allChecks opts

--- a/tests/SignatureSpec.hs
+++ b/tests/SignatureSpec.hs
@@ -17,7 +17,7 @@ import Pact.Types.Info (Info(..))
 import Pact.Types.Runtime (RefStore(..), ModuleData(..),
                            eeRefStore, rsModules)
 import Pact.Types.Term (Module(..), ModuleName(..),
-                        Meta(..), Term(..), Ref(..))
+                        Meta(..), Term(..), Ref(..), Def(..))
 
 
 spec :: Spec
@@ -62,7 +62,7 @@ aggregateFunctionModels :: ModuleData -> [Exp Info]
 aggregateFunctionModels ModuleData{..} =
   foldMap (extractExp . snd) $ HM.toList _mdRefMap
   where
-    extractExp (Ref (TDef _ _ _ _ _ Meta{_mModel=mModel} _)) = mModel
+    extractExp (Ref (TDef (Def _ _ _ _ _ Meta{_mModel=mModel} _) _)) = mModel
     extractExp _ = []
 
 -- Because models will necessarily have conflicting Info values

--- a/tests/TypecheckSpec.hs
+++ b/tests/TypecheckSpec.hs
@@ -18,6 +18,7 @@ import qualified Data.Text as T
 spec :: Spec
 spec = do
   void $ runIO $ inferModule False "tests/pact/tc.repl" "tctest"
+  void $ runIO $ inferModule False "tests/pact/caps.repl" "caps"
   void $ runIO $ inferModule False "examples/cp/cp.repl" "cp"
   void $ runIO $ inferModule False "examples/accounts/accounts.repl" "accounts"
   checkFuns

--- a/tests/TypesSpec.hs
+++ b/tests/TypesSpec.hs
@@ -27,7 +27,7 @@ testJSONPersist = do
   rt (PLiteral (LBool False))
   rt (PLiteral (LString "hello"))
   rt (PLiteral (LTime (read "2016-09-17 22:47:31.904733 UTC")))
-  rt (PKeySet (KeySet [PublicKey "askjh",PublicKey "dfgh"] (Name "predfun" def)))
+  rt (PGuard (GKeySet (KGKeySet (KeySet [PublicKey "askjh",PublicKey "dfgh"] (Name "predfun" def)))))
   rt (PValue (fromJust (decode "{ \"stuff\": [ 1.0, false ] }" :: Maybe Value)))
 
 testJSONColumns :: Spec

--- a/tests/TypesSpec.hs
+++ b/tests/TypesSpec.hs
@@ -27,7 +27,7 @@ testJSONPersist = do
   rt (PLiteral (LBool False))
   rt (PLiteral (LString "hello"))
   rt (PLiteral (LTime (read "2016-09-17 22:47:31.904733 UTC")))
-  rt (PGuard (GKeySet (KGKeySet (KeySet [PublicKey "askjh",PublicKey "dfgh"] (Name "predfun" def)))))
+  rt (PGuard (GKeySet (KeySet [PublicKey "askjh",PublicKey "dfgh"] (Name "predfun" def))))
   rt (PValue (fromJust (decode "{ \"stuff\": [ 1.0, false ] }" :: Maybe Value)))
 
 testJSONColumns :: Spec

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -12,6 +12,8 @@
   (defschema guards g:guard)
   (deftable guard-table:{guards})
 
+  (defschema yieldschema result:integer)
+
   (defcap KALL-CAP () (enforce-keyset 'kall))
 
   (defun with-kall ()
@@ -42,7 +44,7 @@
   (defun step1 (id:string)
     (insert guard-table id { "g": (create-pact-guard "test")}))
 
-  (defun step2 (id:string)
+  (defun step2:object{yieldschema} (id:string)
     (enforce-guard (get-guard id))
     (yield { "result": 1 }))
 
@@ -53,6 +55,8 @@
 (create-table guard-table)
 
 (commit-tx)
+
+(typecheck 'caps)
 
 (begin-tx)
 (use caps)

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -1,10 +1,13 @@
 
-(define-keyset "k" (sig-keyset))
+(begin-tx)
 
-(env-data { "kall": ["a" "b" "c"] })
-(define-keyset 'kall (read-keyset "kall"))
+(env-data { "kall": ["a" "b" "c"], "kadmin": ["admin"] })
+(define-keyset 'kall)
+(define-keyset 'kadmin)
 
-(module caps "k"
+(env-keys ["admin"])
+
+(module caps 'kadmin
 
   (defcap KALL-CAP () (enforce-keyset 'kall))
 
@@ -15,8 +18,15 @@
     (enforce-keyset id))
 
   (defun test-id-cap (id)
-    (with-capability (KEYSET-ID-CAP id) 1))
-)
+    (with-capability (KEYSET-ID-CAP id) (test-require id)))
+
+  (defun test-require (id)
+    (require-capability (KEYSET-ID-CAP id)) 1)
+  )
+
+(commit-tx)
+
+(use caps)
 
 (expect-failure "with-kall should fail w/o kall ks" (with-kall))
 
@@ -24,17 +34,26 @@
 
 (expect "with-kall succeeds with kall ks" 1 (with-kall))
 
-(env-data { "k1": ["d"], "k2": ["e"] })
+(env-data { "k1": ["k1"], "k2": ["k2"] })
 (define-keyset "k1")
 (define-keyset "k2")
 
 (expect-failure "cap k1 fails w/o key" (test-id-cap "k1"))
 (expect-failure "cap k2 fails w/o key" (test-id-cap "k2"))
 
-(env-keys ["d"])
+(env-keys ["k1"])
 (expect "cap k1 succeeds" 1 (test-id-cap "k1"))
+(expect-failure "direct call to test-require fails for k1" (require-capability "k1"))
 (expect-failure "cap k2 fails w/o key" (test-id-cap "k2"))
 
-(env-keys ["e"])
+(env-keys ["k2"])
 (expect-failure "cap k1 fails w/o key" (test-id-cap "k1"))
+(expect-failure "direct call to test-require fails for k2" (require-capability "k2"))
 (expect "cap k2 succeeds" 1 (test-id-cap "k2"))
+
+(expect-failure "top-level with-capability fails"
+                (with-capability (KEYSET-ID-CAP "k2") 1))
+
+(env-keys ["admin","k2"])
+(expect "top-level with-capability succeeds with module admin"
+        1 (with-capability (KEYSET-ID-CAP "k2") 1))

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -9,6 +9,9 @@
 
 (module caps 'kadmin
 
+  (defschema guards g:guard)
+  (deftable guard-table:{guards})
+
   (defcap KALL-CAP () (enforce-keyset 'kall))
 
   (defun with-kall ()
@@ -22,10 +25,36 @@
 
   (defun test-require (id)
     (require-capability (KEYSET-ID-CAP id)) 1)
-  )
+
+  (defun get-module-guard ()
+    (create-module-guard "test"))
+
+  (defun msg-keyset-user-guard (key:string)
+    (create-user-guard key "enforce-msg-keyset"))
+
+  (defun enforce-msg-keyset (key:string)
+    (enforce-keyset (read-keyset key)))
+
+  (defpact test-pact-guards (id:string)
+    (step (step1 id))
+    (step (step2 id)))
+
+  (defun step1 (id:string)
+    (insert guard-table id { "g": (create-pact-guard "test")}))
+
+  (defun step2 (id:string)
+    (enforce-guard (get-guard id))
+    (yield { "result": 1 }))
+
+  (defun get-guard (id:string)
+    (at 'g (read guard-table id)))
+
+)
+(create-table guard-table)
 
 (commit-tx)
 
+(begin-tx)
 (use caps)
 
 (expect-failure "with-kall should fail w/o kall ks" (with-kall))
@@ -54,6 +83,37 @@
 (expect-failure "top-level with-capability fails"
                 (with-capability (KEYSET-ID-CAP "k2") 1))
 
+(expect-failure "module guard fails w/o admin"
+                (enforce-guard (get-module-guard)))
+
 (env-keys ["admin","k2"])
+(enforce-guard (get-module-guard))
 (expect "top-level with-capability succeeds with module admin"
         1 (with-capability (KEYSET-ID-CAP "k2") 1))
+
+(commit-tx)
+(begin-tx)
+(use caps)
+
+(env-data { "k1": ["k1"], "k2": ["k2"] })
+(env-keys ["k1"])
+(enforce-guard (msg-keyset-user-guard "k1"))
+(expect-failure "user guard reading keyset k2 fails"
+                (enforce-guard (msg-keyset-user-guard "k2")))
+
+(enforce-guard (keyset-ref-guard "k1"))
+(expect-failure "keyset ref guard k2"
+                (enforce-guard (keyset-ref-guard "k2")))
+
+(test-pact-guards "a")
+
+(env-step 1) ;;clears pact state
+(let ((g (get-guard "a"))) ;; doing let so db failure doesn't confuse below
+  (expect-failure "enforcing pact guard outside of pact" (enforce-guard g)))
+
+(env-pactid "3")
+(test-pact-guards "a")
+(expect "pact enforce succeeds" 1 (at 'result (at 'yield (pact-state))))
+
+(env-pactid "4")
+(expect-failure "pact enforce fails" (test-pact-guards "a"))

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -1,14 +1,40 @@
 
-(env-data { "kall": ["a" "b" "c"] })
 (define-keyset "k" (sig-keyset))
+
+(env-data { "kall": ["a" "b" "c"] })
 (define-keyset 'kall (read-keyset "kall"))
+
 (module caps "k"
-  (defcap kall-cap () (enforce-keyset 'kall))
+
+  (defcap KALL-CAP () (enforce-keyset 'kall))
+
   (defun with-kall ()
-    (with-capability (kall-cap) 1)))
+    (with-capability (KALL-CAP) 1))
+
+  (defcap KEYSET-ID-CAP (id:string)
+    (enforce-keyset id))
+
+  (defun test-id-cap (id)
+    (with-capability (KEYSET-ID-CAP id) 1))
+)
 
 (expect-failure "with-kall should fail w/o kall ks" (with-kall))
 
 (env-keys ["a" "b" "c"])
 
 (expect "with-kall succeeds with kall ks" 1 (with-kall))
+
+(env-data { "k1": ["d"], "k2": ["e"] })
+(define-keyset "k1")
+(define-keyset "k2")
+
+(expect-failure "cap k1 fails w/o key" (test-id-cap "k1"))
+(expect-failure "cap k2 fails w/o key" (test-id-cap "k2"))
+
+(env-keys ["d"])
+(expect "cap k1 succeeds" 1 (test-id-cap "k1"))
+(expect-failure "cap k2 fails w/o key" (test-id-cap "k2"))
+
+(env-keys ["e"])
+(expect-failure "cap k1 fails w/o key" (test-id-cap "k1"))
+(expect "cap k2 succeeds" 1 (test-id-cap "k2"))

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -1,0 +1,14 @@
+
+(env-data { "kall": ["a" "b" "c"] })
+(define-keyset "k" (sig-keyset))
+(define-keyset 'kall (read-keyset "kall"))
+(module caps "k"
+  (defcap kall-cap () (enforce-keyset 'kall))
+  (defun with-kall ()
+    (with-capability (kall-cap) 1)))
+
+(expect-failure "with-kall should fail w/o kall ks" (with-kall))
+
+(env-keys ["a" "b" "c"])
+
+(expect "with-kall succeeds with kall ks" 1 (with-kall))

--- a/tests/pact/db.repl
+++ b/tests/pact/db.repl
@@ -37,6 +37,7 @@
 (insert persons ID_A ROW_A)
 (expect-failure "dupe key should fail" (insert persons ID_A ROW_A))
 (commit-tx)
+(begin-tx)
 (use dbtest)
 (expect "keys works" [ID_A] (keys persons))
 (expect "txids works" [2] (txids persons 2))
@@ -56,8 +57,10 @@
 
 (expect "read-persons works w/o admin key" ROW_A (read-persons ID_A))
 (expect "read-persons2 works w/o admin key" ROW_A (dbtest2.read-persons2 ID_A))
+(commit-tx)
 
-
+(begin-tx)
+(use dbtest)
 (expect-failure "insert protected by admin key" (insert persons "foo" ROW_A))
 (expect-failure "keys protected by admin key" (keys persons))
 (expect-failure "txids protected by admin key" (txids persons 0))


### PR DESCRIPTION
For #31.

~PactContinuationSpec tests are failing, but the tests in accounts.repl succeed, so will need @LindaOrtega 's help. All other tests are passing.~ All tests are passing.

Changes beyond what's described in #31:
- safe Term constructors for TApp (w/ App), TDef (w/ Def)
- better doc errors in DocGen (namely for backtick madness)
- `define-keyset` now has a one-arg option to `read-keyset` for the same key as the keyset name
- typechecker overloads solve queue now proceeds in leaf-to-root order, roughly
- PureSysRead now PureReadOnly, allows any read