### PR TITLE
Improved the guardTable function in DB.hs and beautified the call function in Runtime.hs

### DIFF
--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -351,9 +351,7 @@ createTable' i as = argsError i as
 
 guardTable :: Show n => FunApp -> Term n -> Eval e ()
 guardTable i TTable {..} = do
-  let findMod _ r@Just {} = r
-      findMod sf _ = firstOf (sfApp . _Just . _1 . faModule . _Just) sf
-  r <- foldr findMod Nothing . reverse <$> use evalCallStack
+  r <- uses evalCallStack (firstOf (traverse . sfApp . _Just . _1 . faModule . _Just))
   case r of
     (Just mn) | mn == _tModule -> enforceBlessedHashes i _tModule _tHash
     _ -> do

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -263,7 +263,7 @@ call :: StackFrame -> Eval e (Gas,a) -> Eval e a
 call s act = do
   evalCallStack %= (s:)
   (_gas,r) <- act -- TODO opportunity for per-call gas logging here
-  evalCallStack %= \st -> case st of (_:as) -> as; [] -> []
+  evalCallStack %= drop 1
   return r
 {-# INLINE call #-}
 


### PR DESCRIPTION
The primary change I made is to use the firstOf lens function. When combined with traverse in the following manner:

`\f -> firstOf (traverse . f)`

The resulting function short circuits on the first part of traversable structure for which the function 
f admits something which satisfies the predicate isJust. This can be easily seen by evaluating:

`(\f -> firstOf (traverse . f) id [1..] == Just 1`.