### PR TITLE
Render line numbers properly on returned errors.

### DIFF
--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -148,8 +148,7 @@ handleCompile src exp a =
                         outStr HErr (renderPrettyString (colors mode) (_pDelta d))
                         outStrLn HErr $ ": error: " ++ unpack (peText er)
             Nothing -> outStrLn HErr $ "[No location]: " ++ unpack (peText er)
-          return (Left $ show er)
-
+          Left <$> renderErr er
 
 compileEval :: String -> Exp Parsed -> Repl (Either String (Term Name))
 compileEval src exp = handleCompile src exp $ \e -> pureEval (_tInfo e) (eval e)


### PR DESCRIPTION
With this change we get proper line numbers on most (all)*) Pact errors in pact-web.

*) I was not able to find any errors that still trigger errors without a line number.