### PR TITLE
add compose-capability

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1298,7 +1298,7 @@ Specifies and tests for existing grant of CAPABILITY, failing if not found in en
 
 Specifies and requests grant of CAPABILITY which is an application of a 'defcap' production. Given the unique token specified by this application, ensure that the token is granted in the environment during execution of BODY. 'with-capability' can only be called in the same module that declares the corresponding 'defcap', otherwise module-admin rights are required. If token is not present, the CAPABILITY is applied, with successful completion resulting in the installation/granting of the token, which will then be revoked upon completion of BODY. Nested 'with-capability' calls for the same token will detect the presence of the token, and will not re-apply CAPABILITY, but simply execute BODY. 
 ```lisp
-(with-capability (update-users id) (update users id { salary: new-salary }))
+(with-capability (UPDATE-USERS id) (update users id { salary: new-salary }))
 ```
 
 ## REPL-only functions {#repl-lib}

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1223,6 +1223,17 @@ Read KEY from message data body as keyset ({ "keys": KEYLIST, "pred": PREDFUN })
 
 ## Capabilities {#Capabilities}
 
+### compose-capability {#compose-capability}
+
+*capability*&nbsp;`( -> bool)` *&rarr;*&nbsp;`bool`
+
+
+Specifies and requests grant of CAPABILITY which is an application of a 'defcap' production, only valid within a (distinct) 'defcap' body, as a way to compose CAPABILITY with the outer capability such that the scope of the containing 'with-capability' call will "import" this capability. Thus, a call to '(with-capability (OUTER-CAP) OUTER-BODY)', where the OUTER-CAP defcap calls '(compose-capability (INNER-CAP))', will result in INNER-CAP being granted in the scope of OUTER-BODY. 
+```lisp
+(compose-capability (TRANSFER src dest))
+```
+
+
 ### create-module-guard {#create-module-guard}
 
 *name*&nbsp;`string` *&rarr;*&nbsp;`guard`

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -51,7 +51,7 @@ withCapability =
   \upon completion of BODY. Nested 'with-capability' calls for the same token \
   \will detect the presence of the token, and will not re-apply CAPABILITY, \
   \but simply execute BODY. \
-   \`$(with-capability (update-users id) (update users id { salary: new-salary }))`"
+   \`$(with-capability (UPDATE-USERS id) (update users id { salary: new-salary }))`"
   where
     withCapability' :: NativeFun e
     withCapability' i [c@TApp{},body@TList{}] = gasUnreduced i [] $ do
@@ -63,7 +63,7 @@ withCapability =
       composedCaps <- state $ \s -> (view (evalCapabilities . capComposed) s,
                                      set (evalCapabilities . capComposed) [] s)
       r <- reduceBody body
-      -- only revoke if newly granted (ie, isNothing grantedCap)
+      -- only revoke if newly granted
       forM_ grantedCap $ \newcap -> do
         revokeCapability newcap
         mapM_ revokeCapability composedCaps

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -34,6 +34,7 @@ module Pact.Types.Runtime
    readRow,writeRow,keys,txids,createUserTable,getUserTableInfo,beginTx,commitTx,rollbackTx,getTxLog,
    KeyPredBuiltins(..),keyPredBuiltins,
    Capability(..),CapAcquireResult(..),
+   Capabilities(..),capGranted,capComposed,
    NamespacePolicy(..), nsPolicy,
    permissiveNamespacePolicy,
    module Pact.Types.Lang,
@@ -239,6 +240,13 @@ updateRefStore RefState {..}
   | HM.null _rsNewModules = id
   | otherwise = over rsModules (HM.union _rsNewModules)
 
+data Capabilities = Capabilities
+  { _capGranted :: [Capability]
+  , _capComposed :: [Capability]
+  } deriving (Show)
+instance Default Capabilities where def = Capabilities def def
+makeLenses ''Capabilities
+
 -- | Interpreter mutable state.
 data EvalState = EvalState {
       -- | New or imported modules and defs.
@@ -250,7 +258,7 @@ data EvalState = EvalState {
       -- | Gas tally
     , _evalGas :: Gas
       -- | Capability list
-    , _evalCapabilities :: [Capability]
+    , _evalCapabilities :: Capabilities
     } deriving (Show)
 makeLenses ''EvalState
 instance Default EvalState where def = EvalState def def def 0 def

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -33,7 +33,7 @@ module Pact.Types.Term
    UserGuard(..),
    ModuleGuard(..),
    Guard(..),
-   DefType(..),
+   DefType(..),_Defun,_Defpact,_Defcap,
    defTypeRep,
    NativeDefName(..),DefName(..),
    FunApp(..),faDefType,faDocs,faInfo,faModule,faName,faTypes,
@@ -64,7 +64,7 @@ module Pact.Types.Term
    ) where
 
 
-import Control.Lens (makeLenses)
+import Control.Lens (makeLenses,makePrisms)
 import Control.Applicative
 import Data.List
 import Control.Monad
@@ -845,3 +845,4 @@ makeLenses ''Module
 makeLenses ''App
 makeLenses ''Def
 makeLenses ''ModuleName
+makePrisms ''DefType

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -51,6 +51,17 @@
   (defun get-guard (id:string)
     (at 'g (read guard-table id)))
 
+  (defcap COMPOSING-CAP ()
+    (compose-capability (KALL-CAP)))
+
+  (defun bad-compose-cap ()
+    (compose-capability (KALL-CAP)))
+
+  (defun test-compose-cap ()
+    (with-capability (COMPOSING-CAP)
+       (require-capability (KALL-CAP))))
+
+
 )
 (create-table guard-table)
 
@@ -76,12 +87,14 @@
 
 (env-keys ["k1"])
 (expect "cap k1 succeeds" 1 (test-id-cap "k1"))
-(expect-failure "direct call to test-require fails for k1" (require-capability "k1"))
+(expect-failure "direct call to test-require fails for k1"
+                (require-capability (KEYSET-ID-CAP "k1")))
 (expect-failure "cap k2 fails w/o key" (test-id-cap "k2"))
 
 (env-keys ["k2"])
 (expect-failure "cap k1 fails w/o key" (test-id-cap "k1"))
-(expect-failure "direct call to test-require fails for k2" (require-capability "k2"))
+(expect-failure "direct call to test-require fails for k2"
+                (require-capability (KEYSET-ID-CAP "k2")))
 (expect "cap k2 succeeds" 1 (test-id-cap "k2"))
 
 (expect-failure "top-level with-capability fails"
@@ -121,3 +134,11 @@
 
 (env-pactid "4")
 (expect-failure "pact enforce fails" (test-pact-guards "a"))
+
+(env-keys ["a" "b" "c"])
+(expect-failure "cannot compose caps at toplevel" (compose-capability (KALL-CAP)))
+(expect-failure "cannot compose caps in defun" (bad-compose-cap))
+;compose test will validate that KALL-CAP was acquired
+(test-compose-cap)
+;now validate that KALL-CAP is gone
+(expect-failure "KALL-CAP composed cap is revoked" (require-capability KALL-CAP))


### PR DESCRIPTION
This adds `compose-capability` which allows a `defcap` to "import" other capabilities, such that a `with-capability` call to that defcap will also scope whatever capabilities were composed with it. The docs for `compose-capability` explain further.

The improvement to `cancel-escrow` in examples/accounts/accounts.pact is a good example. Here's the old code:

```lisp
(defun cancel-escrow (timeout deb-acct cred-acct amount)
    (let ((systime (get-system-time)))
      (enforce-one
        "Cancel can only be effected by creditor, or debitor after timeout"
        [(with-capability (USER_GUARD cred-acct) true)
         (with-capability (USER_GUARD deb-acct)
           (enforce (>= systime timeout) "Timeout expired"))
        ])
   (transfer (get-pact-account ESCROW_ACCT) deb-acct amount (get-system-time))))
```

This is unfortunate in many ways:

1. The control flow of `enforce-one` meant that standard closure-scoping of capabilities was not available, resulting in the empty `with-capability` blocks.
2. This also meant that the USER_GUARD capability was lost once `transfer` was called, meaning `transfer` will have to acquire it again (at least for the debitor), a significant performance hit as the capability requires a database read.
3. While this could have been modeled as a `defcap`, all the above caveats would apply: there was simply no way to compose capabilities. 

Now, the CANCEL-ESCROW can be modeled as a true capability by composing the USER_GUARD caps, and in the case that it follows granting the `(USER_GUARD deb-acct)` path, that capability stays in scope for `transfer`, resulting in a significant performance gain. 