### PR TITLE
Pact.Types.API: remove ApiResponse

### DIFF
--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -19,7 +19,33 @@
 -- functionality.
 --
 
-module Pact.Repl where
+module Pact.Repl
+  ( errToUnit
+  , execScript
+  , execScript'
+  , evalPact
+  , evalRepl
+  , evalRepl'
+  , evalString
+  , getDelta
+  , handleCompile
+  , handleParse
+  , initPureEvalEnv
+  , initReplState
+  , isPactFile
+  , parsedCompileEval
+  , pipeLoop
+  , rSuccess
+  , repl
+  , repl'
+  , runPipedRepl
+  , runPipedRepl'
+  , setReplLib
+  , toUTF8Bytes
+  , trim
+  , unsetReplLib
+  , utf8BytesLength
+  ) where
 
 import Control.Applicative
 import Control.Lens hiding (op)

--- a/src/Pact/Server/API.hs
+++ b/src/Pact/Server/API.hs
@@ -20,13 +20,13 @@ import Data.Text (Text)
 
 type ApiV1API =
   (    "send" :> ReqBody '[JSON] SubmitBatch :>
-    Post '[JSON] (ApiResponse RequestKeys)
+    Post '[JSON] RequestKeys
   :<|> "poll" :> ReqBody '[JSON] Poll :>
-    Post '[JSON] (ApiResponse PollResponses)
+    Post '[JSON] PollResponses
   :<|> "listen" :> ReqBody '[JSON] ListenerRequest :>
-    Post '[JSON] (ApiResponse ApiResult)
+    Post '[JSON] ApiResult
   :<|> "local" :> ReqBody '[JSON] (Command Text) :>
-    Post '[JSON] (ApiResponse (CommandSuccess Value))
+    Post '[JSON] (CommandSuccess Value)
   )
 
 type PactServerAPI =

--- a/src/Pact/Server/Client.hs
+++ b/src/Pact/Server/Client.hs
@@ -25,10 +25,10 @@ import Data.Text (Text)
 
 import Pact.Server.API
 
-send :: SubmitBatch -> ClientM (ApiResponse RequestKeys)
-poll :: Poll -> ClientM (ApiResponse PollResponses)
-listen :: ListenerRequest -> ClientM (ApiResponse ApiResult)
-local :: Command Text -> ClientM (ApiResponse (CommandSuccess Value))
+send :: SubmitBatch -> ClientM RequestKeys
+poll :: Poll -> ClientM PollResponses
+listen :: ListenerRequest -> ClientM ApiResult
+local :: Command Text -> ClientM (CommandSuccess Value)
 verify :: Analyze.Request -> ClientM Analyze.Response
 version :: ClientM Text
 

--- a/tests/ClientSpec.hs
+++ b/tests/ClientSpec.hs
@@ -47,12 +47,12 @@ spec = around_ bracket $ describe "Servant API client tests" $ do
     cmd <- simpleServerCmd
     res <- runClientM (send (SubmitBatch [cmd])) clientEnv
     let rk = cmdToRequestKey cmd
-    res `shouldBe` (Right (ApiSuccess (RequestKeys [rk])))
+    res `shouldBe` (Right (RequestKeys [rk]))
     res' <- runClientM (listen (ListenerRequest rk)) clientEnv
     let cmdData = (toJSON . CommandSuccess . Number) 3
-    res' `shouldBe` (Right (ApiSuccess (ApiResult cmdData (Just 0) Nothing)))
+    res' `shouldBe` (Right (ApiResult cmdData (Just 0) Nothing))
   it "correctly runs a simple command locally" $ do
     cmd <- simpleServerCmd
     res <- runClientM (local cmd) clientEnv
     let cmdData = (CommandSuccess . Number) 3
-    res `shouldBe` (Right (ApiSuccess cmdData))
+    res `shouldBe` (Right cmdData)

--- a/tests/Utils/TestRunner.hs
+++ b/tests/Utils/TestRunner.hs
@@ -113,8 +113,7 @@ run mgr cmds = do
   sendResp <- doSend mgr $ SubmitBatch cmds
   case sendResp of
     Left servantErr -> Exception.evaluate (error $ show servantErr)
-    Right (ApiFailure err) -> Exception.evaluate (error err)
-    Right (ApiSuccess RequestKeys{..}) -> do
+    Right RequestKeys{..} -> do
       results <- timeout 3000000 (helper _rkRequestKeys)
       case results of
         Nothing -> Exception.evaluate (error "Received empty poll. Timeout in retrying.")
@@ -124,17 +123,16 @@ run mgr cmds = do
           pollResp <- doPoll mgr $ Poll reqKeys
           case pollResp of
             Left servantErr -> Exception.evaluate (error $ show servantErr)
-            Right (ApiFailure err) -> Exception.evaluate (error err)
-            Right (ApiSuccess (PollResponses apiResults)) ->
+            Right (PollResponses apiResults) ->
               if null apiResults then helper reqKeys
               else return apiResults
 
-doSend :: Manager -> SubmitBatch -> IO (Either ServantError (ApiResponse RequestKeys))
+doSend :: Manager -> SubmitBatch -> IO (Either ServantError RequestKeys)
 doSend mgr req = do
   baseUrl <- _serverBaseUrl
   runClientM (C.send req) (mkClientEnv mgr baseUrl)
 
-doPoll :: Manager -> Poll -> IO (Either ServantError (ApiResponse PollResponses))
+doPoll :: Manager -> Poll -> IO (Either ServantError PollResponses)
 doPoll mgr req = do
   baseUrl <- _serverBaseUrl
   runClientM (C.poll req) (mkClientEnv mgr baseUrl)


### PR DESCRIPTION
This is now an unnecessary wrapper that we don't seem to use anywhere.