### PR TITLE
Make servant client functions generic

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -162,6 +162,7 @@ library
                      , mmorph >= 1.1 && < 1.2
                      , servant
                      , servant-client
+                     , servant-client-core
 
   if impl(ghcjs)
     build-depends:

--- a/src/Pact/Server/Client.hs
+++ b/src/Pact/Server/Client.hs
@@ -1,23 +1,22 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 
 module Pact.Server.Client
   ( PactServerAPI
+  , PactServerAPIClient(..)
   , pactServerAPI
-  , send
-  , poll
-  , listen
-  , local
-  , verify
-  , version
+  , pactServerApiClient
   ) where
 
 import Data.Aeson
+import Data.Proxy
 import Servant.API
-import Servant.Client
+import Servant.Client.Core
 import qualified Pact.Analyze.Remote.Types as Analyze
 import Pact.Types.API
 import Pact.Types.Command
@@ -25,12 +24,18 @@ import Data.Text (Text)
 
 import Pact.Server.API
 
-send :: SubmitBatch -> ClientM RequestKeys
-poll :: Poll -> ClientM PollResponses
-listen :: ListenerRequest -> ClientM ApiResult
-local :: Command Text -> ClientM (CommandSuccess Value)
-verify :: Analyze.Request -> ClientM Analyze.Response
-version :: ClientM Text
+data PactServerAPIClient m = PactServerAPIClient
+  { send :: SubmitBatch -> m RequestKeys
+  , poll :: Poll -> m PollResponses
+  , listen :: ListenerRequest -> m ApiResult
+  , local :: Command Text -> m (CommandSuccess Value)
+  , verify :: Analyze.Request -> m Analyze.Response
+  , version :: m Text
+  }
 
-(send :<|> poll :<|> listen :<|> local) :<|> verify :<|> version =
-  client pactServerAPI
+pactServerApiClient :: forall m. RunClient m => PactServerAPIClient m
+pactServerApiClient = let
+  (send :<|> poll :<|> listen :<|> local) :<|> verify :<|> version =
+    clientIn pactServerAPI (Proxy :: Proxy m)
+  in PactServerAPIClient{ send, poll, listen, local, verify, version }
+

--- a/tests/ClientSpec.hs
+++ b/tests/ClientSpec.hs
@@ -45,14 +45,14 @@ spec = around_ bracket $ describe "Servant API client tests" $ do
   --   res `shouldBe` expt
   it "correctly runs a simple command publicly and listens to the result" $ do
     cmd <- simpleServerCmd
-    res <- runClientM (send (SubmitBatch [cmd])) clientEnv
+    res <- runClientM (send pactServerApiClient (SubmitBatch [cmd])) clientEnv
     let rk = cmdToRequestKey cmd
     res `shouldBe` (Right (RequestKeys [rk]))
-    res' <- runClientM (listen (ListenerRequest rk)) clientEnv
+    res' <- runClientM (listen pactServerApiClient (ListenerRequest rk)) clientEnv
     let cmdData = (toJSON . CommandSuccess . Number) 3
     res' `shouldBe` (Right (ApiResult cmdData (Just 0) Nothing))
   it "correctly runs a simple command locally" $ do
     cmd <- simpleServerCmd
-    res <- runClientM (local cmd) clientEnv
+    res <- runClientM (local pactServerApiClient cmd) clientEnv
     let cmdData = (CommandSuccess . Number) 3
     res `shouldBe` (Right cmdData)

--- a/tests/RemoteVerifySpec.hs
+++ b/tests/RemoteVerifySpec.hs
@@ -54,7 +54,7 @@ serveAndRequest port body = do
   let clientEnv = mkClientEnv mgr verifyBaseUrl
   tid <- serve port
   finally
-    (runClientM (verify body) clientEnv)
+    (runClientM (verify pactServerApiClient body) clientEnv)
     (killThread tid)
 
 testSingleModule :: Spec

--- a/tests/Utils/TestRunner.hs
+++ b/tests/Utils/TestRunner.hs
@@ -90,7 +90,7 @@ waitUntilStarted = do
   mgr <- HTTP.newManager HTTP.defaultManagerSettings
   baseUrl <- _serverBaseUrl
   let clientEnv = mkClientEnv mgr baseUrl
-  r <- runClientM C.version clientEnv
+  r <- runClientM (C.version C.pactServerApiClient) clientEnv
   case r of
     Right _ -> pure ()
     Left _ -> do
@@ -130,12 +130,12 @@ run mgr cmds = do
 doSend :: Manager -> SubmitBatch -> IO (Either ServantError RequestKeys)
 doSend mgr req = do
   baseUrl <- _serverBaseUrl
-  runClientM (C.send req) (mkClientEnv mgr baseUrl)
+  runClientM (C.send C.pactServerApiClient req) (mkClientEnv mgr baseUrl)
 
 doPoll :: Manager -> Poll -> IO (Either ServantError PollResponses)
 doPoll mgr req = do
   baseUrl <- _serverBaseUrl
-  runClientM (C.poll req) (mkClientEnv mgr baseUrl)
+  runClientM (C.poll C.pactServerApiClient req) (mkClientEnv mgr baseUrl)
 
 flushDb :: IO ()
 flushDb = mapM_ deleteIfExists _logFiles


### PR DESCRIPTION
This allows us to use [`servant-client-ghcjs`](https://github.com/haskell-servant/servant/tree/master/servant-client-ghcjs) or some other client library.