### PR TITLE
Separate module/fun names in inlined applications

### DIFF
--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -290,7 +290,7 @@ verifyFunctionInvariants'
   -> IO (Either CheckFailure (TableMap [CheckResult]))
 verifyFunctionInvariants' modName funName funInfo tables pactArgs body = runExceptT $ do
     (args, tm, graph) <- hoist generalize $
-      withExcept translateToCheckFailure $ runTranslation funName funInfo pactArgs body
+      withExcept translateToCheckFailure $ runTranslation modName funName funInfo pactArgs body
 
     ExceptT $ catchingExceptions $ runSymbolic $ runExceptT $ do
       lift $ SBV.setTimeOut 1000 -- one second
@@ -351,7 +351,7 @@ verifyFunctionProperty modName funName funInfo tables pactArgs body (Located pro
   runExceptT $ do
     (args, tm, graph) <- hoist generalize $
       withExcept translateToCheckFailure $
-        runTranslation funName funInfo pactArgs body
+        runTranslation modName funName funInfo pactArgs body
     ExceptT $ catchingExceptions $ runSymbolic $ runExceptT $ do
       lift $ SBV.setTimeOut 1000 -- one second
       modelArgs' <- lift $ runAlloc $ allocArgs args
@@ -733,7 +733,7 @@ verifyModule modules moduleData = runExceptT $ do
     (\name ref accum -> do
       maybeFun <- lift $ runTC 0 False $ typecheckTopLevel ref
       pure $ case maybeFun of
-        (TopFun (FDefun _info _name funType _args _body) _meta, _tcState)
+        (TopFun (FDefun _info _mod _name funType _args _body) _meta, _tcState)
           -> accum & _1 . at name ?~ (ref, funType)
         (TopConst _info _qualifiedName _type val _doc, _tcState)
           -> accum & _2 . at name ?~ val

--- a/src/Pact/Analyze/Model/Text.hs
+++ b/src/Pact/Analyze/Model/Text.hs
@@ -24,6 +24,7 @@ import           GHC.Natural                (Natural)
 
 import qualified Pact.Types.Info            as Pact
 import qualified Pact.Types.Persistence     as Pact
+import           Pact.Types.Util            (asString)
 
 import           Pact.Analyze.Model.Graph   (linearize)
 import           Pact.Analyze.Types
@@ -181,8 +182,9 @@ showEvent ksProvs tags event = do
             "let" : displayVids showVar
           ObjectScope ->
             "destructuring object" : displayVids showVar
-          FunctionScope nm ->
-            let header = "entering function " <> nm <> " with "
+          FunctionScope modName funName ->
+            let header = "entering function " <> asString modName <> "."
+                      <> funName <> " with "
                       <> if length vids > 1 then "arguments" else "argument"
             in header : (displayVids showArg ++ [emptyLine])
       TracePopScope _ scopeTy tid _ -> do
@@ -190,7 +192,7 @@ showEvent ksProvs tags event = do
         pure $ case scopeTy of
           LetScope -> []
           ObjectScope -> []
-          FunctionScope _ ->
+          FunctionScope _ _ ->
             ["returning with " <> display mtReturns tid showTVal, emptyLine]
 
   where

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -39,9 +39,9 @@ pattern NativeFunc f <- FNative _ f _ _
 
 -- compileNode's Patterns
 
-pattern AST_InlinedApp :: Text -> [(Named a, AST a)] -> [AST a] -> AST a
-pattern AST_InlinedApp funName bindings body <-
-  App _ (FDefun _ funName _ _ [Binding _ bindings body AstBindInlinedCallArgs]) _args
+pattern AST_InlinedApp :: Lang.ModuleName -> Text -> [(Named a, AST a)] -> [AST a] -> AST a
+pattern AST_InlinedApp modName funName bindings body <-
+  App _ (FDefun _ modName funName _ _ [Binding _ bindings body AstBindInlinedCallArgs]) _args
 
 pattern AST_Let :: forall a. [(Named a, AST a)] -> [AST a] -> AST a
 pattern AST_Let bindings body <- Binding _ bindings body AstBindLet

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -18,6 +18,7 @@ import           Prelude                   hiding (Float)
 
 import           Pact.Types.Persistence    (WriteType)
 import qualified Pact.Types.Typecheck      as TC
+import qualified Pact.Types.Lang           as Pact
 
 import           Pact.Analyze.Types.Shared
 
@@ -72,7 +73,7 @@ instance Monoid Recoverability where
 data ScopeType
   = LetScope
   | ObjectScope
-  | FunctionScope Text
+  | FunctionScope Pact.ModuleName Text
   deriving (Eq, Show)
 
 data TraceEvent

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -738,7 +738,8 @@ toFun (TVar (Left (Direct TNative {..})) _) = do
 toFun (TVar (Left (Ref r)) _) = toFun (fmap Left r)
 toFun (TVar Right {} i) = die i "Value in fun position"
 toFun TDef {..} = do -- TODO currently creating new vars every time, is this ideal?
-  let fn = asString (_dModule _tDef) <> "." <> asString (_dDefName _tDef)
+  let mn = _dModule _tDef
+      fn = asString $ _dDefName _tDef
   args <- forM (_ftArgs (_dFunType _tDef)) $ \(Arg n t ai) -> do
     an <- freshId ai $ pfx fn n
     t' <- mangleType an <$> traverse toUserType t
@@ -748,7 +749,7 @@ toFun TDef {..} = do -- TODO currently creating new vars every time, is this ide
   funId <- freshId _tInfo fn
   void $ trackNode (_ftReturn funType) funId
   assocAST funId (last tcs)
-  return $ FDefun _tInfo fn funType args tcs
+  return $ FDefun _tInfo mn fn funType args tcs
 toFun t = die (_tInfo t) "Non-var in fun position"
 
 

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -31,7 +31,7 @@ module Pact.Types.Typecheck
     PrimValue (..),
     TopLevel (..),tlFun,tlInfo,tlName,tlType,tlConstVal,tlUserType,tlMeta,tlDoc,
     Special (..),
-    Fun (..),fInfo,fName,fTypes,fSpecial,fType,fArgs,fBody,
+    Fun (..),fInfo,fModule,fName,fTypes,fSpecial,fType,fArgs,fBody,
     Node (..),aId,aTy,
     Named (..),
     AstBindType (..),
@@ -214,11 +214,12 @@ data Fun t =
     _fSpecial :: Maybe (SpecialForm,Special t)
     } |
   FDefun {
-    _fInfo :: Info,
-    _fName :: Text,
-    _fType :: FunType UserType,
-    _fArgs :: [Named t],
-    _fBody :: [AST t]
+    _fInfo   :: Info,
+    _fModule :: ModuleName,
+    _fName   :: Text,
+    _fType   :: FunType UserType,
+    _fArgs   :: [Named t],
+    _fBody   :: [AST t]
     }
   deriving (Eq,Functor,Foldable,Traversable,Show)
 


### PR DESCRIPTION
For module guard analysis, we need access to the name of the module containing the inlined function