### PR TITLE
Feat/partial schemas

### DIFF
--- a/HLint.hs
+++ b/HLint.hs
@@ -6,7 +6,7 @@ ignore "Avoid lambda"
 ignore "Use let"
 ignore "Redundant do"
 ignore "Evaluate"
- 
+
 -- Temporary ignores
 ignore "Use newtype instead of data"
 ignore "Reduce duplication"
@@ -16,3 +16,4 @@ ignore "Use lambda-case"
 ignore "Use $>" -- added temporarily
 ignore "Unnecessary hiding"
 ignore "Use camelCase"
+ignore "Use infix"

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -540,7 +540,7 @@ Top level only: this function will fail if used in module code.
 *table*&nbsp;`table:<{row}>` *key*&nbsp;`string` *object*&nbsp;`object:<{row}>` *&rarr;*&nbsp;`string`
 
 
-Write entry in TABLE for KEY of OBJECT column data, failing if data already exists for KEY.
+Write entry in TABLE for KEY of OBJECT column data, failing if data already exists for KEY. OBJECT must have all fields specified by row type.
 ```lisp
 (insert accounts id { "balance": 0.0, "note": "Created account." })
 ```
@@ -619,10 +619,10 @@ Return all updates to TABLE performed in transaction TXID.
 
 ### update {#update}
 
-*table*&nbsp;`table:<{row}>` *key*&nbsp;`string` *object*&nbsp;`object:~<{row}>` *&rarr;*&nbsp;`string`
+*table*&nbsp;`table:<{row}>` *key*&nbsp;`string` *object*&nbsp;`object:<{row}>~` *&rarr;*&nbsp;`string`
 
 
-Write entry in TABLE for KEY of OBJECT column data, failing if data does not exist for KEY.
+Write entry in TABLE for KEY of OBJECT column data, failing if data does not exist for KEY. OBJECT can have just the fields to update.
 ```lisp
 (update accounts id { "balance": (+ bal amount), "change": amount, "note": "credit" })
 ```
@@ -630,7 +630,7 @@ Write entry in TABLE for KEY of OBJECT column data, failing if data does not exi
 
 ### with-default-read {#with-default-read}
 
-*table*&nbsp;`table:<{row}>` *key*&nbsp;`string` *defaults*&nbsp;`object:<{row}>` *bindings*&nbsp;`binding:<{row}>` *&rarr;*&nbsp;`<a>`
+*table*&nbsp;`table:<{row}>` *key*&nbsp;`string` *defaults*&nbsp;`object:<{row}>~` *bindings*&nbsp;`binding:<{row}>~` *&rarr;*&nbsp;`<a>`
 
 
 Special form to read row from TABLE for KEY and bind columns per BINDINGS over subsequent body statements. If row not found, read columns from DEFAULTS, an object with matching key names. 
@@ -657,7 +657,7 @@ Special form to read row from TABLE for KEY and bind columns per BINDINGS over s
 *table*&nbsp;`table:<{row}>` *key*&nbsp;`string` *object*&nbsp;`object:<{row}>` *&rarr;*&nbsp;`string`
 
 
-Write entry in TABLE for KEY of OBJECT column data.
+Write entry in TABLE for KEY of OBJECT column data. OBJECT must have all fields specified by row type.
 ```lisp
 (write accounts id { "balance": 100.0 })
 ```

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -619,7 +619,7 @@ Return all updates to TABLE performed in transaction TXID.
 
 ### update {#update}
 
-*table*&nbsp;`table:<{row}>` *key*&nbsp;`string` *object*&nbsp;`object:<{row}>` *&rarr;*&nbsp;`string`
+*table*&nbsp;`table:<{row}>` *key*&nbsp;`string` *object*&nbsp;`object:<{row}>(partial)` *&rarr;*&nbsp;`string`
 
 
 Write entry in TABLE for KEY of OBJECT column data, failing if data does not exist for KEY.

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -619,7 +619,7 @@ Return all updates to TABLE performed in transaction TXID.
 
 ### update {#update}
 
-*table*&nbsp;`table:<{row}>` *key*&nbsp;`string` *object*&nbsp;`object:<{row}>(partial)` *&rarr;*&nbsp;`string`
+*table*&nbsp;`table:<{row}>` *key*&nbsp;`string` *object*&nbsp;`object:~<{row}>` *&rarr;*&nbsp;`string`
 
 
 Write entry in TABLE for KEY of OBJECT column data, failing if data does not exist for KEY.

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -354,8 +354,8 @@ maybeTranslateType' f = \case
   TyUser a         -> f a
 
   -- TODO(joel): understand the difference between the TyUser and TySchema cases
-  TySchema Pact.TyTable _ -> pure QTable
-  TySchema _ ty'   -> maybeTranslateType' f ty'
+  TySchema Pact.TyTable _ _ -> pure QTable
+  TySchema _ ty' _   -> maybeTranslateType' f ty'
 
   TyPrim TyBool    -> pure $ EType TBool
   TyPrim TyDecimal -> pure $ EType TDecimal

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -570,7 +570,7 @@ parseListType = withList' Brackets $ TyList <$> parseType
 
 parseSchemaType :: Text -> SchemaType -> Compile (Type (Term Name))
 parseSchemaType tyRep sty = symbol tyRep >>
-  (TySchema sty <$> (parseUserSchemaType <|> pure TyAny))
+  (TySchema sty <$> (parseUserSchemaType <|> pure TyAny) <*> pure def)
 
 
 parseUserSchemaType :: Compile (Type (Term Name))

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -717,8 +717,7 @@ checkUserType partial i ps (TyUser tu@TSchema {..}) = do
           "Missing fields for {" ++ unpack (asString _tSchemaName) ++ "}: " ++ show (M.elems missing)
   case partial of
     SPFull -> findMissing fields
-    SPPartial [] -> return ()
-    SPPartial fs -> findMissing (M.restrictKeys fields (S.fromList fs))
+    SPPartial -> return ()
   typecheck aps
   return $ TySchema TyObject (TyUser tu) partial
 checkUserType _ i _ t = evalError i $ "Invalid reference in user type: " ++ show t

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -717,7 +717,8 @@ checkUserType partial i ps (TyUser tu@TSchema {..}) = do
           "Missing fields for {" ++ unpack (asString _tSchemaName) ++ "}: " ++ show (M.elems missing)
   case partial of
     SPFull -> findMissing fields
-    SPPartial -> return ()
+    SPPartial [] -> return ()
+    SPPartial fs -> findMissing (M.filter ((`elem` fs) . _aName) fields)
   typecheck aps
   return $ TySchema TyObject (TyUser tu) partial
 checkUserType _ i _ t = evalError i $ "Invalid reference in user type: " ++ show t

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -717,8 +717,9 @@ checkUserType partial i ps (TyUser tu@TSchema {..}) = do
           "Missing fields for {" ++ unpack (asString _tSchemaName) ++ "}: " ++ show (M.elems missing)
   case partial of
     SPFull -> findMissing fields
-    SPPartial [] -> return ()
-    SPPartial fs -> findMissing (M.filter ((`elem` fs) . _aName) fields)
+    SPPartial fs
+      | null fs   -> return ()
+      | otherwise -> findMissing (M.restrictKeys fields fs)
   typecheck aps
   return $ TySchema TyObject (TyUser tu) partial
 checkUserType _ i _ t = evalError i $ "Invalid reference in user type: " ++ show t

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -90,7 +90,7 @@ lengthDef = defRNative "length" length' (funType tTyInteger [("x",listA)])
  \`(length [1 2 3])` `(length \"abcdefgh\")` `(length { \"a\": 1, \"b\": 2 })`"
 
 listA :: Type n
-listA = mkTyVar "a" [TyList (mkTyVar "l" []),TyPrim TyString,TySchema TyObject (mkSchemaVar "o")]
+listA = mkTyVar "a" [TyList (mkTyVar "l" []),TyPrim TyString,TySchema TyObject (mkSchemaVar "o") def]
 
 enforceDef :: NativeDef
 enforceDef = defNative "enforce" enforce
@@ -352,7 +352,7 @@ langDefs =
      "Obtain hash of current transaction as a string. `(tx-hash)`"
 
     ,defNative (specialForm Bind) bind
-     (funType a [("src",tTyObject row),("binding",TySchema TyBinding row)])
+     (funType a [("src",tTyObject row),("binding",TySchema TyBinding row def)])
      "Special form evaluates SRC to an object which is bound to with BINDINGS over subsequent body statements. \
      \`(bind { \"a\": 1, \"b\": 2 } { \"a\" := a-value } a-value)`"
     ,defRNative "typeof" typeof'' (funType tTyString [("x",a)])
@@ -364,7 +364,7 @@ langDefs =
      \only the top level can be bound to in 'resume'; nested objects are converted to opaque JSON values. \
      \`$(yield { \"amount\": 100.0 })`"
     ,defNative "resume" resume
-     (funType a [("binding",TySchema TyBinding (mkSchemaVar "y")),("body",TyAny)])
+     (funType a [("binding",TySchema TyBinding (mkSchemaVar "y") def),("body",TyAny)])
      "Special form binds to a yielded object value from the prior step execution in a pact."
 
     ,pactVersionDef
@@ -399,7 +399,7 @@ langDefs =
           c = mkTyVar "c" []
           d = mkTyVar "d" []
           row = mkSchemaVar "row"
-          yieldv = TySchema TyObject (mkSchemaVar "y")
+          yieldv = TySchema TyObject (mkSchemaVar "y") def
           obj = tTyObject (mkSchemaVar "o")
           listStringA = mkTyVar "a" [TyList (mkTyVar "l" []),TyPrim TyString]
           takeDrop = funType listStringA [("count",tTyInteger),("list",listStringA)] <>

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -62,7 +62,7 @@ dbDefs =
       tableTy = TySchema TyTable rt def
       rowTy = TySchema TyObject rt def
       bindTy = TySchema TyBinding rt def
-      partialize = set tySchemaPartial (SPPartial [])
+      partialize = set tySchemaPartial (SPPartial mempty)
       a = mkTyVar "a" []
   in ("Database",
     [setTopLevelOnly $ defRNative "create-table" createTable'
@@ -109,7 +109,7 @@ dbDefs =
     ,defRNative "insert" (write Insert SPFull) (writeArgs SPFull)
      (writeDocs ", failing if data already exists for KEY. OBJECT must have all fields specified by row type."
      "(insert accounts id { \"balance\": 0.0, \"note\": \"Created account.\" })")
-    ,defRNative "update" (write Update $ SPPartial []) (writeArgs $ SPPartial [])
+    ,defRNative "update" (write Update $ SPPartial mempty) (writeArgs $ SPPartial mempty)
      (writeDocs ", failing if data does not exist for KEY. OBJECT can have just the fields to update."
       "(update accounts id { \"balance\": (+ bal amount), \"change\": amount, \"note\": \"credit\" })")
     ,defGasRNative "txlog" txlog

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -63,8 +63,6 @@ dbDefs =
       rowTy = TySchema TyObject rt def
       bindTy = TySchema TyBinding rt def
       a = mkTyVar "a" []
-      partial = SPPartial []
-      full = SPFull
   in ("Database",
     [setTopLevelOnly $ defRNative "create-table" createTable'
      (funType tTyString [("table",tableTy)])
@@ -105,12 +103,12 @@ dbDefs =
      (funType (TyList tTyInteger) [("table",tableTy),("txid",tTyInteger)])
      "Return all txid values greater than or equal to TXID in TABLE. `$(txids accounts 123849535)`"
 
-    ,defRNative "write" (write Write partial) (writeArgs partial)
+    ,defRNative "write" (write Write SPFull) (writeArgs SPFull)
      (writeDocs "." "(write accounts id { \"balance\": 100.0 })")
-    ,defRNative "insert" (write Insert full) (writeArgs full)
+    ,defRNative "insert" (write Insert SPFull) (writeArgs SPFull)
      (writeDocs ", failing if data already exists for KEY."
      "(insert accounts id { \"balance\": 0.0, \"note\": \"Created account.\" })")
-    ,defRNative "update" (write Update partial) (writeArgs partial)
+    ,defRNative "update" (write Update SPPartial) (writeArgs SPPartial)
      (writeDocs ", failing if data does not exist for KEY."
       "(update accounts id { \"balance\": (+ bal amount), \"change\": amount, \"note\": \"credit\" })")
     ,defGasRNative "txlog" txlog

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -133,7 +133,7 @@ tTyBool :: Type n; tTyBool = TyPrim TyBool
 tTyString :: Type n; tTyString = TyPrim TyString
 tTyValue :: Type n; tTyValue = TyPrim TyValue
 tTyKeySet :: Type n; tTyKeySet = TyPrim (TyGuard $ Just GTyKeySet)
-tTyObject :: Type n -> Type n; tTyObject o = TySchema TyObject o
+tTyObject :: Type n -> Type n; tTyObject o = TySchema TyObject o def
 tTyGuard :: Maybe GuardType -> Type n; tTyGuard gt = TyPrim (TyGuard gt)
 
 getPactId :: FunApp -> Eval e PactId

--- a/src/Pact/Native/Ops.hs
+++ b/src/Pact/Native/Ops.hs
@@ -160,7 +160,7 @@ eqTy = binTy tTyBool eqA eqA
 
 eqA :: Type n
 eqA = mkTyVar "a" [tTyInteger,tTyString,tTyTime,tTyDecimal,tTyBool,
-  TyList (mkTyVar "l" []),TySchema TyObject (mkSchemaVar "o"),tTyKeySet]
+  TyList (mkTyVar "l" []),TySchema TyObject (mkSchemaVar "o") def,tTyKeySet]
 
 orDef :: NativeDef
 orDef = defLogic "or" (||) True
@@ -204,7 +204,7 @@ coerceBinNum :: FunTypes n
 coerceBinNum = binTy numA numA numA <> binTy tTyDecimal numA (numV "b")
 
 plusA :: Type n
-plusA = mkTyVar "a" [tTyString,TyList (mkTyVar "l" []),TySchema TyObject (mkSchemaVar "o")]
+plusA = mkTyVar "a" [tTyString,TyList (mkTyVar "l" []),TySchema TyObject (mkSchemaVar "o") def]
 
 defTrunc :: NativeDefName -> Text -> (Decimal -> Integer) -> NativeDef
 defTrunc n desc op = defRNative n fun (funType tTyDecimal [("x",tTyDecimal),("prec",tTyInteger)] <>

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -92,7 +92,8 @@ replDefs = ("Repl",
       setstep (funType tTyString [] <>
                funType tTyString [("step-idx",tTyInteger)] <>
                funType tTyString [("step-idx",tTyInteger),("rollback",tTyBool)] <>
-               funType tTyString [("step-idx",tTyInteger),("rollback",tTyBool),("resume",TySchema TyObject (mkSchemaVar "y"))])
+               funType tTyString [("step-idx",tTyInteger),("rollback",tTyBool),
+                                  ("resume",TySchema TyObject (mkSchemaVar "y") def)])
       ("Set pact step state. With no arguments, unset step. With STEP-IDX, set step index to execute. " <>
        "ROLLBACK instructs to execute rollback expression, if any. RESUME sets a value to be read via 'resume'." <>
        "Clears any previous pact execution state. `$(env-step 1)` `$(env-step 0 true)`")
@@ -146,7 +147,7 @@ replDefs = ("Repl",
      ])
      where
        json = mkTyVar "a" [tTyInteger,tTyString,tTyTime,tTyDecimal,tTyBool,
-                         TyList (mkTyVar "l" []),TySchema TyObject (mkSchemaVar "o"),tTyKeySet,tTyValue]
+                         TyList (mkTyVar "l" []),TySchema TyObject (mkSchemaVar "o") def,tTyKeySet,tTyValue]
        a = mkTyVar "a" []
 
 invokeEnv :: (MVar (DbEnv PureDb) -> IO b) -> MVar LibState -> IO b

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -755,6 +755,7 @@ guardTypeOf g = case g of
   GModule {} -> GTyModule
 
 -- | Return a Pact type, or a String description of non-value Terms.
+-- Does not handle partial schema types.
 typeof :: Term a -> Either Text (Type (Term a))
 typeof t = case t of
       TLiteral l _ -> Right $ TyPrim $ litToPrim l
@@ -767,14 +768,14 @@ typeof t = case t of
       TVar {..} -> Left "var"
       TBinding {..} -> case _tBindType of
         BindLet -> Left "let"
-        BindSchema bt -> Right $ TySchema TyBinding bt
-      TObject {..} -> Right $ TySchema TyObject _tObjectType
+        BindSchema bt -> Right $ TySchema TyBinding bt def
+      TObject {..} -> Right $ TySchema TyObject _tObjectType def
       TGuard {..} -> Right $ TyPrim $ TyGuard $ Just $ guardTypeOf _tGuard
       TUse {} -> Left "use"
       TValue {} -> Right $ TyPrim TyValue
       TStep {} -> Left "step"
       TSchema {..} -> Left $ "defobject:" <> asString _tSchemaName
-      TTable {..} -> Right $ TySchema TyTable _tTableType
+      TTable {..} -> Right $ TySchema TyTable _tTableType def
 {-# INLINE typeof #-}
 
 -- | Return string type description.

--- a/src/Pact/Types/Type.hs
+++ b/src/Pact/Types/Type.hs
@@ -26,9 +26,10 @@ module Pact.Types.Type
    tyInteger,tyDecimal,tyTime,tyBool,tyString,
    tyList,tyObject,tyValue,tyKeySet,tyTable,
    SchemaType(..),
+   SchemaPartial(..),
    TypeVarName(..),typeVarName,
    TypeVar(..),tvName,tvConstraint,
-   Type(..),tyFunType,tyListType,tySchema,tySchemaType,tyUser,tyVar,tyGuard,
+   Type(..),tyFunType,tyListType,tySchema,tySchemaType,tySchemaPartial,tyUser,tyVar,tyGuard,
    mkTyVar,mkTyVar',mkSchemaVar,
    isAnyTy,isVarTy,isUnconstrainedTy,canUnifyWith,
 
@@ -51,6 +52,7 @@ import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import Text.PrettyPrint.ANSI.Leijen
 import Control.DeepSeq
 import Data.Text (Text,unpack)
+import Data.Default (Default(..))
 
 import Pact.Types.Util
 import Pact.Types.Info
@@ -199,6 +201,19 @@ instance Eq1 TypeVar where
   liftEq _ (SchemaVar a) (SchemaVar m) = a == m
   liftEq _ _ _ = False
 
+-- | Represent a full or partial schema specification.
+data SchemaPartial =
+    -- | only fully-saturated schema inhabitants allowed
+    SPFull
+    -- | Partial allowed, where the [Text] lists specified fields
+    -- allowed, such that a Full inhabitant is always allowed, or
+    -- an inhabitant containing at least the specified fields.
+    -- [] (empty) means any subset is allowed, as empty (no fields)
+    -- is NOT a valid subset.
+  | SPPartial [Text]
+  deriving (Eq,Show,Ord,Generic)
+instance NFData SchemaPartial
+instance Default SchemaPartial where def = SPFull
 
 -- | Pact types.
 data Type v =
@@ -206,7 +221,10 @@ data Type v =
   TyVar { _tyVar :: TypeVar v } |
   TyPrim PrimType |
   TyList { _tyListType :: Type v } |
-  TySchema { _tySchema :: SchemaType, _tySchemaType :: Type v } |
+  TySchema
+  { _tySchema :: SchemaType
+  , _tySchemaType :: Type v
+  , _tySchemaPartial :: SchemaPartial } |
   TyFun { _tyFunType :: FunType v } |
   TyUser { _tyUser :: v }
     deriving (Eq,Ord,Functor,Foldable,Traversable,Generic)
@@ -216,7 +234,7 @@ instance Eq1 Type where
   liftEq eq (TyVar a) (TyVar m) = liftEq eq a m
   liftEq _ (TyPrim a) (TyPrim m) = a == m
   liftEq eq (TyList a) (TyList m) = liftEq eq a m
-  liftEq eq (TySchema a b) (TySchema m n) = a == m && liftEq eq b n
+  liftEq eq (TySchema a b c) (TySchema m n o) = a == m && liftEq eq b n && c == o
   liftEq eq (TyFun a) (TyFun b) = liftEq eq a b
   liftEq eq (TyUser a) (TyUser b) = eq a b
   liftEq _ _ _ = False
@@ -227,8 +245,8 @@ instance (Show v) => Show (Type v) where
   show (TyPrim t) = show t
   show (TyList t) | isAnyTy t = unpack tyList
                   | otherwise = "[" ++ show t ++ "]"
-  show (TySchema s t) | isAnyTy t = show s
-                      | otherwise = show s ++ ":" ++ show t
+  show (TySchema s t _) | isAnyTy t = show s
+                      | otherwise = show s ++ ":" ++ show t -- TODO need partial rep
   show (TyFun f) = show f
   show (TyUser v) = show v
   show TyAny = "*"
@@ -239,7 +257,7 @@ instance (Pretty o) => Pretty (Type o) where
     TyVar n -> pretty n
     TyUser v -> pretty v
     TyFun f -> pretty f
-    TySchema s t -> pretty s PP.<> colon PP.<> pretty t
+    TySchema s t _ -> pretty s PP.<> colon PP.<> pretty t -- TODO need partial rep
     TyList t -> "list:" PP.<> pretty t
     TyPrim t -> pretty t
     TyAny -> "*"
@@ -274,9 +292,21 @@ canUnifyWith (TyVar SchemaVar {}) (TyVar SchemaVar {}) = True
 canUnifyWith (TyVar (TypeVar _ ac)) (TyVar (TypeVar _ bc)) = all (`elem` ac) bc
 canUnifyWith (TyVar (TypeVar _ cs)) b = null cs || b `elem` cs
 canUnifyWith (TyList a) (TyList b) = a `canUnifyWith` b
-canUnifyWith (TySchema _ a) (TySchema _ b) = a `canUnifyWith` b
+canUnifyWith (TySchema _ aTy aP) (TySchema _ bTy bP) = aTy `canUnifyWith` bTy && aP `canUnifyPartial` bP
 canUnifyWith a b = a == b
 {-# INLINE canUnifyWith #-}
+
+-- | a `canUnifyPartial` b means the subset specified by b is
+-- valid in a, etc. [] in a subset is a wildcard.
+canUnifyPartial :: SchemaPartial -> SchemaPartial -> Bool
+canUnifyPartial a b | a == b = True -- equality works
+canUnifyPartial SPFull _ = True -- a full can always satisfy a subset
+canUnifyPartial _ (SPPartial []) = True -- a wildcard subset is trivially satisfiable
+canUnifyPartial (SPPartial as) (SPPartial bs) = all (`elem` as) bs -- bs is specified, as must contain all
+canUnifyPartial _ _ = False
+
+
+
 
 makeLenses ''Type
 makeLenses ''FunType

--- a/tests/TypecheckSpec.hs
+++ b/tests/TypecheckSpec.hs
@@ -15,6 +15,7 @@ import qualified Text.PrettyPrint.ANSI.Leijen as PP
 import Control.Monad
 import Data.Foldable
 import qualified Data.Text as T
+import qualified Data.Set as Set
 
 spec :: Spec
 spec = do
@@ -87,7 +88,9 @@ customFunChecks name (tl,_) = case name of
   "tests/pact/tc.repl.tc-update-partial" -> do
     -- TODO top levels don't get inferred return type, so we have to dig in here
     it (show name ++ ":specializes partial type") $
-      preview (tlFun . fBody . _head . aNode . aTy . tySchemaPartial) tl `shouldBe` (Just $ SPPartial ["name"])
+      preview (tlFun . fBody . _head . aNode . aTy . tySchemaPartial) tl
+        `shouldBe`
+      (Just $ SPPartial $ Set.singleton "name")
   _ -> return ()
 
 loadModule :: FilePath -> ModuleName -> IO ModuleData

--- a/tests/TypecheckSpec.hs
+++ b/tests/TypecheckSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
 module TypecheckSpec (spec) where
 
@@ -17,17 +18,19 @@ import qualified Data.Text as T
 
 spec :: Spec
 spec = do
-  void $ runIO $ inferModule False "tests/pact/tc.repl" "tctest"
-  void $ runIO $ inferModule False "tests/pact/caps.repl" "caps"
-  void $ runIO $ inferModule False "examples/cp/cp.repl" "cp"
-  void $ runIO $ inferModule False "examples/accounts/accounts.repl" "accounts"
+  checkModule "tests/pact/caps.repl" "caps"
+  checkModule "examples/cp/cp.repl" "cp"
+  checkFun "examples/accounts/accounts.repl" "accounts" "transfer"
   checkFuns
 
 type TCResult = (TopLevel Node,TcState)
 type TCResultCheck a = TCResult -> ([a] -> [a] -> Expectation) -> Expectation
 
 checkUnresolvedTys :: TCResultCheck (Type UserType)
-checkUnresolvedTys (tl,_) test = filter isUnresolvedTy (map _aTy (toList tl)) `test` []
+checkUnresolvedTys (tl,_) test = getUnresolvedTys tl `test` []
+
+getUnresolvedTys :: TopLevel Node -> [Type UserType]
+getUnresolvedTys tl = filter isUnresolvedTy (map _aTy (toList tl))
 
 checkFailures :: TCResultCheck Failure
 checkFailures (_,s) test = toList (_tcFailures s) `test` []
@@ -46,10 +49,21 @@ topLevelFails n r =
 topLevelChecks :: Text -> TCResult -> Spec
 topLevelChecks n r = topLevelTypechecks n r >> topLevelNoFailures n r
 
+checkModule :: FilePath -> ModuleName -> Spec
+checkModule fp mn = describe (fp ++ ": " ++ show mn ++ " typechecks") $ do
+  (tls,fs) <- runIO $ inferModule False fp mn
+  it (show mn ++ ": module has no failures") $ map prettyFail fs `shouldBe` []
+  it (show mn ++ ": all toplevels typecheck") $ concatMap getUnresolvedTys tls `shouldBe` []
+
+prettyFail :: Failure -> String
+prettyFail (Failure TcId{..} msg) = renderInfo _tiInfo ++ ": " ++ msg
+
+
 checkFun :: FilePath -> ModuleName -> Text -> Spec
 checkFun fp mn fn = do
   r <- runIO $ inferFun False fp mn fn
   topLevelChecks (asString mn <> "." <> fn) r
+
 
 checkFuns :: Spec
 checkFuns = describe "pact typecheck" $ do
@@ -59,14 +73,22 @@ checkFuns = describe "pact typecheck" $ do
     let doTc = runIO $ runTC 0 False (typecheckTopLevel ref)
         n = asString mn <> "." <> fn
     when (T.take 3 fn == "tc-") $
-      doTc >>= topLevelChecks n
+      doTc >>= \r -> do
+      topLevelChecks n r
+      customFunChecks n r
     when (T.take 6 fn == "fails-") $
       doTc >>= \r -> do
         topLevelTypechecks n r
         topLevelFails n r
 
-  checkFun "examples/cp/cp.repl" "cp" "issue"
-  checkFun "examples/accounts/accounts.repl" "accounts" "transfer"
+
+customFunChecks :: Text -> TCResult -> Spec
+customFunChecks name (tl,_) = case name of
+  "tests/pact/tc.repl.tc-update-partial" -> do
+    -- TODO top levels don't get inferred return type, so we have to dig in here
+    it (show name ++ ":specializes partial type") $
+      preview (tlFun . fBody . _head . aNode . aTy . tySchemaPartial) tl `shouldBe` (Just $ SPPartial ["name"])
+  _ -> return ()
 
 loadModule :: FilePath -> ModuleName -> IO ModuleData
 loadModule fp mn = do
@@ -86,10 +108,10 @@ inferFun :: Bool -> FilePath -> ModuleName -> Text -> IO TCResult
 inferFun dbg fp mn fn = loadFun fp mn fn >>= \r -> runTC 0 dbg (typecheckTopLevel r)
 
 
-inferModule :: Bool -> FilePath -> ModuleName -> IO [TopLevel Node]
+inferModule :: Bool -> FilePath -> ModuleName -> IO ([TopLevel Node],[Failure])
 inferModule debug fp mn = do
   md <- loadModule fp mn
-  fst <$> typecheckModule debug md
+  typecheckModule debug md
 
 
 
@@ -102,16 +124,16 @@ _inferIssue = inferFun True "examples/cp/cp.repl" "cp" "issue"
 _inferTransfer :: IO TCResult
 _inferTransfer = inferFun True "examples/accounts/accounts.repl" "accounts" "transfer"
 
-_inferTestModule :: IO [TopLevel Node]
+_inferTestModule :: IO ([TopLevel Node],[Failure])
 _inferTestModule = inferModule True "tests/pact/tc.repl" "tctest"
 
 _inferTestFun :: Text -> IO TCResult
 _inferTestFun = inferFun True "tests/pact/tc.repl" "tctest"
 
-_inferAccounts :: IO [TopLevel Node]
+_inferAccounts :: IO ([TopLevel Node],[Failure])
 _inferAccounts = inferModule False "examples/accounts/accounts.repl" "accounts"
 
-_inferCP :: IO [TopLevel Node]
+_inferCP :: IO ([TopLevel Node],[Failure])
 _inferCP = inferModule False "examples/cp/cp.repl" "cp"
 
 -- | prettify output of 'inferFun' runs

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -142,7 +142,9 @@
 
   (defun tc-update-partial ()
     "update allows partial schema"
-    (update persons "foo" { "name": "dave" }))
+    (let ((partial { "name": "dave" }))
+      (update persons "foo" partial)
+      partial))
 
 
 )

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -136,6 +136,14 @@
   (defun fails-list-literal-type:[integer] ()
     [1.0 2.0])
 
+  (defun fails-write-partial ()
+    "will fail as write demands full schema"
+    (write persons "foo" { "name": "dave" }))
+
+  (defun tc-update-partial ()
+    "update allows partial schema"
+    (update persons "foo" { "name": "dave" }))
+
 
 )
 


### PR DESCRIPTION
Fixes #360.

@joelburget note on this implementation: it is done in a way that ensures that partial schemas are only allowed when specified, which is only `update` at this time. (It might turn out that we need to stare at `+` and `remove` but that can wait). `update` now indicates that it accepts a partial type in the signature, and the typechecker enforces that. Along the way, `SPPartial` specializes `SPFull`, so anywhere a partial type appears it will specialize any associated `SPFull` types. This all seems to work as it should, and is a big improvement in typechecking as full records will now be enforced where specified.

However, it will not tell you if `update` has a fully-saturated rowtype argument; this will still show up as `SPPartial` even if the update object argument has all fields. Hopefully this is usable in FV; if not, we can seek to overwrite the type at that point with `SPFull` but it's a little ugly as it reverses the specialization rules, meaning I have to subvert the `assocTy` machinery and simply overwrite the association. I'd rather not so I thought I'd check with you first.