### PR TITLE
Get rid of redundant "expected" in error output.

### DIFF
--- a/src/Pact/Types/ExpParser.hs
+++ b/src/Pact/Types/ExpParser.hs
@@ -139,7 +139,7 @@ runCompile act cs a =
         (Label s:_) -> doErr def (toList s)
         er -> doErr def (show er)
       Label ne -> doErr def (toList ne)
-      Tokens (x :| _) -> doErr (getInfo x) $ "expected " <> showExpect expect
+      Tokens (x :| _) -> doErr (getInfo x) $ showExpect expect
     (Left e) -> doErr def (show e)
     where doErr i s = Left $ PactError SyntaxError i def (pack s)
           showExpect e = case labelText $ S.toList e of


### PR DESCRIPTION
I was not able to proof that this "expected" is redundant in all cases,
but it looks like it.

In fact I was not even able to figure out why this was redudant at all,
but it definitely is (at least in the cases I tested).