### PR TITLE
Introduced CommandValue

### DIFF
--- a/src-ghc/Pact/Server/ApiServer.hs
+++ b/src-ghc/Pact/Server/ApiServer.hs
@@ -120,7 +120,7 @@ listenHandler (ListenerRequest rk) = do
       log $ "Listener Serviced for: " ++ show rk
       pure $ crToAr cr
 
-localHandler :: Command T.Text -> Api (CommandValue Value)
+localHandler :: Command T.Text -> Api CommandValue
 localHandler commandText = do
   let (cmd :: Command ByteString) = fmap encodeUtf8 commandText
   mv <- liftIO newEmptyMVar

--- a/src-ghc/Pact/Server/ApiServer.hs
+++ b/src-ghc/Pact/Server/ApiServer.hs
@@ -120,7 +120,7 @@ listenHandler (ListenerRequest rk) = do
       log $ "Listener Serviced for: " ++ show rk
       pure $ crToAr cr
 
-localHandler :: Command T.Text -> Api (CommandSuccess Value)
+localHandler :: Command T.Text -> Api (CommandValue Value)
 localHandler commandText = do
   let (cmd :: Command ByteString) = fmap encodeUtf8 commandText
   mv <- liftIO newEmptyMVar
@@ -128,7 +128,7 @@ localHandler commandText = do
   liftIO $ writeInbound c (LocalCmd cmd mv)
   r <- liftIO $ takeMVar mv
   case parseMaybe parseJSON r of
-    Just v@CommandSuccess{} -> pure v
+    Just v  -> pure v
     Nothing -> die' "command could not be run locally"
 
 versionHandler :: Handler T.Text

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -71,11 +71,8 @@ applyCmd logger conf dbv cv gasModel exMode _ (ProcSucc cmd) = do
       return cr
     Left e -> do
       logLog logger "ERROR" $ "tx failure for requestKey: " ++ show (cmdToRequestKey cmd) ++ ": " ++ show e
-      let
-        cValue :: CommandValue (Term Name)
-        cValue = CommandFailure $
-          CommandError "Command execution failed" (Just $ show e)
-      return $ jsonResult exMode (cmdToRequestKey cmd) cValue
+      return $ jsonResult exMode (cmdToRequestKey cmd) $
+        CommandFailure $ CommandError "Command execution failed" (Just $ show e)
 
 
 jsonResult :: ToJSON a => ExecutionMode -> RequestKey -> a -> CommandResult

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -71,8 +71,12 @@ applyCmd logger conf dbv cv gasModel exMode _ (ProcSucc cmd) = do
       return cr
     Left e -> do
       logLog logger "ERROR" $ "tx failure for requestKey: " ++ show (cmdToRequestKey cmd) ++ ": " ++ show e
-      return $ jsonResult exMode (cmdToRequestKey cmd) $
-               CommandError "Command execution failed" (Just $ show e)
+      let
+        cValue :: CommandValue (Term Name)
+        cValue = CommandFailure $
+          CommandError "Command execution failed" (Just $ show e)
+      return $ jsonResult exMode (cmdToRequestKey cmd) cValue
+
 
 jsonResult :: ToJSON a => ExecutionMode -> RequestKey -> a -> CommandResult
 jsonResult ex cmd a = CommandResult cmd (exToTx ex) (toJSON a)

--- a/src/Pact/Analyze/Remote/Client.hs
+++ b/src/Pact/Analyze/Remote/Client.hs
@@ -41,6 +41,7 @@ verifyModule namedMods mod' uri = do
       nothingText = Nothing
   XHR.open req ("POST" :: Text) requestURI True nothingText nothingText
   XHR.setTimeout req 5000 -- Terminate at some point (5 seconds).
+  XHR.setRequestHeader req ("content-type" :: Text) ("application/json;charset=utf-8" :: Text)
   alreadyHandled <- liftIO $ newIORef False
   respVar :: MVar [Text] <- newEmptyMVar
   void $ req `onAsync` XHR.readyStateChange $ do

--- a/src/Pact/Server/API.hs
+++ b/src/Pact/Server/API.hs
@@ -16,7 +16,6 @@ import qualified Pact.Analyze.Remote.Types as Analyze
 import Pact.Types.API
 import Pact.Types.Command
 import Data.Text (Text)
-import Data.Aeson (Value)
 
 type ApiV1API =
   (    "send" :> ReqBody '[JSON] SubmitBatch :>
@@ -26,7 +25,7 @@ type ApiV1API =
   :<|> "listen" :> ReqBody '[JSON] ListenerRequest :>
     Post '[JSON] ApiResult
   :<|> "local" :> ReqBody '[JSON] (Command Text) :>
-    Post '[JSON] (CommandValue Value)
+    Post '[JSON] CommandValue
   )
 
 type PactServerAPI =

--- a/src/Pact/Server/API.hs
+++ b/src/Pact/Server/API.hs
@@ -10,13 +10,13 @@ module Pact.Server.API
   , pactServerAPI
   ) where
 
-import Data.Aeson
 import Data.Proxy
 import Servant.API
 import qualified Pact.Analyze.Remote.Types as Analyze
 import Pact.Types.API
 import Pact.Types.Command
 import Data.Text (Text)
+import Data.Aeson (Value)
 
 type ApiV1API =
   (    "send" :> ReqBody '[JSON] SubmitBatch :>
@@ -26,7 +26,7 @@ type ApiV1API =
   :<|> "listen" :> ReqBody '[JSON] ListenerRequest :>
     Post '[JSON] ApiResult
   :<|> "local" :> ReqBody '[JSON] (Command Text) :>
-    Post '[JSON] (CommandSuccess Value)
+    Post '[JSON] (CommandValue Value)
   )
 
 type PactServerAPI =

--- a/src/Pact/Server/Client.hs
+++ b/src/Pact/Server/Client.hs
@@ -13,7 +13,6 @@ module Pact.Server.Client
   , pactServerApiClient
   ) where
 
-import Data.Aeson
 import Data.Proxy
 import Servant.API
 import Servant.Client.Core
@@ -21,6 +20,7 @@ import qualified Pact.Analyze.Remote.Types as Analyze
 import Pact.Types.API
 import Pact.Types.Command
 import Data.Text (Text)
+import Data.Aeson (Value)
 
 import Pact.Server.API
 
@@ -28,7 +28,7 @@ data PactServerAPIClient m = PactServerAPIClient
   { send :: SubmitBatch -> m RequestKeys
   , poll :: Poll -> m PollResponses
   , listen :: ListenerRequest -> m ApiResult
-  , local :: Command Text -> m (CommandSuccess Value)
+  , local :: Command Text -> m (CommandValue Value)
   , verify :: Analyze.Request -> m Analyze.Response
   , version :: m Text
   }
@@ -38,4 +38,3 @@ pactServerApiClient = let
   (send :<|> poll :<|> listen :<|> local) :<|> verify :<|> version =
     clientIn pactServerAPI (Proxy :: Proxy m)
   in PactServerAPIClient{ send, poll, listen, local, verify, version }
-

--- a/src/Pact/Server/Client.hs
+++ b/src/Pact/Server/Client.hs
@@ -20,7 +20,6 @@ import qualified Pact.Analyze.Remote.Types as Analyze
 import Pact.Types.API
 import Pact.Types.Command
 import Data.Text (Text)
-import Data.Aeson (Value)
 
 import Pact.Server.API
 
@@ -28,7 +27,7 @@ data PactServerAPIClient m = PactServerAPIClient
   { send :: SubmitBatch -> m RequestKeys
   , poll :: Poll -> m PollResponses
   , listen :: ListenerRequest -> m ApiResult
-  , local :: Command Text -> m (CommandValue Value)
+  , local :: Command Text -> m CommandValue
   , verify :: Analyze.Request -> m Analyze.Response
   , version :: m Text
   }

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -261,8 +261,8 @@ data CommandResult = CommandResult {
   } deriving (Eq,Show)
 
 -- | Actual value of a `CommandResult`.
-data CommandValue a
-  = CommandSuccess a
+data CommandValue
+  = CommandSuccess (Term Name)
   | CommandFailure CommandError
   deriving (Eq, Show)
 
@@ -273,7 +273,7 @@ data CommandError = CommandError {
   } deriving (Eq, Show)
 
 
-instance ToJSON a => ToJSON (CommandValue a) where
+instance ToJSON CommandValue where
     toJSON = \case
       CommandSuccess a -> object
         [ "status" .= ("success" :: Text)
@@ -285,7 +285,7 @@ instance ToJSON a => ToJSON (CommandValue a) where
         ]
         ++ maybe [] (pure . ("detail" .=)) _ceDetail
 
-instance FromJSON a => FromJSON (CommandValue a) where
+instance FromJSON CommandValue where
   parseJSON = withObject "CommandValue" $ \o -> do
     status <- o .: "status"
     case status of

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -291,7 +291,7 @@ instance FromJSON a => FromJSON (CommandValue a) where
     case status of
       "failure" -> do
         msg <- o .: "error"
-        detail <- fmap Just (o .: "detail") <|> pure Nothing
+        detail <- o .:? "detail"
         pure $ CommandFailure $ CommandError msg detail
       "success" -> do
         CommandSuccess <$> o .: "data"

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -293,7 +293,7 @@ instance FromJSON a => FromJSON (CommandValue a) where
         msg <- o .: "error"
         detail <- o .:? "detail"
         pure $ CommandFailure $ CommandError msg detail
-      "success" -> do
+      "success" ->
         CommandSuccess <$> o .: "data"
       _ -> fail $ "Expected a status of `success` or `failure`, not: " <> status
 

--- a/tests/ClientSpec.hs
+++ b/tests/ClientSpec.hs
@@ -16,9 +16,8 @@ import Pact.Types.API
 import Pact.Types.Command
 import Data.Text (Text)
 import Pact.Server.Client
-import Pact.Types.Term (Term (TLiteral))
+import Pact.Types.Term (tLit)
 import Pact.Types.Exp (Literal(LInteger))
-import Pact.Types.Info (Info (..))
 import Servant.Client
 
 _testLogDir, _testConfigFilePath, _testPort, _serverPath :: String
@@ -37,7 +36,7 @@ simpleServerCmd = do
   mkExec  "(+ 1 2)" Null def [simpleKeys] (Just "test1")
 
 simpleServerResult :: CommandValue
-simpleServerResult = CommandSuccess $ TLiteral (LInteger 3) (Info Nothing)
+simpleServerResult = CommandSuccess $ tLit $ LInteger 3
 
 spec :: Spec
 spec = around_ bracket $ describe "Servant API client tests" $ do

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -55,7 +55,7 @@ testNestedPacts mgr = before_ flushDb $ after_ flushDb $
 testPactContinuation :: HTTP.Manager -> Spec
 testPactContinuation mgr = before_ flushDb $ after_ flushDb $ do
   it "sends (+ 1 2) command to locally running dev server" $ do
-    let cmdRes = CommandSuccess $ TLiteral (LInteger 3) (Info Nothing)
+    let cmdRes = CommandSuccess $ tLit $ LInteger 3
         cmdData = toJSON cmdRes
         expRes = Just $ ApiResult cmdData ((Just . TxId) 0) Nothing
     testSimpleServerCmd mgr `shouldReturn` expRes

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -55,7 +55,8 @@ testNestedPacts mgr = before_ flushDb $ after_ flushDb $
 testPactContinuation :: HTTP.Manager -> Spec
 testPactContinuation mgr = before_ flushDb $ after_ flushDb $ do
   it "sends (+ 1 2) command to locally running dev server" $ do
-    let cmdData = (toJSON . CommandSuccess . Number) 3
+    let cmdRes = CommandSuccess $ TLiteral (LInteger 3) (Info Nothing)
+        cmdData = toJSON cmdRes
         expRes = Just $ ApiResult cmdData ((Just . TxId) 0) Nothing
     testSimpleServerCmd mgr `shouldReturn` expRes
 


### PR DESCRIPTION
so we can properly differentiate between `CommandError` and
`CommandSuccess`.

Previously on the client side one would have needed to try to parse an
error, catch that parsing error and then try to parse success. With this
change, the client can simply parse `CommandValue` and get the result
(either success or error). `CommandSuccess` is now no longer a type of
its own, but a constructor of `CommandValue`. I kept `CommandError`, so
we don't have partial accessor functions for `CommandValue`.

What I am not sure about is:

1. Should we really return `CommandValue Value` from /local or should it be the more
type safe: `CommandValue (Term Name)`? For now I kept it as it was
before, which is `CommandValue Value`.
2. If we are going to return `Term Name`, I think `CommandValue` no longer
needs to be a type constructor, but could be a simple type isomorph
to `CommandValue (Term Name)`.
3. Is it really necessary to have `_crResult` to be of type `Value`,
can't it be `CommandValue` directly? This would make things more typesafe and the
REST API a bit more approachable.