### PR TITLE
Verify output partial binding

### DIFF
--- a/src/Pact/Analyze/Eval/Core.hs
+++ b/src/Pact/Analyze/Eval/Core.hs
@@ -181,7 +181,7 @@ evalCore (ObjMerge
     S _ obj1' <- eval obj1
     S _ obj2' <- eval obj2
     case sing @a of
-      SObjectUnsafe schema -> pure $ sansProv $
+      SObject schema -> pure $ sansProv $
         evalObjMerge' (obj1' :< schema1) (obj2' :< schema2) schema
       _ -> throwErrorNoLoc "this must be an object"
 evalCore ObjMerge{} = throwErrorNoLoc "both types must be objects"

--- a/src/Pact/Analyze/Eval/Prop.hs
+++ b/src/Pact/Analyze/Eval/Prop.hs
@@ -219,7 +219,7 @@ evalPropSpecific (PropRead objTy@(SObjectUnsafe fields) ba tn pRk) = do
   aValFields <- foldrSingList
     (pure $ Some SObjectNil $ AnSBV $ literal ())
     (\k ty accum -> do
-      Some objTy'@(SObjectUnsafe schema) (AnSBV obj) <- accum
+      Some objTy'@(SObject schema) (AnSBV obj) <- accum
       let fieldName = symbolVal k
           cn = ColumnName fieldName
 

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -162,7 +162,7 @@ mkAnalyzeEnv modName pactMetadata registry tables args tags info = do
 
   columnIds <- for tables $ \(Table tname ut _) ->
     case maybeTranslateUserType' ut of
-      Just (EType (SObjectUnsafe ty)) -> Just
+      Just (EType (SObject ty)) -> Just
         (TableName (T.unpack tname), varIdColumns ty)
       _ -> Nothing
 


### PR DESCRIPTION
CI on the previous commits failed with

```
*** Data.SBV: Unexpected non-success response from Z3:
***
***    Sent      : (define-fun s177 () (SBVTuple2 String (SBVTuple2 String (SBVTuple2 (_ BitVec 64) (SBVTuple2 (_ BitVec 64) (SBVTuple2 Int (SBVTuple2 Int (SBVTuple2 String (SBVTuple2 String SBVTuple0)))))))) (proj_2_SBVTuple2 s165))
***    Expected  : success
***    Received  : (error "line 211 column 213: invalid function/constant definition, sort mismatch")
***
***    Exit code : ExitFailure (-15)
***    Executable: /home/travis/build/kadena-io/pact/z3_downloaded/z3-4.8.3.7f5d66c3c299-x64-ubuntu-14.04/bin/z3
***    Options   : -nw -in -smt2
***
***    Reason    : Check solver response for further information. If your code is correct,
***                please report this as an issue either with SBV or the solver itself!
```

This was the result of the typechecker producing the wrong type for a binding. In `cp.pact` we have the line `(bind (with-order-status order-id ORDER_FILLED) { "price" := price }`, but the return type of `with-order-status` is `object{order}`, which has several more keys.

This updates the typechecker to report when bindings are partial. Note that I'm not confident in my fix here.

It also updates the analysis type translation to be aware of partial types reported from the typechecker.

The `SObjectUnsafe` -> `SObject` changes have no functional effect, but it's nice to reduce the number of uses of "unsafe" things.