### PR TITLE
Add 'test-capability' and 'revoke-all-capabilities'

### DIFF
--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -68,7 +68,7 @@ withCapability =
       -- only revoke if newly granted
       forM_ grantedCap $ \newcap -> do
         revokeCapability newcap
-      mapM_ revokeCapability composedCaps
+        mapM_ revokeCapability composedCaps
       return r
     withCapability' i as = argsError' i as
 

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -10,7 +10,10 @@
 -- Builtins for working with capabilities.
 --
 
-module Pact.Native.Capabilities (capDefs) where
+module Pact.Native.Capabilities
+  ( capDefs
+  , evalCap
+  ) where
 
 import Control.Monad
 import Pact.Eval
@@ -27,7 +30,6 @@ capDefs =
    , enforceGuardDef "enforce-guard"
    , requireCapability
    , composeCapability
-   , grantCapability
    , createUserGuard
    , createPactGuard
    , createModuleGuard
@@ -40,7 +42,7 @@ tvA = mkTyVar "a" []
 
 withCapability :: NativeDef
 withCapability =
-  defNative (specialForm WithCapability) (applyCap True)
+  defNative (specialForm WithCapability) withCapability'
   (funType tvA [("capability",TyFun $ funType' tTyBool []),("body",TyList TyAny)])
   "Specifies and requests grant of CAPABILITY which is an application of a 'defcap' \
   \production. Given the unique token specified by this application, ensure \
@@ -53,42 +55,22 @@ withCapability =
   \will detect the presence of the token, and will not re-apply CAPABILITY, \
   \but simply execute BODY. \
    \`$(with-capability (UPDATE-USERS id) (update users id { salary: new-salary }))`"
-
--- | This is the only place we can do an external call to a capability,
--- using 'evalCap False'. This allows us to call magical capbilities
--- within the coin contract code.
-grantCapability :: NativeDef
-grantCapability =
-  defNative "grant-capability" (applyCap False)
-  (funType tTyBool [("capability", TyFun $ funType' tTyBool []),("body", TyList TyAny)])
-  "Specifies and requests grant of CAPABILITY which is an application of a 'defcap' \
-  \production. Given the unique token specified by this application, ensure \
-  \that the token is granted in the environment during execution of BODY. \
-  \'grant-capability' can obe called outside of a module module that declares the \
-  \corresponding 'defcap', otherwise module-admin rights are required. \
-  \If token is not present, the CAPABILITY is applied, with successful completion \
-  \resulting in the installation/granting of the token, which will then be revoked \
-  \upon completion of BODY. Nested 'grant-capability' calls for the same token \
-  \will detect the presence of the token, and will not re-apply CAPABILITY, \
-  \but simply execute BODY. \
-   \`$(grant-capability (UPDATE-USERS id) (my-module.update-users users id { salary: new-salary }))`"
-
-applyCap :: Bool -> NativeFun e
-applyCap inModule i [c@TApp{},body@TList{}] = gasUnreduced i [] $ do
-  -- erase composed
-  evalCapabilities . capComposed .= []
-  -- evaluate in-module cap
-  grantedCap <- evalCap inModule (_tApp c)
-  -- grab composed caps and clear composed state
-  composedCaps <- state $ \s -> (view (evalCapabilities . capComposed) s,
-                                 set (evalCapabilities . capComposed) [] s)
-  r <- reduceBody body
-  -- only revoke if newly granted
-  forM_ grantedCap $ \newcap -> do
-    revokeCapability newcap
-    mapM_ revokeCapability composedCaps
-  return r
-applyCap _ i as = argsError' i as
+  where
+    withCapability' i [c@TApp{},body@TList{}] = gasUnreduced i [] $ do
+      -- erase composed
+      evalCapabilities . capComposed .= []
+      -- evaluate in-module cap
+      grantedCap <- evalCap True (_tApp c)
+      -- grab composed caps and clear composed state
+      composedCaps <- state $ \s -> (view (evalCapabilities . capComposed) s,
+                                     set (evalCapabilities . capComposed) [] s)
+      r <- reduceBody body
+      -- only revoke if newly granted
+      forM_ grantedCap $ \newcap -> do
+        revokeCapability newcap
+      mapM_ revokeCapability composedCaps
+      return r
+    withCapability' i as = argsError' i as
 
 -- | Given cap app, enforce in-module call, eval args to form capability,
 -- and attempt to acquire. Return capability if newly-granted. When

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -19,7 +19,6 @@ import Control.Monad
 import Pact.Eval
 import Pact.Native.Internal
 import Pact.Types.Runtime
-import Pact.Types.Type (tvA)
 import Control.Lens
 import Control.Monad.State (state)
 
@@ -36,6 +35,9 @@ capDefs =
    , createModuleGuard
    , keysetRefGuard
    ])
+
+tvA :: Type n
+tvA = mkTyVar "a" []
 
 withCapability :: NativeDef
 withCapability =

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -27,6 +27,7 @@ capDefs =
    , enforceGuardDef "enforce-guard"
    , requireCapability
    , composeCapability
+   , grantCapability
    , createUserGuard
    , createPactGuard
    , createModuleGuard
@@ -57,8 +58,8 @@ withCapability =
     withCapability' i [c@TApp{},body@TList{}] = gasUnreduced i [] $ do
       -- erased composed
       evalCapabilities . capComposed .= []
-      -- evaluate cap
-      grantedCap <- evalCap (_tApp c)
+      -- evaluate in-module cap
+      grantedCap <- evalCap True (_tApp c)
       -- grab composed caps and clear composed state
       composedCaps <- state $ \s -> (view (evalCapabilities . capComposed) s,
                                      set (evalCapabilities . capComposed) [] s)
@@ -70,11 +71,24 @@ withCapability =
       return r
     withCapability' i as = argsError' i as
 
+-- | This is the only place we can do an external call to a capability,
+-- using 'evalCap False'. This allows us to call magical capbilities
+-- within the coin contract code.
+grantCapability :: NativeDef
+grantCapability =
+  defNative "grant-capability" grantCapability'
+  (funType tvA [("capability", TyFun $ funType' tTyBool []), ("body", TyList TyAny)])
+  ""
+  where
+    grantCapability' :: NativeFun e
+    grantCapability' = undefined
+
 -- | Given cap app, enforce in-module call, eval args to form capability,
--- and attempt to acquire. Return capability if newly-granted.
-evalCap :: App (Term Ref) -> Eval e (Maybe Capability)
-evalCap a@App{..} = requireDefcap a >>= \d@Def{..} -> do
-      guardForModuleCall _appInfo _dModule $ return ()
+-- and attempt to acquire. Return capability if newly-granted. When
+-- 'inModule' is 'True', natives can only be run within module scope.
+evalCap :: Bool -> App (Term Ref) -> Eval e (Maybe Capability)
+evalCap inModule a@App{..} = requireDefcap a >>= \d@Def{..} -> do
+      when inModule $ guardForModuleCall _appInfo _dModule $ return ()
       prep@(args,_) <- prepareUserAppArgs d _appArgs
       let cap = UserCapability _dDefName args
       acquired <- acquireCapability cap $ do
@@ -127,7 +141,8 @@ composeCapability =
       void $ case isDefCap of
         Nothing -> evalError' i "compose-capability valid only within defcap body"
         Just {} -> do
-          granted <- evalCap app
+          -- should be granted in-module
+          granted <- evalCap True app
           -- if newly granted, add to composed list
           forM_ granted $ \newcap -> evalCapabilities . capComposed %= (newcap:)
       return $ toTerm True

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -19,6 +19,7 @@ import Control.Monad
 import Pact.Eval
 import Pact.Native.Internal
 import Pact.Types.Runtime
+import Pact.Types.Type (tvA)
 import Control.Lens
 import Control.Monad.State (state)
 
@@ -35,10 +36,6 @@ capDefs =
    , createModuleGuard
    , keysetRefGuard
    ])
-
-tvA :: Type n
-tvA = mkTyVar "a" []
-
 
 withCapability :: NativeDef
 withCapability =

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -450,4 +450,5 @@ testCapability i as = argsError' i as
 revokeAll :: RNativeFun ReplState
 revokeAll _ _ = do
   evalCapabilities . capComposed .= []
+  evalCapabilities . capGranted .= []
   pure . tStr $ "All capabilities revoked"

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -149,7 +149,7 @@ replDefs = ("Repl",
       (funType tTyString [("capability", TyFun $ funType' tTyBool [])]) $
      "Specify and request grant of CAPABILITY. Once granted, CAPABILITY and any composed capabilities are in scope " <>
      "for the rest of the transaction. Allows direct invocation of capabilities, which is not available in the " <>
-     "blockchain environment. `$(grant-capability (TRANSFER) (my-module.transfer sender receiver 1.0))`"
+     "blockchain environment. `$(test-capability (MY-CAP))`"
      ])
      where
        json = mkTyVar "a" [tTyInteger,tTyString,tTyTime,tTyDecimal,tTyBool,
@@ -433,8 +433,7 @@ setGasRate _ [TLitInteger r] = do
 setGasRate i as = argsError i as
 
 -- | This is the only place we can do an external call to a capability,
--- using 'evalCap False'. This allows us to call magical capabilities
--- within the coin contract code.
+-- using 'evalCap False'.
 testCapability :: ZNativeFun ReplState
 testCapability _ [ c@TApp{} ] = do
   cap <- evalCap False $ _tApp c

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -441,12 +441,12 @@ grantCapability _ [c@TApp{},body@TList{}] = do
   -- evaluate in-module cap
   grantedCap <- evalCap False (_tApp c)
   -- grab composed caps and clear composed state
-  _composedCaps <- state $ \s -> (view (evalCapabilities . capComposed) s,
+  composedCaps <- state $ \s -> (view (evalCapabilities . capComposed) s,
                                   set (evalCapabilities . capComposed) [] s)
   r <- reduceBody body
   -- only revoke if newly granted
   forM_ grantedCap $ \newcap -> do
     revokeCapability newcap
-  -- mapM_ revokeCapability composedCaps
+    mapM_ revokeCapability composedCaps
   return r
 grantCapability i as = argsError' i as

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -48,6 +48,7 @@ import Pact.Types.Typecheck
 import Pact.Native.Internal hiding (defRNative,defGasRNative,defNative)
 import qualified Pact.Native.Internal as Native
 import Pact.Types.Runtime
+import Pact.Types.Type (tvA)
 import Pact.Eval
 import Pact.Persist.Pure
 import Pact.PersistPactDb
@@ -146,7 +147,7 @@ replDefs = ("Repl",
      ,defZRNative "env-hash" envHash (funType tTyString [("hash",tTyString)])
      "Set current transaction hash. HASH must be a valid BLAKE2b 512-bit hash. `(env-hash (hash \"hello\"))`"
      ,defZNative "grant-capability" grantCapability
-      (funType tTyBool [("capability", TyFun $ funType' tTyBool []),("body", TyList TyAny)]) $
+      (funType tvA [("capability", TyFun $ funType' tTyBool []),("body", TyList TyAny)]) $
      "Allow the granting of capability CAPABILITY for use in BODY outside of a module. " <>
       "`$(grant-capability (TRANSFER) (my-module.transfer sender receiver 1.0))`"
      ])
@@ -439,7 +440,7 @@ grantCapability _ [c@TApp{},body@TList{}] = do
   -- erase composed
   evalCapabilities . capComposed .= []
   -- evaluate in-module cap
-  grantedCap <- evalCap False (_tApp c)
+  grantedCap <- evalCap False $ _tApp c
   -- grab composed caps and clear composed state
   composedCaps <- state $ \s -> (view (evalCapabilities . capComposed) s,
                                   set (evalCapabilities . capComposed) [] s)

--- a/src/Pact/Types/Type.hs
+++ b/src/Pact/Types/Type.hs
@@ -31,7 +31,7 @@ module Pact.Types.Type
    TypeVar(..),tvName,tvConstraint,
    Type(..),tyFunType,tyListType,tySchema,tySchemaType,tySchemaPartial,tyUser,tyVar,tyGuard,
    mkTyVar,mkTyVar',mkSchemaVar,
-   isAnyTy,isVarTy,canUnifyWith,tvA
+   isAnyTy,isVarTy,canUnifyWith
    ) where
 
 
@@ -273,9 +273,6 @@ mkTyVar' :: TypeVarName -> Type n
 mkTyVar' n = mkTyVar n []
 mkSchemaVar :: TypeVarName -> Type n
 mkSchemaVar n = TyVar (SchemaVar n)
-
-tvA :: Type n
-tvA = mkTyVar "a" []
 
 isAnyTy :: Type v -> Bool
 isAnyTy TyAny = True

--- a/src/Pact/Types/Type.hs
+++ b/src/Pact/Types/Type.hs
@@ -31,7 +31,7 @@ module Pact.Types.Type
    TypeVar(..),tvName,tvConstraint,
    Type(..),tyFunType,tyListType,tySchema,tySchemaType,tySchemaPartial,tyUser,tyVar,tyGuard,
    mkTyVar,mkTyVar',mkSchemaVar,
-   isAnyTy,isVarTy,canUnifyWith
+   isAnyTy,isVarTy,canUnifyWith,tvA
    ) where
 
 
@@ -273,6 +273,9 @@ mkTyVar' :: TypeVarName -> Type n
 mkTyVar' n = mkTyVar n []
 mkSchemaVar :: TypeVarName -> Type n
 mkSchemaVar n = TyVar (SchemaVar n)
+
+tvA :: Type n
+tvA = mkTyVar "a" []
 
 isAnyTy :: Type v -> Bool
 isAnyTy TyAny = True

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -62,9 +62,6 @@
   (defun test-compose-cap ()
     (with-capability (COMPOSING-CAP)
        (require-capability (KALL-CAP))))
-
-  (defun test-granted ()
-    (require-capability (GRANTED)))
 )
 
 (create-table guard-table)

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -14,6 +14,8 @@
 
   (defschema yieldschema result:integer)
 
+  (defcap GRANTED () true)
+
   (defcap KALL-CAP () (enforce-keyset 'kall))
 
   (defun with-kall ()
@@ -61,8 +63,10 @@
     (with-capability (COMPOSING-CAP)
        (require-capability (KALL-CAP))))
 
-
+  (defun test-granted ()
+    (require-capability (GRANTED)))
 )
+
 (create-table guard-table)
 
 (commit-tx)
@@ -142,3 +146,5 @@
 (test-compose-cap)
 ;now validate that KALL-CAP is gone
 (expect-failure "KALL-CAP composed cap is revoked" (require-capability KALL-CAP))
+
+(expect "can grant caps at toplevel" (grant-capability (GRANTED) (test-granted)))

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -62,6 +62,9 @@
   (defun test-compose-cap ()
     (with-capability (COMPOSING-CAP)
        (require-capability (KALL-CAP))))
+
+  (defun test-granted ()
+    (require-capability (GRANTED)))
 )
 
 (create-table guard-table)
@@ -143,7 +146,13 @@
 (test-compose-cap)
 ;now validate that KALL-CAP is gone
 (expect-failure "KALL-CAP composed cap is revoked" (require-capability KALL-CAP))
+; defuns requiring magic capabilities should not work
+(expect-failure "functions requiring restricted governance should fail" (test-granted))
 ; bring magical capabilities into scope at repl scope
 (test-capability (GRANTED))
+; defuns requiring magic capabilities should now work
+(expect "functions requiring restricted governance should succeed after 'test-capability'" true (test-granted))
 ; revoke all
 (revoke-all-capabilities)
+; revocation now makes functions requiring certain caps to now fail
+(expect-failure "functions requiring restricted governance should fail after revocation" (test-granted))

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -146,5 +146,7 @@
 (test-compose-cap)
 ;now validate that KALL-CAP is gone
 (expect-failure "KALL-CAP composed cap is revoked" (require-capability KALL-CAP))
-
-(expect "can grant caps at toplevel" (grant-capability (GRANTED) (test-granted)))
+; bring magical capabilities into scope at repl scope
+(test-capability (GRANTED))
+; revoke all
+(revoke-all-capabilities)

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -152,7 +152,8 @@
 (test-capability (GRANTED))
 ; defuns requiring magic capabilities should now work
 (expect "functions requiring restricted governance should succeed after 'test-capability'" true (test-granted))
-; revoke all
-(revoke-all-capabilities)
+(commit-tx)
+
+(use caps)
 ; revocation now makes functions requiring certain caps to now fail
 (expect-failure "functions requiring restricted governance should fail after revocation" (test-granted))


### PR DESCRIPTION
This PR comes in addition to the [coin contract PR](https://github.com/kadena-io/chainweb/pull/294). After discussions with Stuart, we decided that some of the commands using magic capabilities (such as the `coinbase` command) will need us to "inject" capabilities outside of module scope for additional security. `grant-capability` relaxes the in-module restriction for capabilities, and will only be called by us for those few blessed commands. 