### PR TITLE
Pact.Repl: remove unused exports

### DIFF
--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -27,22 +27,16 @@ module Pact.Repl
   , evalRepl
   , evalRepl'
   , evalString
-  , getDelta
   , handleCompile
   , handleParse
   , initPureEvalEnv
   , initReplState
   , isPactFile
   , parsedCompileEval
-  , pipeLoop
   , rSuccess
   , repl
-  , repl'
   , runPipedRepl
-  , runPipedRepl'
   , setReplLib
-  , toUTF8Bytes
-  , trim
   , unsetReplLib
   , utf8BytesLength
   ) where


### PR DESCRIPTION
@slpopejoy you were right that I was exporting more than strictly required. Tested against the web REPL and Chainweb.