### PR TITLE
Pact.Server.ApiServer: expose handlers

### DIFF
--- a/src-ghc/Pact/Server/ApiServer.hs
+++ b/src-ghc/Pact/Server/ApiServer.hs
@@ -19,6 +19,7 @@
 module Pact.Server.ApiServer
   ( runApiServer
   , ApiEnv(..), aiLog, aiHistoryChan
+  , sendHandler, pollHandler, listenHandler, localHandler, versionHandler
   ) where
 
 import Prelude hiding (log)


### PR DESCRIPTION
This makes reusing them in other applications possible.