### PR TITLE
Pact guard analysis

### DIFF
--- a/src/Pact/Analyze/Eval.hs
+++ b/src/Pact/Analyze/Eval.hs
@@ -92,13 +92,19 @@ runAnalysis'
   -> Info
   -> ExceptT AnalyzeFailure Symbolic (f AnalysisResult)
 runAnalysis' modName query tables args tm rootPath tags info = do
-  --
-  -- TODO: pass this in (from a previous analysis) when we analyze >1 function
-  --       calls. we will want to propagate previous db state too.
-  --
-  let reg = mkRegistry
+  let --
+      --
+      -- TODO: pass this in (from a previous analysis) when we analyze >1
+      --       function calls. we will want to propagate previous db state too.
+      --
+      reg = mkRegistry
+      --
+      -- TODO: potentially pre-set this metadata in some circumstances once we
+      --       add support for analyzing pacts:
+      --
+      pactMetadata = mkPactMetadata
 
-  aEnv <- case mkAnalyzeEnv modName reg tables args tags info of
+  aEnv <- case mkAnalyzeEnv modName pactMetadata reg tables args tags info of
     Just env -> pure env
     Nothing  -> throwError $ AnalyzeFailure info $ fromString
       "Unable to make analyze env (couldn't translate schema)"

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -441,6 +441,11 @@ evalTerm = \case
   ReadDecimal nameT -> readDecimal =<< evalTerm nameT
   ReadInteger nameT -> readInteger =<< evalTerm nameT
 
+  PactId -> do
+    whetherInPact <- view inPact
+    succeeds %= (.&& whetherInPact)
+    view currentPactId
+
   --
   -- If in the future Pact is able to store guards other than keysets in the
   -- registry, our approach will work for that generally.

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -452,6 +452,11 @@ evalTerm = \case
   --
   MkKsRefGuard nameT -> resolveGuard =<< symRegistryName <$> evalTerm nameT
 
+  MkPactGuard _nameT -> do
+    whetherInPact <- view inPact
+    succeeds %= (.&& whetherInPact)
+    view aeTrivialGuard
+
   GuardPasses tid guardT -> do
     guard <- evalTerm guardT
 

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -78,6 +78,10 @@ pattern AST_KeysetRefGuard :: forall a. AST a -> AST a
 pattern AST_KeysetRefGuard name <-
   App _node (NativeFunc "keyset-ref-guard") [name]
 
+pattern AST_CreatePactGuard :: forall a. AST a -> AST a
+pattern AST_CreatePactGuard name <-
+  App _node (NativeFunc "create-pact-guard") [name]
+
 pattern AST_Enforce :: forall a. a -> AST a -> AST a
 pattern AST_Enforce node cond <-
   App node (NativeFunc "enforce") (cond:_rest)

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -98,6 +98,9 @@ pattern AST_ReadMsg :: forall a. AST a -> AST a
 pattern AST_ReadMsg name <-
   App _node (NativeFunc "read-msg") [name]
 
+pattern AST_PactId :: AST a
+pattern AST_PactId <- App _node (NativeFunc "pact-id") []
+
 typeSatisfying :: (Lang.Type TC.UserType -> Bool) -> AST Node -> Maybe (AST Node)
 typeSatisfying test x = case x ^? aNode.aTy of
   Just ty | test ty -> Just x

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -669,6 +669,8 @@ translateNode astNode = withAstContext astNode $ case astNode of
 
   AST_ReadMsg _ -> throwError' $ NoReadMsg astNode
 
+  AST_PactId -> pure $ Some SInteger PactId
+
   AST_KeysetRefGuard strA -> do
     Some SStr strT <- translateNode strA
     pure $ Some SGuard $ MkKsRefGuard strT

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -675,6 +675,10 @@ translateNode astNode = withAstContext astNode $ case astNode of
     Some SStr strT <- translateNode strA
     pure $ Some SGuard $ MkKsRefGuard strT
 
+  AST_CreatePactGuard strA -> do
+    Some SStr strT <- translateNode strA
+    pure $ Some SGuard $ MkPactGuard strT
+
   AST_Enforce _ cond -> do
     Some SBool condTerm <- translateNode cond
     tid <- tagAssert $ cond ^. aNode

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -95,6 +95,8 @@ data PactMetadata
 mkPactMetadata :: PactMetadata
 mkPactMetadata = PactMetadata (uninterpretS "in_pact") (uninterpretS "pact_id")
 
+-- | The registry of names to keysets that is shared across multiple modules in
+-- a namespace.
 newtype Registry
   = Registry
     { _registryMap :: SFunArray RegistryName Guard }

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -1299,6 +1299,8 @@ data Term (a :: Ty) where
 
   -- TODO: ReadMsg
 
+  PactId          :: Term 'TyInteger
+
   -- Guards
   MkKsRefGuard :: Term 'TyStr            -> Term 'TyGuard
   GuardPasses  :: TagId -> Term 'TyGuard -> Term 'TyBool
@@ -1409,6 +1411,7 @@ showsTerm ty p tm = withSing ty $ showParen (p > 10) $ case tm of
   ReadKeySet  name -> showString "ReadKeySet " . showsPrec 11 name
   ReadDecimal name -> showString "ReadDecimal " . showsPrec 11 name
   ReadInteger name -> showString "ReadInteger " . showsPrec 11 name
+  PactId -> showString "PactId"
 
 showsProp :: SingTy ty -> Int -> Prop ty -> ShowS
 showsProp ty p = withSing ty $ \case
@@ -1471,6 +1474,7 @@ userShowTerm ty p = \case
   ReadKeySet name      -> parenList ["read-keyset", userShow name]
   ReadDecimal name     -> parenList ["read-decimal", userShow name]
   ReadInteger name     -> parenList ["read-integer", userShow name]
+  PactId               -> parenList ["pact-id"]
   MkKsRefGuard name    -> parenList ["keyset-ref-guard", userShow name]
 
 eqTerm :: SingTy ty -> Term ty -> Term ty -> Bool

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -1303,6 +1303,7 @@ data Term (a :: Ty) where
 
   -- Guards
   MkKsRefGuard :: Term 'TyStr            -> Term 'TyGuard
+  MkPactGuard  :: Term 'TyStr            -> Term 'TyGuard
   GuardPasses  :: TagId -> Term 'TyGuard -> Term 'TyBool
 
   -- Table access
@@ -1359,6 +1360,9 @@ showsTerm ty p tm = withSing ty $ showParen (p > 10) $ case tm of
 
   MkKsRefGuard a ->
       showString "MkKsRefGuard "
+    . showsPrec 11 a
+  MkPactGuard a ->
+      showString "MkPactGuard "
     . showsPrec 11 a
   GuardPasses a b ->
       showString "GuardPasses "
@@ -1476,6 +1480,7 @@ userShowTerm ty p = \case
   ReadInteger name     -> parenList ["read-integer", userShow name]
   PactId               -> parenList ["pact-id"]
   MkKsRefGuard name    -> parenList ["keyset-ref-guard", userShow name]
+  MkPactGuard name     -> parenList ["create-pact-guard", userShow name]
 
 eqTerm :: SingTy ty -> Term ty -> Term ty -> Bool
 eqTerm ty (CoreTerm a1) (CoreTerm a2) = singEqTm ty a1 a2

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -582,6 +582,9 @@ literalS = sansProv . literal
 unliteralS :: SymVal a => S a -> Maybe a
 unliteralS = unliteral . _sSbv
 
+uninterpretS :: HasKind a => String -> S a
+uninterpretS = sansProv . SBV.uninterpret
+
 sbv2SFrom :: Provenance -> Iso (SBV a) (SBV b) (S a) (S b)
 sbv2SFrom prov = iso (withProv prov) _sSbv
 

--- a/tests/Analyze/Eval.hs
+++ b/tests/Analyze/Eval.hs
@@ -28,8 +28,9 @@ import           Pact.Analyze.Eval.Term   (evalETerm)
 import           Pact.Analyze.Types       hiding (Object, Term)
 import           Pact.Analyze.Types.Eval  (aeRegistry, aeTxMetadata,
                                            tmDecimals, tmIntegers, tmKeySets,
-                                           mkAnalyzeEnv, mkRegistry,
-                                           mkInitialAnalyzeState, registryMap)
+                                           mkAnalyzeEnv, mkPactMetadata,
+                                           mkRegistry, mkInitialAnalyzeState,
+                                           registryMap)
 import           Pact.Analyze.Util        (dummyInfo)
 
 import           Pact.Eval                (reduce)
@@ -104,9 +105,10 @@ analyzeEval' etm ty (GenState _ registryKSs txKSs txDecs txInts) = do
         Map.empty Map.empty
 
       modName = Pact.ModuleName "test" Nothing
+      pactMd  = mkPactMetadata
       reg     = mkRegistry
 
-  Just aEnv <- pure $ mkAnalyzeEnv modName reg tables args tags dummyInfo
+  Just aEnv <- pure $ mkAnalyzeEnv modName pactMd reg tables args tags dummyInfo
 
   let writeArray' k v env = writeArray env k v
 

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -751,6 +751,16 @@ spec = describe "analyze" $ do
           |]
     expectVerified code
 
+  describe "create-pact-guard" $ do
+    let code =
+          [text|
+            (defun test:bool ()
+              (enforce-guard (create-pact-guard "foo")))
+          |]
+    -- Depending on whether we're executing in a pact:
+    expectPass code $ Satisfiable Abort'
+    expectPass code $ Satisfiable Success'
+
   describe "call-by-value semantics for inlining" $ do
     let code =
           [text|

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -908,6 +908,19 @@ spec = describe "analyze" $ do
     expectPass code $ Satisfiable Success'
     expectPass code $ Valid Success'
 
+  describe "pact-id" $ do
+    let code =
+          [text|
+            (defun test:integer ()
+              (pact-id))
+          |]
+
+    expectPass code $ Satisfiable Abort'
+    expectPass code $ Satisfiable Success'
+    expectPass code $ Satisfiable $ CoreProp $ IntegerComparison Eq
+      (Inj Result :: Prop 'TyInteger)
+      10
+
   describe "logical short-circuiting" $ do
     describe "and" $ do
       let code =


### PR DESCRIPTION
- Add analysis for `pact-id`
- Add "simplified" analysis for `create-pact-guard`. This works currently, but will need to change when we add support for sharing guards between txes via the DB in the future. This will require symbolic sums.
