### PR TITLE
Support list typechecking

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -129,7 +129,6 @@ library
                      , bound >= 2 && < 2.1
                      , bytestring >=0.10.8.1 && < 0.11
                      , cereal >=0.5.4.0 && < 0.6
-                     , compactable >= 0.1 && < 0.2
                      , containers >= 0.5.7 && < 0.6
                      , data-default >= 0.7.1.1 && < 0.8
                      , deepseq >= 1.4.2.0 && < 1.5

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -281,10 +281,8 @@ listLiteral = withList Brackets $ \ListExp{..} -> do
   ls <- case _listList of
     _ : CommaExp : _ -> valueLevel `sepBy` sep Comma
     _                -> many valueLevel
-  let lty = case nub (map typeof ls) of
-              [Right ty] -> ty
-              _ -> TyAny
-  pure $ TList ls lty _listInfo
+  lty <- freshTyVar
+  return $ TList ls lty _listInfo
 
 objectLiteral :: Compile (Term Name)
 objectLiteral = withList Braces $ \ListExp{..} -> do

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -121,6 +121,16 @@
   ;;not tc per se but runtime type enforce error
   (defun rtc-empty-string-list:[string] (input:[string]) input)
 
+  (defun tc-at-literal-typed-list:integer (a:integer)
+    (at 0 [a]))
+
+  (defun tc-format-heterogenous:string ()
+    (format "{} {} {}" [1 1.0 true]))
+
+  (defun fails-literal-typed-list:integer (a:integer)
+    (at 0 [a 1 true]))
+
+
 )
 
 (create-table persons)

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -130,6 +130,12 @@
   (defun fails-literal-typed-list:integer (a:integer)
     (at 0 [a 1 true]))
 
+  (defun tc-list-assumes-literal-type:[integer] ()
+    [1 2 3])
+
+  (defun fails-list-literal-type:[integer] ()
+    [1.0 2.0])
+
 
 )
 


### PR DESCRIPTION
Fixes #312 .

Supporting `format`, which accepts a heterogenous list, meant taking the `TyList TyAny` type seriously: if a function specifies this, then the typechecker ignores list contents. 

Compile no longer attempts to infer a list type but simply parameterizes the list with a fresh var; this is overwritten with `TyAny` in the typechecker on a specified heterogenous list, which is then seen in `applySchemas` to defeat typechecking. 

Otherwise, the list var is specialized based on contents such that a bad list member will fail to typecheck, and a good list results in the var being properly specialized.