### PR TITLE
Pact.Types.Command: expose PPKScheme to GHCJS

### DIFF
--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -26,6 +26,8 @@ module Pact.Types.Command
   ( Command(..)
 #if !defined(ghcjs_HOST_OS)
   ,mkCommand,mkCommand',verifyUserSig,verifyCommand
+#else
+  ,PPKScheme(..)
 #endif
   , ProcessedCommand(..)
   , Address(..),aFrom,aTo


### PR DESCRIPTION
We need this to use `servant-client` from GHCJS.