### PR TITLE
Use a timeout of one second for all z3 queries.

### DIFF
--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -291,6 +291,7 @@ verifyFunctionInvariants' funName funInfo tables pactArgs body = runExceptT $ do
       withExcept translateToCheckFailure $ runTranslation funName funInfo pactArgs body
 
     ExceptT $ catchingExceptions $ runSymbolic $ runExceptT $ do
+      lift $ SBV.setTimeOut 1000 -- one second
       modelArgs' <- lift $ runAlloc $ allocArgs args
       tags <- lift $ runAlloc $ allocModelTags modelArgs' (Located funInfo tm) graph
       let rootPath = _egRootPath graph
@@ -349,6 +350,7 @@ verifyFunctionProperty funName funInfo tables pactArgs body (Located propInfo ch
         withExcept translateToCheckFailure $
           runTranslation funName funInfo pactArgs body
       ExceptT $ catchingExceptions $ runSymbolic $ runExceptT $ do
+        lift $ SBV.setTimeOut 1000 -- one second
         modelArgs' <- lift $ runAlloc $ allocArgs args
         tags <- lift $ runAlloc $ allocModelTags modelArgs' (Located funInfo tm) graph
         let rootPath = _egRootPath graph


### PR DESCRIPTION
Motivation:
Due to https://github.com/Z3Prover/z3/issues/2060, our CI was recently
failing for a couple months in a way that made it very hard to debug (we
just saw no output on travis' logs). This timeout will cause any future
z3 hanging to be diagnosable.

We've also previously considered adding a timeout for user queries
(which are more likely to take a long time). With this change queries
that take longer than a second will show a warning on the line with the
property / invariant being checked.

In the future we may want the timeout to be configurable.