### PR TITLE
Add public metadata to Pact command API

### DIFF
--- a/src-ghc/Pact/ApiReq.hs
+++ b/src-ghc/Pact/ApiReq.hs
@@ -149,12 +149,12 @@ mkApiReqCont ar@ApiReq{..} fp = do
 
 mkCont :: TxId -> Int -> Bool  -> Value -> PublicMeta -> [KeyPair]
   -> Maybe String -> IO (Command Text)
-mkCont txid step rollback mdata addy kps ridm = do
+mkCont txid step rollback mdata pubMeta kps ridm = do
   rid <- maybe (show <$> getCurrentTime) return ridm
   return $ decodeUtf8 <$>
     mkCommand
     (map (\KeyPair {..} -> (ED25519,_kpSecret,_kpPublic)) kps)
-    addy
+    pubMeta
     (pack $ show rid)
     (Continuation (ContMsg txid step rollback mdata) :: (PactRPC ContMsg))
 

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -56,7 +56,9 @@ benchCompile es = bgroup "compile" $ (`map` es) $
 
 benchVerify :: [(String,Command ByteString)] -> Benchmark
 benchVerify cs = bgroup "verify" $ (`map` cs) $
-  \(bname,c) -> bench bname $ nf verifyCommand c
+  \(bname,c) ->
+    bench bname $
+      nf (verifyCommand :: Command ByteString -> ProcessedCommand () ParsedCode) c
 
 eitherDie :: Either String a -> IO a
 eitherDie = either (throwIO . userError) (return $!)
@@ -122,7 +124,7 @@ main = do
   !mpdbRS <- loadBenchModule mockPersistDb
   print =<< runPactExec mockPersistDb mpdbRS benchCmd
   !cmds <- return $!! (`fmap` exps) $ fmap $ \t -> mkCommand' [(ED25519,pub,priv)]
-              (toStrict $ encode (Payload (Exec (ExecMsg t Null)) "nonce" Nothing))
+              (toStrict $ encode (Payload (Exec (ExecMsg t Null)) "nonce" ()))
 
   defaultMain [
     benchParse,

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -20,8 +20,6 @@ import Control.Exception.Safe
 import Control.Monad.Except
 import Control.Monad.Reader
 import qualified Data.Map.Strict as M
-import qualified Data.Set as S
-import Control.Lens (view)
 
 import Data.Aeson as A
 import Data.Maybe (fromMaybe)
@@ -32,23 +30,23 @@ import Pact.Types.Runtime hiding (PublicKey)
 import Pact.Types.Server
 import Pact.Types.Logger
 import Pact.Gas
+import Pact.Parse (ParsedDecimal(..))
 
 import Pact.Interpreter
 
-initPactService :: CommandConfig -> Loggers -> IO (CommandExecInterface (PactRPC ParsedCode))
+initPactService :: CommandConfig -> Loggers -> IO (CommandExecInterface PublicMeta ParsedCode)
 initPactService CommandConfig {..} loggers = do
   let logger = newLogger loggers "PactService"
       klog s = logLog logger "INIT" s
-      gasLimit = fromMaybe 0 _ccGasLimit
       gasRate = fromMaybe 0 _ccGasRate
-      gasEnv = (GasEnv (fromIntegral gasLimit) 0.0 (constGasModel (fromIntegral gasRate)))
+      gasModel = constGasModel (fromIntegral gasRate)
       mkCEI p@PactDbEnv {..} = do
         cmdVar <- newMVar (CommandState initRefStore M.empty)
         klog "Creating Pact Schema"
         initSchema p
         return CommandExecInterface
-          { _ceiApplyCmd = \eMode cmd -> applyCmd logger _ccEntity p cmdVar gasEnv eMode cmd (verifyCommand cmd)
-          , _ceiApplyPPCmd = applyCmd logger _ccEntity p cmdVar gasEnv }
+          { _ceiApplyCmd = \eMode cmd -> applyCmd logger _ccEntity p cmdVar gasModel eMode cmd (verifyCommand cmd)
+          , _ceiApplyPPCmd = applyCmd logger _ccEntity p cmdVar gasModel }
   case _ccSqlite of
     Nothing -> do
       klog "Initializing pure pact"
@@ -58,10 +56,14 @@ initPactService CommandConfig {..} loggers = do
       mkSQLiteEnv logger True sqlc loggers >>= mkCEI
 
 
-applyCmd :: Logger -> Maybe EntityName -> PactDbEnv p -> MVar CommandState -> GasEnv -> ExecutionMode -> Command a ->
-            ProcessedCommand (PactRPC ParsedCode) -> IO CommandResult
+applyCmd :: Logger -> Maybe EntityName -> PactDbEnv p -> MVar CommandState ->
+            GasModel -> ExecutionMode -> Command a ->
+            ProcessedCommand PublicMeta ParsedCode -> IO CommandResult
 applyCmd _ _ _ _ _ ex cmd (ProcFail s) = return $ jsonResult ex (cmdToRequestKey cmd) s
-applyCmd logger conf dbv cv gasEnv exMode _ (ProcSucc cmd) = do
+applyCmd logger conf dbv cv gasModel exMode _ (ProcSucc cmd) = do
+  let pubMeta = _pMeta $ _cmdPayload cmd
+      (ParsedDecimal gasPrice) = _pmGasPrice pubMeta
+      gasEnv = GasEnv (fromIntegral $ _pmGasLimit pubMeta) (GasPrice gasPrice) gasModel
   r <- tryAny $ runCommand (CommandEnv conf exMode dbv cv logger gasEnv) $ runPayload cmd
   case r of
     Right cr -> do
@@ -79,20 +81,11 @@ exToTx :: ExecutionMode -> Maybe TxId
 exToTx (Transactional t) = Just t
 exToTx Local = Nothing
 
-runPayload :: Command (Payload (PactRPC ParsedCode)) -> CommandM p CommandResult
-runPayload c@Command{..} = do
-  let runRpc (Exec pm) = applyExec (cmdToRequestKey c) pm c
-      runRpc (Continuation ym) = applyContinuation (cmdToRequestKey c) ym c
-      Payload{..} = _cmdPayload
-  case _pAddress of
-    Just Address{..} -> do
-      -- simulate fake blinding if not addressed to this entity or no entity specified
-      ent <- view ceEntity
-      mode <- view ceMode
-      case ent of
-        Just entName | entName == _aFrom || (entName `S.member` _aTo) -> runRpc _pPayload
-        _ -> return $ jsonResult mode (cmdToRequestKey c) $ CommandError "Private" Nothing
-    Nothing -> runRpc _pPayload
+runPayload :: Command (Payload PublicMeta ParsedCode) -> CommandM p CommandResult
+runPayload c@Command{..} = case (_pPayload _cmdPayload) of
+  Exec pm -> applyExec (cmdToRequestKey c) pm c
+  Continuation ym -> applyContinuation (cmdToRequestKey c) ym c
+
 
 applyExec :: RequestKey -> ExecMsg ParsedCode -> Command a -> CommandM p CommandResult
 applyExec rk (ExecMsg parsedCode edata) Command{..} = do
@@ -153,7 +146,7 @@ applyContinuation rk msg@ContMsg{..} Command{..} = do
             Left (SomeException ex) -> throwM ex
             Right EvalResult{..} -> do
               exec@PactExec{..} <- maybe (throwCmdEx "No pact execution in continuation exec!")
-                                   return erExec         
+                                   return erExec
               if _cmRollback
                 then rollbackUpdate env msg state
                 else continuationUpdate env msg state pact exec
@@ -162,7 +155,7 @@ applyContinuation rk msg@ContMsg{..} Command{..} = do
 rollbackUpdate :: CommandEnv p -> ContMsg -> CommandState -> CommandM p ()
 rollbackUpdate CommandEnv{..} ContMsg{..} CommandState{..} = do
   -- if step doesn't have a rollback function, no error thrown. Therefore, pact will be deleted
-  -- from state. 
+  -- from state.
   let newState = CommandState _csRefStore $ M.delete _cmTxId _csPacts
   liftIO $ logLog _ceLogger "DEBUG" $ "applyContinuation: rollbackUpdate: reaping pact "
     ++ show _cmTxId
@@ -172,7 +165,7 @@ continuationUpdate :: CommandEnv p -> ContMsg -> CommandState -> CommandPact -> 
 continuationUpdate CommandEnv{..} ContMsg{..} CommandState{..} CommandPact{..} PactExec{..} = do
   let nextStep = _cmStep + 1
       isLast = nextStep >= _cpStepCount
-      updateState pacts = CommandState _csRefStore pacts -- never loading modules during continuations 
+      updateState pacts = CommandState _csRefStore pacts -- never loading modules during continuations
 
   if isLast
     then do
@@ -183,4 +176,4 @@ continuationUpdate CommandEnv{..} ContMsg{..} CommandState{..} CommandPact{..} P
       let newPact = CommandPact _cpTxId _cpContinuation _cpStepCount _cmStep _peYield
       liftIO $ logLog _ceLogger "DEBUG" $ "applyContinuation: updated state of pact "
         ++ show _cmTxId ++ ": " ++ show newPact
-      void $ liftIO $ swapMVar _ceState $ updateState $ M.insert _cmTxId newPact _csPacts 
+      void $ liftIO $ swapMVar _ceState $ updateState $ M.insert _cmTxId newPact _csPacts

--- a/src-ghc/Pact/Types/Command.hs
+++ b/src-ghc/Pact/Types/Command.hs
@@ -11,8 +11,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FunctionalDependencies #-}
 
 -- |
 -- Module      :  Pact.Types.Command

--- a/src-ghc/Pact/Types/Command.hs
+++ b/src-ghc/Pact/Types/Command.hs
@@ -11,6 +11,8 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
 
 -- |
 -- Module      :  Pact.Types.Command
@@ -24,7 +26,10 @@
 module Pact.Types.Command
   ( Command(..),mkCommand,mkCommand'
   , ProcessedCommand(..)
-  , Address(..)
+  , Address(..),aFrom,aTo
+  , PrivateMeta(..),pmAddress
+  , PublicMeta(..),pmChainId,pmSender,pmGasLimit,pmGasPrice,pmFee
+  , HasPlafMeta(..)
   , Payload(..)
   , ParsedCode(..)
   , UserSig(..),usScheme,usPubKey,usSig
@@ -54,6 +59,7 @@ import Data.String
 import Data.Text hiding (filter, all)
 import Data.Hashable (Hashable)
 import qualified Data.Set as S
+import Data.Default (Default,def)
 
 
 import GHC.Generics
@@ -66,6 +72,11 @@ import Pact.Types.Hash
 import Pact.Parse
 import Pact.Types.RPC
 
+-- | Command is the signed, hashed envelope of a Pact execution instruction or command.
+-- In 'Command ByteString', the 'ByteString' payload is hashed and signed; the ByteString
+-- being the JSON serialization of 'Payload Text', where the 'Text' is the pact code; when
+-- executed this is parsed to 'ParsedCode'.
+-- Thus, 'Command (Payload ParsedCode)' is the fully executable specialization.
 data Command a = Command
   { _cmdPayload :: !a
   , _cmdSigs :: ![UserSig]
@@ -87,7 +98,9 @@ instance (FromJSON a) => FromJSON (Command a) where
 
 instance NFData a => NFData (Command a)
 
-mkCommand :: ToJSON a => [(PPKScheme, PrivateKey, Base.PublicKey)] -> Maybe Address -> Text -> a -> Command ByteString
+mkCommand :: (ToJSON m, ToJSON c) =>
+             [(PPKScheme, PrivateKey, Base.PublicKey)] -> m ->
+             Text -> PactRPC c -> Command ByteString
 mkCommand creds addy nonce a = mkCommand' creds $ BSL.toStrict $ A.encode (Payload a nonce addy)
 
 mkCommand' :: [(PPKScheme, PrivateKey, Base.PublicKey)] -> ByteString -> Command ByteString
@@ -98,12 +111,12 @@ mkCommand' creds env = Command env (sig <$> creds) hsh
 
 
 
-verifyCommand :: Command ByteString -> ProcessedCommand (PactRPC ParsedCode)
+verifyCommand :: FromJSON m => Command ByteString -> ProcessedCommand m ParsedCode
 verifyCommand orig@Command{..} = case (ppcmdPayload', ppcmdHash', mSigIssue) of
       (Right env', Right _, Nothing) -> ProcSucc $ orig { _cmdPayload = env' }
       (e, h, s) -> ProcFail $ "Invalid command: " ++ toErrStr e ++ toErrStr h ++ fromMaybe "" s
   where
-    ppcmdPayload' = traverse (traverse parsePact) =<< A.eitherDecodeStrict' _cmdPayload
+    ppcmdPayload' = traverse parsePact =<< A.eitherDecodeStrict' _cmdPayload
     parsePact :: Text -> Either String ParsedCode
     parsePact code = ParsedCode code <$> parseExprs code
     (ppcmdSigs' :: [(UserSig,Bool)]) = (\u -> (u,verifyUserSig _cmdHash u)) <$> _cmdSigs
@@ -115,19 +128,22 @@ verifyCommand orig@Command{..} = case (ppcmdPayload', ppcmdHash', mSigIssue) of
     toErrStr (Left s) = s ++ "; "
 {-# INLINE verifyCommand #-}
 
-
-data ProcessedCommand a =
-  ProcSucc !(Command (Payload a)) |
+-- | Strict Either thing for attempting to desz a Command.
+data ProcessedCommand m a =
+  ProcSucc !(Command (Payload m a)) |
   ProcFail !String
   deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
-instance NFData a => NFData (ProcessedCommand a)
+instance (NFData a,NFData m) => NFData (ProcessedCommand m a)
 
+-- | Pair parsed Pact expressions with the original text.
 data ParsedCode = ParsedCode {
   _pcCode :: !Text,
   _pcExps :: ![Exp Parsed]
   } deriving (Eq,Show,Generic)
 instance NFData ParsedCode
 
+
+-- | Confidential/Encrypted addressing info, for use in metadata on privacy-supporting platforms.
 data Address = Address {
     _aFrom :: EntityName
   , _aTo :: S.Set EntityName
@@ -137,15 +153,54 @@ instance Serialize Address
 instance ToJSON Address where toJSON = lensyToJSON 2
 instance FromJSON Address where parseJSON = lensyParseJSON 2
 
-data Payload a = Payload
-  { _pPayload :: !a
-  , _pNonce :: !Text
-  , _pAddress :: !(Maybe Address)
-  } deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
+data PrivateMeta = PrivateMeta
+  { _pmAddress :: Maybe Address
+  } deriving (Eq,Show,Generic)
+instance Default PrivateMeta where def = PrivateMeta def
+instance ToJSON PrivateMeta where toJSON = lensyToJSON 3
+instance FromJSON PrivateMeta where parseJSON = lensyParseJSON 3
+instance NFData PrivateMeta
+instance Serialize PrivateMeta
 
-instance NFData a => NFData (Payload a)
-instance ToJSON a => ToJSON (Payload a) where toJSON = lensyToJSON 2
-instance FromJSON a => FromJSON (Payload a) where parseJSON = lensyParseJSON 2
+-- | Contains all necessary metadata for a Chainweb-style public chain.
+data PublicMeta = PublicMeta
+  { _pmChainId :: Text
+  , _pmSender :: Text
+  , _pmGasLimit :: ParsedInteger
+  , _pmGasPrice :: ParsedDecimal
+  , _pmFee :: ParsedDecimal
+  } deriving (Eq,Show,Generic)
+instance Default PublicMeta where def = PublicMeta "" "" 0 0 0
+instance ToJSON PublicMeta where toJSON = lensyToJSON 3
+instance FromJSON PublicMeta where parseJSON = lensyParseJSON 3
+instance NFData PublicMeta
+instance Serialize PublicMeta
+
+class HasPlafMeta a where
+  getPrivateMeta :: a -> PrivateMeta
+  getPublicMeta :: a -> PublicMeta
+
+instance HasPlafMeta PrivateMeta where
+  getPrivateMeta = id
+  getPublicMeta = const def
+
+instance HasPlafMeta PublicMeta where
+  getPrivateMeta = const def
+  getPublicMeta = id
+
+instance HasPlafMeta () where
+  getPrivateMeta = const def
+  getPublicMeta = const def
+
+-- | Payload combines a 'PactRPC' with a nonce and platform-specific metadata.
+data Payload m c = Payload
+  { _pPayload :: !(PactRPC c)
+  , _pNonce :: !Text
+  , _pMeta :: !m
+  } deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
+instance (NFData a,NFData m) => NFData (Payload m a)
+instance (ToJSON a,ToJSON m) => ToJSON (Payload m a) where toJSON = lensyToJSON 2
+instance (FromJSON a,FromJSON m) => FromJSON (Payload m a) where parseJSON = lensyParseJSON 2
 
 
 
@@ -213,11 +268,11 @@ data ExecutionMode =
 
 
 type ApplyCmd = ExecutionMode -> Command ByteString -> IO CommandResult
-type ApplyPPCmd a = ExecutionMode -> Command ByteString -> ProcessedCommand a -> IO CommandResult
+type ApplyPPCmd m a = ExecutionMode -> Command ByteString -> ProcessedCommand m a -> IO CommandResult
 
-data CommandExecInterface a = CommandExecInterface
+data CommandExecInterface m a = CommandExecInterface
   { _ceiApplyCmd :: ApplyCmd
-  , _ceiApplyPPCmd :: ApplyPPCmd a
+  , _ceiApplyPPCmd :: ApplyPPCmd m a
   }
 
 
@@ -239,3 +294,6 @@ initialRequestKey = RequestKey initialHash
 makeLenses ''UserSig
 makeLenses ''CommandExecInterface
 makeLenses ''ExecutionMode
+makeLenses ''Address
+makeLenses ''PrivateMeta
+makeLenses ''PublicMeta

--- a/src-ghc/Pact/Types/Command.hs
+++ b/src-ghc/Pact/Types/Command.hs
@@ -99,7 +99,7 @@ instance NFData a => NFData (Command a)
 mkCommand :: (ToJSON m, ToJSON c) =>
              [(PPKScheme, PrivateKey, Base.PublicKey)] -> m ->
              Text -> PactRPC c -> Command ByteString
-mkCommand creds addy nonce a = mkCommand' creds $ BSL.toStrict $ A.encode (Payload a nonce addy)
+mkCommand creds meta nonce a = mkCommand' creds $ BSL.toStrict $ A.encode (Payload a nonce meta)
 
 mkCommand' :: [(PPKScheme, PrivateKey, Base.PublicKey)] -> ByteString -> Command ByteString
 mkCommand' creds env = Command env (sig <$> creds) hsh
@@ -126,7 +126,7 @@ verifyCommand orig@Command{..} = case (ppcmdPayload', ppcmdHash', mSigIssue) of
     toErrStr (Left s) = s ++ "; "
 {-# INLINE verifyCommand #-}
 
--- | Strict Either thing for attempting to desz a Command.
+-- | Strict Either thing for attempting to deserialize a Command.
 data ProcessedCommand m a =
   ProcSucc !(Command (Payload m a)) |
   ProcFail !String

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -47,7 +47,6 @@ import Safe
 import Control.Arrow hiding (app)
 import Data.Foldable
 import Data.Aeson hiding ((.=))
-import Data.Decimal
 import Data.List
 import Data.Function (on)
 import Data.ByteString.Lazy (toStrict)
@@ -447,27 +446,6 @@ readMsg i [TLitString key] = parseMsgKey i "read-msg" key
 readMsg _ [] = TValue <$> view eeMsgBody <*> pure def
 readMsg i as = argsError i as
 
--- | One-off type for 'readDecimal', not exported.
-newtype ParsedDecimal = ParsedDecimal Decimal
-instance FromJSON ParsedDecimal where
-  parseJSON (String s) =
-    ParsedDecimal <$> case AP.parseOnly (unPactParser number) s of
-                        Right (LDecimal d) -> return d
-                        Right (LInteger i) -> return (fromIntegral i)
-                        _ -> fail $ "Failure parsing decimal string: " ++ show s
-  parseJSON (Number n) = return $ ParsedDecimal (fromRational $ toRational n)
-  parseJSON v = fail $ "Failure parsing integer: " ++ show v
-
-
--- | One-off type for 'readInteger', not exported.
-newtype ParsedInteger = ParsedInteger Integer
-instance FromJSON ParsedInteger where
-  parseJSON (String s) =
-    ParsedInteger <$> case AP.parseOnly (unPactParser number) s of
-                        Right (LInteger i) -> return i
-                        _ -> fail $ "Failure parsing integer string: " ++ show s
-  parseJSON (Number n) = return $ ParsedInteger (round n)
-  parseJSON v = fail $ "Failure parsing integer: " ++ show v
 
 readInteger :: RNativeFun e
 readInteger i [TLitString key] = do

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -10,6 +10,7 @@ import Data.Aeson hiding (Options)
 import qualified Network.HTTP.Client as HTTP
 import Network.Wreq
 import Control.Lens ((&), (.~))
+import Data.Default (def)
 
 import Pact.ApiReq
 import Pact.Types.API
@@ -40,9 +41,9 @@ testNestedPacts opts = before_ flushDb $ after_ flushDb $
 
     moduleCmd <- mkExec (T.unpack (threeStepPactCode "nestedPact"))
                  (object ["admin-keyset" .= [_kpPublic adminKeys]])
-                 Nothing [adminKeys] (Just "test1")
+                 def [adminKeys] (Just "test1")
     nestedExecPactCmd <- mkExec ("(nestedPact.tester)" ++ " (nestedPact.tester)")
-                         Null Nothing [adminKeys] (Just "test2")
+                         Null def [adminKeys] (Just "test2")
     allResults <- runAll opts [moduleCmd, nestedExecPactCmd]
 
     let allChecks = [makeCheck moduleCmd False Nothing,
@@ -80,7 +81,7 @@ testPactContinuation opts = before_ flushDb $ after_ flushDb $ do
 testSimpleServerCmd :: Options -> IO (Maybe ApiResult)
 testSimpleServerCmd opts = do
   simpleKeys <- genKeys
-  cmd <- mkExec  "(+ 1 2)" Null Nothing
+  cmd <- mkExec  "(+ 1 2)" Null def
              [simpleKeys] (Just "test1")
   allResults <- runAll opts [cmd]
   return $ HM.lookup (RequestKey (_cmdHash cmd)) allResults
@@ -93,11 +94,11 @@ testCorrectNextStep opts = do
 
   moduleCmd       <- mkExec (T.unpack (threeStepPactCode moduleName))
                      (object ["admin-keyset" .= [_kpPublic adminKeys]])
-                     Nothing [adminKeys] (Just "test1")
+                     def [adminKeys] (Just "test1")
   executePactCmd  <- mkExec ("(" ++ moduleName ++ ".tester)")
-                     Null Nothing [adminKeys] (Just "test2")
-  contNextStepCmd <- mkCont (TxId 1) 1 False Null Nothing [adminKeys] (Just "test3")
-  checkStateCmd   <- mkCont (TxId 1) 1 False Null Nothing [adminKeys] (Just "test4")
+                     Null def [adminKeys] (Just "test2")
+  contNextStepCmd <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
+  checkStateCmd   <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test4")
   allResults      <- runAll opts [moduleCmd, executePactCmd, contNextStepCmd, checkStateCmd]
 
   let moduleCheck       = makeCheck moduleCmd False Nothing
@@ -117,11 +118,11 @@ testIncorrectNextStep opts = do
 
   moduleCmd         <- mkExec (T.unpack (threeStepPactCode moduleName))
                        (object ["admin-keyset" .= [_kpPublic adminKeys]])
-                       Nothing [adminKeys] (Just "test1")
+                       def [adminKeys] (Just "test1")
   executePactCmd    <- mkExec ("(" ++ moduleName ++ ".tester)")
-                       Null Nothing [adminKeys] (Just "test2")
-  incorrectStepCmd  <- mkCont (TxId 1) 2 False Null Nothing [adminKeys] (Just "test3")
-  checkStateCmd     <- mkCont (TxId 1) 1 False Null Nothing [adminKeys] (Just "test4")
+                       Null def [adminKeys] (Just "test2")
+  incorrectStepCmd  <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test3")
+  checkStateCmd     <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test4")
   allResults        <- runAll opts [moduleCmd, executePactCmd, incorrectStepCmd, checkStateCmd]
 
   let moduleCheck        = makeCheck moduleCmd False Nothing
@@ -141,12 +142,12 @@ testLastStep opts = do
 
   moduleCmd        <- mkExec (T.unpack (threeStepPactCode moduleName))
                       (object ["admin-keyset" .= [_kpPublic adminKeys]])
-                      Nothing [adminKeys] (Just "test1")
+                      def [adminKeys] (Just "test1")
   executePactCmd   <- mkExec ("(" ++ moduleName ++ ".tester)")
-                      Null Nothing [adminKeys] (Just "test2")
-  contNextStep1Cmd <- mkCont (TxId 1) 1 False Null Nothing [adminKeys] (Just "test3")
-  contNextStep2Cmd <- mkCont (TxId 1) 2 False Null Nothing [adminKeys] (Just "test4")
-  checkStateCmd    <- mkCont (TxId 1) 3 False Null Nothing [adminKeys] (Just "test5")
+                      Null def [adminKeys] (Just "test2")
+  contNextStep1Cmd <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
+  contNextStep2Cmd <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test4")
+  checkStateCmd    <- mkCont (TxId 1) 3 False Null def [adminKeys] (Just "test5")
   allResults       <- runAll opts [moduleCmd, executePactCmd, contNextStep1Cmd,
                               contNextStep2Cmd, checkStateCmd]
 
@@ -169,11 +170,11 @@ testErrStep opts = do
 
   moduleCmd        <- mkExec (T.unpack (errorStepPactCode moduleName))
                       (object ["admin-keyset" .= [_kpPublic adminKeys]])
-                      Nothing [adminKeys] (Just "test1")
+                      def [adminKeys] (Just "test1")
   executePactCmd   <- mkExec ("(" ++ moduleName ++ ".tester)")
-                      Null Nothing [adminKeys] (Just "test2")
-  contErrStepCmd   <- mkCont (TxId 1) 1 False Null Nothing [adminKeys] (Just "test3")
-  checkStateCmd    <- mkCont (TxId 1) 2 False Null Nothing [adminKeys] (Just "test4")
+                      Null def [adminKeys] (Just "test2")
+  contErrStepCmd   <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
+  checkStateCmd    <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test4")
   allResults       <- runAll opts [moduleCmd, executePactCmd, contErrStepCmd, checkStateCmd]
 
   let moduleCheck        = makeCheck moduleCmd False Nothing
@@ -215,12 +216,12 @@ testCorrectRollbackStep opts = do
 
   moduleCmd       <- mkExec (T.unpack (pactWithRollbackCode moduleName))
                      (object ["admin-keyset" .= [_kpPublic adminKeys]])
-                     Nothing [adminKeys] (Just "test1")
+                     def [adminKeys] (Just "test1")
   executePactCmd  <- mkExec ("(" ++ moduleName ++ ".tester)")
-                     Null Nothing [adminKeys] (Just "test2")
-  contNextStepCmd <- mkCont (TxId 1) 1 False Null Nothing [adminKeys] (Just "test3")
-  rollbackStepCmd <- mkCont (TxId 1) 1 True Null Nothing [adminKeys] (Just "test4") -- rollback = True
-  checkStateCmd   <- mkCont (TxId 1) 2 False Null Nothing [adminKeys] (Just "test5")
+                     Null def [adminKeys] (Just "test2")
+  contNextStepCmd <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
+  rollbackStepCmd <- mkCont (TxId 1) 1 True Null def [adminKeys] (Just "test4") -- rollback = True
+  checkStateCmd   <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test5")
   allResults      <- runAll opts [moduleCmd, executePactCmd, contNextStepCmd,
                              rollbackStepCmd, checkStateCmd]
 
@@ -243,12 +244,12 @@ testIncorrectRollbackStep opts = do
 
   moduleCmd       <- mkExec (T.unpack (pactWithRollbackCode moduleName))
                      (object ["admin-keyset" .= [_kpPublic adminKeys]])
-                     Nothing [adminKeys] (Just "test1")
+                     def [adminKeys] (Just "test1")
   executePactCmd  <- mkExec ("(" ++ moduleName ++ ".tester)")
-                     Null Nothing [adminKeys] (Just "test2")
-  contNextStepCmd <- mkCont (TxId 1) 1 False Null Nothing [adminKeys] (Just "test3")
-  incorrectRbCmd  <- mkCont (TxId 1) 2 True Null Nothing [adminKeys] (Just "test4")
-  checkStateCmd   <- mkCont (TxId 1) 2 False Null Nothing [adminKeys] (Just "test5")
+                     Null def [adminKeys] (Just "test2")
+  contNextStepCmd <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
+  incorrectRbCmd  <- mkCont (TxId 1) 2 True Null def [adminKeys] (Just "test4")
+  checkStateCmd   <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test5")
   allResults      <- runAll opts [moduleCmd, executePactCmd, contNextStepCmd,
                              incorrectRbCmd, checkStateCmd]
 
@@ -271,12 +272,12 @@ testRollbackErr opts = do
 
   moduleCmd        <- mkExec (T.unpack (pactWithRollbackErrCode moduleName))
                       (object ["admin-keyset" .= [_kpPublic adminKeys]])
-                      Nothing [adminKeys] (Just "test1")
+                      def [adminKeys] (Just "test1")
   executePactCmd   <- mkExec ("(" ++ moduleName ++ ".tester)")
-                      Null Nothing [adminKeys] (Just "test2")
-  contNextStepCmd  <- mkCont (TxId 1) 1 False Null Nothing [adminKeys] (Just "test3")
-  rollbackErrCmd   <- mkCont (TxId 1) 1 True Null Nothing [adminKeys] (Just "test4")
-  checkStateCmd    <- mkCont (TxId 1) 2 False Null Nothing [adminKeys] (Just "test5")
+                      Null def [adminKeys] (Just "test2")
+  contNextStepCmd  <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
+  rollbackErrCmd   <- mkCont (TxId 1) 1 True Null def [adminKeys] (Just "test4")
+  checkStateCmd    <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test5")
   allResults       <- runAll opts [moduleCmd, executePactCmd, contNextStepCmd,
                               rollbackErrCmd, checkStateCmd]
 
@@ -298,12 +299,12 @@ testNoRollbackFunc opts = do
 
   moduleCmd        <- mkExec (T.unpack (threeStepPactCode moduleName))
                       (object ["admin-keyset" .= [_kpPublic adminKeys]])
-                      Nothing [adminKeys] (Just "test1")
+                      def [adminKeys] (Just "test1")
   executePactCmd   <- mkExec ("(" ++ moduleName ++ ".tester)")
-                      Null Nothing [adminKeys] (Just "test2")
-  contNextStepCmd  <- mkCont (TxId 1) 1 False Null Nothing [adminKeys] (Just "test3")
-  noRollbackCmd    <- mkCont (TxId 1) 1 True Null Nothing [adminKeys] (Just "test4")
-  checkStateCmd    <- mkCont (TxId 1) 2 False Null Nothing [adminKeys] (Just "test5")
+                      Null def [adminKeys] (Just "test2")
+  contNextStepCmd  <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
+  noRollbackCmd    <- mkCont (TxId 1) 1 True Null def [adminKeys] (Just "test4")
+  checkStateCmd    <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test5")
   allResults       <- runAll opts [moduleCmd, executePactCmd, contNextStepCmd,
                               noRollbackCmd, checkStateCmd]
 
@@ -343,12 +344,12 @@ testValidYield opts = do
 
   moduleCmd          <- mkExec (T.unpack (pactWithYield moduleName))
                         (object ["admin-keyset" .= [_kpPublic adminKeys]])
-                        Nothing [adminKeys] (Just "test1")
+                        def [adminKeys] (Just "test1")
   executePactCmd <- mkExec ("(" ++ moduleName ++ ".tester \"testing\")") -- pact takes an input
-                        Null Nothing [adminKeys] (Just "test2")
-  resumeAndYieldCmd  <- mkCont (TxId 1) 1 False Null Nothing [adminKeys] (Just "test3")
-  resumeOnlyCmd      <- mkCont (TxId 1) 2 False Null Nothing [adminKeys] (Just "test4")
-  checkStateCmd      <- mkCont (TxId 1) 3 False Null Nothing [adminKeys] (Just "test5")
+                        Null def [adminKeys] (Just "test2")
+  resumeAndYieldCmd  <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
+  resumeOnlyCmd      <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test4")
+  checkStateCmd      <- mkCont (TxId 1) 3 False Null def [adminKeys] (Just "test5")
   allResults         <- runAll opts [moduleCmd, executePactCmd, resumeAndYieldCmd,
                                 resumeOnlyCmd, checkStateCmd]
 
@@ -371,12 +372,12 @@ testNoYield opts = do
 
   moduleCmd      <- mkExec (T.unpack (pactWithYieldErr moduleName))
                     (object ["admin-keyset" .= [_kpPublic adminKeys]])
-                    Nothing [adminKeys] (Just "test1")
+                    def [adminKeys] (Just "test1")
   executePactCmd <- mkExec ("(" ++ moduleName ++ ".tester \"testing\")") -- pact takes an input
-                    Null Nothing [adminKeys] (Just "test2")
-  noYieldStepCmd <- mkCont (TxId 1) 1 False Null Nothing [adminKeys] (Just "test3")
-  resumeErrCmd   <- mkCont (TxId 1) 2 False Null Nothing [adminKeys] (Just "test3")
-  checkStateCmd  <- mkCont (TxId 1) 1 False Null Nothing [adminKeys] (Just "test5")
+                    Null def [adminKeys] (Just "test2")
+  noYieldStepCmd <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
+  resumeErrCmd   <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test3")
+  checkStateCmd  <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test5")
   allResults     <- runAll opts [moduleCmd, executePactCmd, noYieldStepCmd,
                            resumeErrCmd, checkStateCmd]
 
@@ -399,12 +400,12 @@ testResetYield opts = do
 
   moduleCmd        <- mkExec (T.unpack (pactWithSameNameYield moduleName))
                         (object ["admin-keyset" .= [_kpPublic adminKeys]])
-                        Nothing [adminKeys] (Just "test1")
+                        def [adminKeys] (Just "test1")
   executePactCmd   <- mkExec ("(" ++ moduleName ++ ".tester)")
-                        Null Nothing [adminKeys] (Just "test2")
-  yieldSameKeyCmd  <- mkCont (TxId 1) 1 False Null Nothing [adminKeys] (Just "test3")
-  resumeStepCmd    <- mkCont (TxId 1) 2 False Null Nothing [adminKeys] (Just "test4")
-  checkStateCmd    <- mkCont (TxId 1) 3 False Null Nothing [adminKeys] (Just "test5")
+                        Null def [adminKeys] (Just "test2")
+  yieldSameKeyCmd  <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
+  resumeStepCmd    <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test4")
+  checkStateCmd    <- mkCont (TxId 1) 3 False Null def [adminKeys] (Just "test5")
   allResults       <- runAll opts [moduleCmd, executePactCmd, yieldSameKeyCmd,
                               resumeStepCmd, checkStateCmd]
 


### PR DESCRIPTION
- `Maybe Address` removed from `Payload`, added to `PrivateMeta`
- `Payload` has new `m` type param for platform meta, with accessor `_pMeta`
- new `PublicMeta` type for chainweb params (gas, fee, chain id)
- Typeclass `HasPlafMeta` provides interop for pub, priv meta
- API standardizes on PublicMeta for now
- `Payload` hardcodes `PactRPC` for _pPayload as this never varied, type param now refers to PactRPC type param