### PR TITLE
Fix native pretty-printed appearance.

### DIFF
--- a/src/Pact/Types/Pretty.hs
+++ b/src/Pact/Types/Pretty.hs
@@ -23,6 +23,7 @@ module Pact.Types.Pretty
   , dquotes
   , encloseSep
   , equals
+  , fillSep
   , fromAnsiWlPprint
   , hardline
   , hsep
@@ -62,7 +63,7 @@ import           Data.Text.Prettyprint.Doc
   defaultLayoutOptions, vsep, hsep, (<+>), colon, angles, list, braces,
   brackets, encloseSep, parens, sep, line, dquotes, viaShow, punctuate, dot,
   encloseSep, space, nest, align, hardline, tupled, indent, equals, reAnnotate,
-  reAnnotateS)
+  reAnnotateS, fillSep)
 import qualified Data.Text.Prettyprint.Doc as PP
 import qualified Data.Text.Prettyprint.Doc.Internal.Type as PP
 import qualified Data.Text.Prettyprint.Doc.Render.String as PP

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -110,7 +110,6 @@ import Pact.Types.Info
 import Pact.Types.Type
 import Pact.Types.Exp
 
-
 data Meta = Meta
   { _mDocs  :: !(Maybe Text) -- ^ docs
   , _mModel :: ![Exp Info]   -- ^ models
@@ -869,7 +868,7 @@ instance Pretty n => Pretty (Term n) where
     TNative{..} -> annotate Header ("native `" <> pretty _tNativeName <> "`")
       <> nest 2 (
          line
-      <> line <> pretty _tNativeDocs
+      <> line <> fillSep (pretty <$> T.words _tNativeDocs)
       <> examples
       <> line
       <> line <> annotate Header "Type:"

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -866,7 +866,7 @@ instance Pretty n => Pretty (Term n) where
     TModule{..} -> pretty _tModuleDef
     TList{..} -> bracketsSep $ pretty <$> _tList
     TDef{..} -> pretty _tDef
-    TNative{..} -> annotate Header ("native `" <> pretty (asString' _tNativeName) <> "`")
+    TNative{..} -> annotate Header ("native `" <> pretty _tNativeName <> "`")
       <> nest 2 (
          line
       <> line <> pretty _tNativeDocs


### PR DESCRIPTION
Before:

    native `[t, e, s, t, -, c, a, p, a, b, i, l, i, t, y]`

After:

    native `test-capability`