### PR TITLE
Get rid of redundant "expected" in error messages.

### DIFF
--- a/src/Pact/Types/ExpParser.hs
+++ b/src/Pact/Types/ExpParser.hs
@@ -139,7 +139,7 @@ runCompile act cs a =
         (Label s:_) -> doErr def (toList s)
         er -> doErr def (show er)
       Label ne -> doErr def (toList ne)
-      Tokens (x :| _) -> doErr (getInfo x) $ "expected " <> showExpect expect
+      Tokens (x :| _) -> doErr (getInfo x) $ showExpect expect
     (Left e) -> doErr def (show e)
     where doErr i s = Left $ PactError SyntaxError i def (pack s)
           showExpect e = case labelText $ S.toList e of

--- a/src/Pact/Types/ExpParser.hs
+++ b/src/Pact/Types/ExpParser.hs
@@ -147,7 +147,7 @@ runCompile act cs a =
             ss -> intercalate "," ss
           labelText [] = []
           labelText (Label s:r) = toList s:labelText r
-          labelText (EndOfInput:r) = "end of expression or input":labelText r
+          labelText (EndOfInput:r) = "Expected: end of expression or input":labelText r
           labelText (_:r) = labelText r
 
 


### PR DESCRIPTION
Error reporting sites use the `expected` function for reporting about missing things that were expected, which already prepends "Expected:". Therefore we get "expected Expected: ...." error messages.