### PR TITLE
Add analysis groundwork for capabilities

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -95,6 +95,7 @@ library
       Pact.Analyze.PrenexNormalize
       Pact.Analyze.Translate
       Pact.Analyze.Types
+      Pact.Analyze.Types.Capability
       Pact.Analyze.Types.Eval
       Pact.Analyze.Types.Languages
       Pact.Analyze.Types.Model

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -447,8 +447,8 @@ moduleTables modules ModuleData{..} = do
 
 moduleCapabilities :: ModuleData -> ExceptT VerificationFailure IO [Capability]
 moduleCapabilities md = do
-    toplevels <- withExceptT ModuleCheckFailure $ ExceptT $
-                   fmap sequence $ traverse typecheck defcapRefs
+    toplevels <- withExceptT ModuleCheckFailure $
+                   traverse (ExceptT . typecheck) defcapRefs
     hoist generalize $ traverse mkCap toplevels
 
   where

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -50,7 +50,6 @@ import qualified Data.List                 as List
 import           Data.Map.Strict           (Map)
 import qualified Data.Map.Strict           as Map
 import           Data.Maybe                (mapMaybe)
-import           Data.Proxy                (Proxy)
 import           Data.SBV                  (Symbolic)
 import qualified Data.SBV                  as SBV
 import qualified Data.SBV.Control          as SBV
@@ -60,7 +59,6 @@ import qualified Data.Set                  as Set
 import           Data.Text                 (Text)
 import qualified Data.Text                 as T
 import           Data.Traversable          (for)
-import           GHC.TypeLits              (SomeSymbol(..), someSymbolVal)
 import           Prelude                   hiding (exp)
 
 import           Pact.Typechecker          (typecheckTopLevel)
@@ -470,15 +468,6 @@ moduleCapabilities md = do
             Just ety -> pure (name, ety)
             Nothing  -> throwError $
               TypeTranslationFailure "couldn't translate argument type" ty
-
-        mkESchema :: [(Text, EType)] -> ESchema
-        mkESchema [] = ESchema SNil'
-        mkESchema ((name, (EType ty)):rest) =
-          case mkESchema rest of
-            ESchema restSchema ->
-              case someSymbolVal (T.unpack name) of
-                SomeSymbol (_ :: Proxy k) -> withSing ty $ withTypeable ty $
-                  ESchema $ SCons' (SSymbol @k) ty restSchema
 
         (capName, pactArgs) = case toplevel of
           TopFun FDefun{_fName,_fType} _ ->

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -721,8 +721,8 @@ verifyModule modules moduleData = runExceptT $ do
       propDefs :: HM.HashMap Text (DefinedProperty (Exp Info))
       propDefs = HM.unions allModulePropDefs
 
-      typecheckedRefs :: HM.HashMap Text Ref
-      typecheckedRefs = moduleTypecheckableRefs moduleData
+      typecheckableRefs :: HM.HashMap Text Ref
+      typecheckableRefs = moduleTypecheckableRefs moduleData
 
   -- For each ref, if it typechecks as a function (it'll be either a function
   -- or a constant), keep its signature.
@@ -739,7 +739,7 @@ verifyModule modules moduleData = runExceptT $ do
         _ -> accum
     )
     (HM.empty, HM.empty)
-    typecheckedRefs
+    typecheckableRefs
 
   let valueToProp' :: ETerm -> Except VerificationFailure EProp
       valueToProp' tm = case valueToProp tm of
@@ -770,7 +770,7 @@ verifyModule modules moduleData = runExceptT $ do
 
   funChecks''' <- lift $ ifor funChecks'' $ \name (ref, check) ->
     verifyFunProps ref name check
-  invariantChecks <- ifor typecheckedRefs $ \name ref ->
+  invariantChecks <- ifor typecheckableRefs $ \name ref ->
     withExceptT ModuleCheckFailure $ ExceptT $
       verifyFunctionInvariants modName tables ref name
 

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -484,7 +484,7 @@ moduleCapabilities md = do
           TopFun FDefun{_fName,_fType} _ ->
             (CapName $ T.unpack _fName, _ftArgs _fType)
           _ ->
-            vacuousMatch "invariant: defcap toplevel must be a defun"
+            error "invariant violation: defcap toplevel must be a defun"
 
 data PropertyScope
   = Everywhere

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -375,7 +375,7 @@ capabilityAppToken (Capability schema capName) vids = do
         ( SBVI.SBV sval
         , buildObject tys avals
         )
-    buildObject _ _ = vacuousMatch "buildObject: list length mismatch"
+    buildObject _ _ = error "invariant violation: list length mismatch"
 
 addPendingGrant :: Token -> Analyze ()
 addPendingGrant token = pendingCapabilityGranted token .= sTrue

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -344,7 +344,7 @@ writeFields writeType tid tn sRk (S mProv obj)
 
 writeFields _ _ _ _ _ _ = vacuousMatch "the previous two cases are complete"
 
-accumulatingPendingGrants :: Analyze () -> Analyze CapabilityGrants
+accumulatingPendingGrants :: Analyze () -> Analyze TokenGrants
 accumulatingPendingGrants act = do
     emptyGrants <- view aeEmptyGrants
     previouslyPending <- swapIn emptyGrants
@@ -352,7 +352,7 @@ accumulatingPendingGrants act = do
     swapIn previouslyPending
 
   where
-    swapIn :: CapabilityGrants -> Analyze CapabilityGrants
+    swapIn :: TokenGrants -> Analyze TokenGrants
     swapIn next = do
       prev <- use $ latticeState.lasPendingGrants
       latticeState.lasPendingGrants .= next
@@ -378,9 +378,9 @@ capabilityAppToken (Capability schema capName) vids = do
     buildObject _ _ = error "invariant violation: list length mismatch"
 
 addPendingGrant :: Token -> Analyze ()
-addPendingGrant token = pendingCapabilityGranted token .= sTrue
+addPendingGrant token = pendingTokenGranted token .= sTrue
 
-extendingGrants :: CapabilityGrants -> Analyze (S a) -> Analyze (S a)
+extendingGrants :: TokenGrants -> Analyze (S a) -> Analyze (S a)
 extendingGrants newGrants = local $ aeActiveGrants %~ (<> newGrants)
 
 evalTerm :: SingI a => Term a -> Analyze (S (Concrete a))

--- a/src/Pact/Analyze/LegacySFunArray.hs
+++ b/src/Pact/Analyze/LegacySFunArray.hs
@@ -7,6 +7,7 @@
 module Pact.Analyze.LegacySFunArray
   ( SFunArray
   , mkSFunArray
+  , eitherArray
   ) where
 
 import           Control.Monad.IO.Class (liftIO)
@@ -61,3 +62,6 @@ instance SymArray SFunArray where
 
 instance SymVal b => Mergeable (SFunArray a b) where
   symbolicMerge _ = mergeArrays
+
+eitherArray :: SFunArray a Bool -> SFunArray a Bool -> SFunArray a Bool
+eitherArray (SFunArray g) (SFunArray h) = SFunArray (\x -> g x .|| h x)

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -196,6 +196,16 @@ pattern AST_Bind node object bindings schema body <-
       (NativeFuncSpecial "bind" (AST_BindSchema _ bindings schema body))
       [object]
 
+pattern AST_WithCapability
+  :: Node
+  -> AST Node
+  -> [AST Node]
+  -> AST Node
+pattern AST_WithCapability node app body <-
+  App node
+      (NativeFuncSpecial "with-capability" (List _ body))
+      [app]
+
 -- pattern RawTableName :: Text -> AST Node
 -- pattern RawTableName t <- Table (Node (TcId _ t _) _) _
 

--- a/src/Pact/Analyze/Types.hs
+++ b/src/Pact/Analyze/Types.hs
@@ -8,7 +8,8 @@
 
 -- | Toplevel module for types related to symbolic analysis of Pact programs.
 module Pact.Analyze.Types
-  ( module Pact.Analyze.Types.Languages
+  ( module Pact.Analyze.Types.Capability
+  , module Pact.Analyze.Types.Languages
   , module Pact.Analyze.Types.Model
   , module Pact.Analyze.Types.Numerical
   , module Pact.Analyze.Types.ObjUtil
@@ -38,6 +39,7 @@ import           Prelude                      hiding (Float)
 
 import qualified Pact.Types.Typecheck         as TC
 
+import           Pact.Analyze.Types.Capability
 import           Pact.Analyze.Types.Languages
 import           Pact.Analyze.Types.Model
 import           Pact.Analyze.Types.Numerical

--- a/src/Pact/Analyze/Types/Capability.hs
+++ b/src/Pact/Analyze/Types/Capability.hs
@@ -14,6 +14,7 @@ import           Pact.Analyze.LegacySFunArray (eitherArray, mkSFunArray)
 import           Pact.Analyze.Types.Shared
 import           Pact.Analyze.Types.Types
 
+-- | The "signature" for a capability in Pact.
 data Capability where
   Capability :: SingList schema -> CapName -> Capability
 
@@ -24,6 +25,9 @@ instance Show Capability where
     . showChar ' '
     . showsPrec 11 capName
 
+-- | Whether each capability is currently granted. The keys in this map are
+-- statically determined by the number of @defcap@s in the module under
+-- analysis.
 newtype CapabilityGrants
   = CapabilityGrants { _capabilityGrants :: Map CapName (EKeySFunArray Bool) }
   deriving Show
@@ -54,10 +58,11 @@ instance Semigroup CapabilityGrants where
 instance Mergeable CapabilityGrants where
   symbolicMerge f t (CapabilityGrants left) (CapabilityGrants right) =
     -- Using intersectionWith here is fine, because we know that each map has
-    -- all possible capabilities:
+    -- all possible capabilities in the module.
     CapabilityGrants $ Map.intersectionWith (symbolicMerge f t) left right
 
--- | The index into the family that is a 'Capability'.
+-- | The index into the family that is a 'Capability'. Think of this of the
+-- arguments to a particular call of a capability.
 data Token where
   Token :: SingList schema -> CapName -> S (ConcreteObj schema) -> Token
 

--- a/src/Pact/Analyze/Types/Capability.hs
+++ b/src/Pact/Analyze/Types/Capability.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE GADTs           #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Types for representing capabilities in analysis.
+module Pact.Analyze.Types.Capability where
+
+import           Control.Lens                 ((<&>), makeLenses)
+import           Data.Map.Strict              (Map)
+import qualified Data.Map.Strict              as Map
+import           Data.SBV                     (Mergeable(..), sFalse)
+import           Data.Type.Equality           ((:~:) (Refl))
+
+import           Pact.Analyze.LegacySFunArray (eitherArray, mkSFunArray)
+import           Pact.Analyze.Types.Shared
+import           Pact.Analyze.Types.Types
+
+data Capability where
+  Capability :: SingList schema -> CapName -> Capability
+
+instance Show Capability where
+  showsPrec p (Capability sch capName) = showParen (p > 10) $
+      showString "Capability "
+    . showsPrec 11 sch
+    . showChar ' '
+    . showsPrec 11 capName
+
+newtype CapabilityGrants
+  = CapabilityGrants { _capabilityGrants :: Map CapName (EKeySFunArray Bool) }
+  deriving Show
+
+mkCapabilityGrants :: [Capability] -> CapabilityGrants
+mkCapabilityGrants caps = CapabilityGrants $ Map.fromList $
+  caps <&> \(Capability schema name) ->
+    ( name
+    , EKeySFunArray (SObjectUnsafe schema) (mkSFunArray $ const sFalse)
+    )
+
+extendGrants :: CapabilityGrants -> CapabilityGrants -> CapabilityGrants
+extendGrants (CapabilityGrants newGrants) (CapabilityGrants oldGrants) =
+    -- We can intersect because both maps will contain the exact same keys
+    CapabilityGrants $ Map.intersectionWith eitherContains newGrants oldGrants
+
+  where
+    eitherContains :: EKeySFunArray Bool -> EKeySFunArray Bool -> EKeySFunArray Bool
+    eitherContains (EKeySFunArray ty1 arr1) (EKeySFunArray ty2 arr2) =
+      case singEq ty1 ty2 of
+        Just Refl -> EKeySFunArray ty1 $ eitherArray arr1 arr2
+        Nothing   -> error $
+          "extendGrants: type mismatch: " ++ show ty1 ++ " vs " ++ show ty2
+
+instance Semigroup CapabilityGrants where
+  (<>) = extendGrants
+
+instance Mergeable CapabilityGrants where
+  symbolicMerge f t (CapabilityGrants left) (CapabilityGrants right) =
+    -- Using intersectionWith here is fine, because we know that each map has
+    -- all possible capabilities:
+    CapabilityGrants $ Map.intersectionWith (symbolicMerge f t) left right
+
+-- | The index into the family that is a 'Capability'.
+data Token where
+  Token :: SingList schema -> CapName -> S (ConcreteObj schema) -> Token
+
+makeLenses ''CapabilityGrants

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -196,21 +196,24 @@ instance Show (EValSFunArray k) where
     . showChar ' '
     . withHasKind ty (showsPrec 11 sfunarr)
 
-eArrayAt :: forall a.
-  SingTy a -> S RowKey -> Lens' (EValSFunArray RowKey) (SBV (Concrete a))
-eArrayAt ty (S _ symKey) = lens getter setter where
+eVArrayAt
+  :: forall k v
+   . SingTy v
+  -> S k
+  -> Lens' (EValSFunArray k) (SBV (Concrete v))
+eVArrayAt ty (S _ symKey) = lens getter setter where
 
-  getter :: EValSFunArray RowKey -> SBV (Concrete a)
+  getter :: EValSFunArray k -> SBV (Concrete v)
   getter (EValSFunArray ty' arr) = case singEq ty ty' of
     Just Refl -> readArray arr symKey
     Nothing   -> error $
-      "eArrayAt: bad getter access: " ++ show ty ++ " vs " ++ show ty'
+      "eVArrayAt: bad getter access: " ++ show ty ++ " vs " ++ show ty'
 
-  setter :: EValSFunArray RowKey -> SBV (Concrete a) -> EValSFunArray RowKey
+  setter :: EValSFunArray k -> SBV (Concrete v) -> EValSFunArray k
   setter (EValSFunArray ty' arr) val = case singEq ty ty' of
     Just Refl -> withSymVal ty $ EValSFunArray ty $ writeArray arr symKey val
     Nothing   -> error $
-      "eArrayAt: bad setter access: " ++ show ty ++ " vs " ++ show ty'
+      "eVArrayAt: bad setter access: " ++ show ty ++ " vs " ++ show ty'
 
 instance Mergeable (EValSFunArray k) where
   symbolicMerge force test (EValSFunArray ty1 arr1) (EValSFunArray ty2 arr2)
@@ -602,7 +605,7 @@ typedCell ty cellValues tn cn sRk sDirty
   . singular (ix tn)
   . scValues
   . singular (ix cn)
-  . eArrayAt ty sRk
+  . eVArrayAt ty sRk
   . sbv2SFrom (fromCell tn cn sRk sDirty)
 
 symArrayAt

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -196,9 +196,6 @@ instance Show ESFunArray where
     . showChar ' '
     . withHasKind ty (showsPrec 11 sfunarr)
 
-data SymbolicCells = SymbolicCells { _scValues :: ColumnMap ESFunArray }
-  deriving (Show)
-
 eArrayAt :: forall a.
   SingTy a -> S RowKey -> Lens' ESFunArray (SBV (Concrete a))
 eArrayAt ty (S _ symKey) = lens getter setter where
@@ -221,6 +218,9 @@ instance Mergeable ESFunArray where
       Nothing   -> error "mismatched types when merging two ESFunArrays"
       Just Refl -> withSymVal ty1 $
         SomeSFunArray ty1 $ symbolicMerge force test arr1 arr2
+
+data SymbolicCells = SymbolicCells { _scValues :: ColumnMap ESFunArray }
+  deriving (Show)
 
 instance Mergeable SymbolicCells where
   symbolicMerge force test (SymbolicCells left) (SymbolicCells right)

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -127,7 +127,9 @@ data AnalyzeEnv
     , _aeInfo         :: !Info
     , _aeTrivialGuard :: !(S Guard)
     , _aeEmptyGrants  :: CapabilityGrants
+    -- ^ the default, blank slate of grants, where no token is granted.
     , _aeActiveGrants :: CapabilityGrants
+    -- ^ the current set of tokens that are granted, manipulated as a stack
     } deriving Show
 
 mkAnalyzeEnv

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -75,6 +75,7 @@ data ScopeType
   = LetScope
   | ObjectScope
   | FunctionScope Pact.ModuleName Text
+  | CapabilityScope Pact.ModuleName CapName
   deriving (Eq, Show)
 
 data TraceEvent

--- a/src/Pact/Analyze/Types/ObjUtil.hs
+++ b/src/Pact/Analyze/Types/ObjUtil.hs
@@ -32,7 +32,7 @@ module Pact.Analyze.Types.ObjUtil
 
   -- * Utilities
   , mkSObject
-  , mkSchema
+  , normalizeSchema
   ) where
 
 import           Data.Type.Bool           (If)
@@ -194,5 +194,5 @@ insert k v (SCons k' v' kvs) = case compareKeys k k' of
 mkSObject :: Sing schema -> Sing ('TyObject (Normalize schema))
 mkSObject = SObjectUnsafe . eraseList . normalize . UnSingList
 
-mkSchema :: SingList schema -> SingList (Normalize schema)
-mkSchema = eraseList . normalize . UnSingList
+normalizeSchema :: SingList schema -> SingList (Normalize schema)
+normalizeSchema = eraseList . normalize . UnSingList

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -519,7 +519,7 @@ instance Show ESchema where
 
 mkESchema :: [(Text, EType)] -> ESchema
 mkESchema tys = case go tys of
-                  ESchema unsorted -> ESchema $ mkSchema unsorted
+                  ESchema unsorted -> ESchema $ normalizeSchema unsorted
   where
     go :: [(Text, EType)] -> ESchema
     go [] = ESchema SNil'

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -517,6 +517,20 @@ instance Show ESchema where
       showString "ESchema "
     . showsPrec 11 ty
 
+mkESchema :: [(Text, EType)] -> ESchema
+mkESchema tys = case go tys of
+                  ESchema unsorted -> ESchema $ mkSchema unsorted
+  where
+    go :: [(Text, EType)] -> ESchema
+    go [] = ESchema SNil'
+    go ((name, (EType ty)):rest) =
+      case go rest of
+        ESchema restSchema ->
+          case someSymbolVal (T.unpack name) of
+            SomeSymbol (_ :: Proxy k) ->
+              withSing ty $ withTypeable ty $
+                ESchema $ SCons' (SSymbol @k) ty restSchema
+
 -- | When given a column mapping, this function gives a canonical way to assign
 -- var ids to each column. Also see 'varIdArgs'.
 varIdColumns :: SingList m -> Map Text VarId

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -74,6 +74,7 @@ import qualified Pact.Types.Pretty            as Pretty
 import qualified Pact.Types.Lang              as Pact
 import           Pact.Types.Util              (AsString)
 
+import           Pact.Analyze.LegacySFunArray (SFunArray)
 import           Pact.Analyze.Feature         hiding (Constraint, Doc, Type,
                                                dec, ks, obj, str, time)
 import           Pact.Analyze.Orphans         ()
@@ -214,6 +215,13 @@ instance HasKind ColumnName where
 
 instance IsString ColumnName where
   fromString = ColumnName
+
+newtype CapName
+  = CapName String
+  deriving (Eq, Ord, Show)
+
+instance IsString CapName where
+  fromString = CapName
 
 newtype Str = Str String
   deriving (Eq, Ord, Show, SMTValue, HasKind, Typeable, IsString)
@@ -1084,6 +1092,80 @@ data DefinedProperty a = DefinedProperty
   { propertyArgs :: [(Text, QType)]
   , propertyBody :: a
   } deriving Show
+
+-- | SFunArray with existential value type
+data EValSFunArray k where
+  EValSFunArray :: HasKind k => SingTy v -> SFunArray k (Concrete v) -> EValSFunArray k
+
+instance Show (EValSFunArray k) where
+  showsPrec p (EValSFunArray ty sfunarr) = showParen (p > 10) $
+      showString "EValSFunArray "
+    . showsPrec 11 ty
+    . showChar ' '
+    . withHasKind ty (showsPrec 11 sfunarr)
+
+eVArrayAt
+  :: forall k v
+   . SingTy v
+  -> S k
+  -> Lens' (EValSFunArray k) (SBV (Concrete v))
+eVArrayAt ty (S _ symKey) = lens getter setter where
+
+  getter :: EValSFunArray k -> SBV (Concrete v)
+  getter (EValSFunArray ty' arr) = case singEq ty ty' of
+    Just Refl -> SBV.readArray arr symKey
+    Nothing   -> error $
+      "eVArrayAt: bad getter access: " ++ show ty ++ " vs " ++ show ty'
+
+  setter :: EValSFunArray k -> SBV (Concrete v) -> EValSFunArray k
+  setter (EValSFunArray ty' arr) val = case singEq ty ty' of
+    Just Refl -> withSymVal ty $ EValSFunArray ty $ SBV.writeArray arr symKey val
+    Nothing   -> error $
+      "eVArrayAt: bad setter access: " ++ show ty ++ " vs " ++ show ty'
+
+instance Mergeable (EValSFunArray k) where
+  symbolicMerge force test (EValSFunArray ty1 arr1) (EValSFunArray ty2 arr2)
+    = case singEq ty1 ty2 of
+      Nothing   -> error "mismatched types when merging two EValSFunArrays"
+      Just Refl -> withSymVal ty1 $
+        EValSFunArray ty1 $ symbolicMerge force test arr1 arr2
+
+-- | SFunArray with existential key type
+data EKeySFunArray v where
+  EKeySFunArray :: SingTy k -> SFunArray (Concrete k) v -> EKeySFunArray v
+
+instance SymVal v => Show (EKeySFunArray v) where
+  showsPrec p (EKeySFunArray ty sfunarr) = showParen (p > 10) $
+      showString "EKeySFunArray "
+    . showsPrec 11 ty
+    . showChar ' '
+    . withHasKind ty (showsPrec 11 sfunarr)
+
+eKArrayAt
+  :: forall k v
+   . SymVal v
+  => SingTy k
+  -> S (Concrete k)
+  -> Lens' (EKeySFunArray v) (SBV v)
+eKArrayAt ty (S _ symKey) = lens getter setter
+  where
+    getter :: EKeySFunArray v -> SBV v
+    getter (EKeySFunArray ty' arr) = case singEq ty ty' of
+      Just Refl -> SBV.readArray arr symKey
+      Nothing   -> error $
+        "eKArrayAt: bad getter access: " ++ show ty ++ " vs " ++ show ty'
+
+    setter :: EKeySFunArray v -> SBV v -> EKeySFunArray v
+    setter (EKeySFunArray ty' arr) val = case singEq ty ty' of
+      Just Refl -> EKeySFunArray ty $ SBV.writeArray arr symKey val
+      Nothing   -> error $
+        "eKArrayAt: bad setter access: " ++ show ty ++ " vs " ++ show ty'
+
+instance SymVal v => Mergeable (EKeySFunArray v) where
+  symbolicMerge f t (EKeySFunArray ty1 arr1) (EKeySFunArray ty2 arr2) =
+    case singEq ty1 ty2 of
+      Nothing   -> error "mismatched types when merging two EKeySFunArrays"
+      Just Refl -> EKeySFunArray ty1 $ symbolicMerge f t arr1 arr2
 
 makeLenses ''Located
 makePrisms ''AVal

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -40,7 +40,7 @@ module Pact.Types.Term
    defTypeRep,
    NativeDefName(..),DefName(..),
    FunApp(..),faDefType,faDocs,faInfo,faModule,faName,faTypes,
-   Ref(..),
+   Ref(..),_Direct,_Ref,
    NativeDFun(..),
    BindType(..),
    TableName(..),
@@ -1124,6 +1124,7 @@ abbrev TTable {..} = "<deftable " ++ asString' _tTableName ++ ">"
 makeLenses ''Term
 makeLenses ''Namespace
 makeLenses ''FunApp
+makePrisms ''Ref
 makeLenses ''Meta
 makeLenses ''Module
 makeLenses ''Interface

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 -- |
 -- Module      :  Pact.Types.Typecheck
@@ -29,7 +30,7 @@ module Pact.Types.Typecheck
     TcState (..),tcDebug,tcSupply,tcOverloads,tcOverloadOrder,tcFailures,tcAstToVar,tcVarToTypes,
     TC (..), runTC,
     PrimValue (..),
-    TopLevel (..),tlFun,tlInfo,tlName,tlType,tlConstVal,tlUserType,tlMeta,tlDoc,
+    TopLevel (..),tlFun,tlInfo,tlName,tlType,tlConstVal,tlUserType,tlMeta,tlDoc,toplevelInfo,
     Special (..),
     Fun (..),fInfo,fModule,fName,fTypes,fSpecial,fType,fArgs,fBody,
     Node (..),aId,aTy,
@@ -200,6 +201,12 @@ instance Pretty t => Pretty (TopLevel t) where
   pretty (TopTable _i n t _m) =
     "Table" <+> pretty n <> colon <> pretty t
   pretty (TopUserType _i t _m) = "UserType" <+> pretty t
+
+toplevelInfo :: TopLevel t -> Info
+toplevelInfo (TopFun fun _) = _fInfo fun
+toplevelInfo TopConst{_tlInfo} = _tlInfo
+toplevelInfo TopTable{_tlInfo} = _tlInfo
+toplevelInfo TopUserType{_tlInfo} = _tlInfo
 
 -- | Special-form handling (with-read, map etc)
 data Special t =

--- a/tests/Analyze/Eval.hs
+++ b/tests/Analyze/Eval.hs
@@ -98,8 +98,9 @@ analyzeEval' :: ETerm -> SingTy a -> GenState -> IO (Either String ETerm)
 analyzeEval' etm ty (GenState _ registryKSs txKSs txDecs txInts) = do
   -- analyze setup
   let tables = []
+      caps   = []
       args   = Map.empty
-      state0 = mkInitialAnalyzeState tables
+      state0 = mkInitialAnalyzeState tables caps
 
       tags = ModelTags Map.empty Map.empty Map.empty Map.empty Map.empty
         -- this 'Located TVal' is never forced so we don't provide it
@@ -110,7 +111,7 @@ analyzeEval' etm ty (GenState _ registryKSs txKSs txDecs txInts) = do
       pactMd  = mkPactMetadata
       reg     = mkRegistry
 
-  Just aEnv <- pure $ mkAnalyzeEnv modName pactMd reg tables args tags dummyInfo
+  Just aEnv <- pure $ mkAnalyzeEnv modName pactMd reg tables caps args tags dummyInfo
 
   let writeArray' k v env = writeArray env k v
 

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -813,6 +813,30 @@ spec = describe "analyze" $ do
           |]
     expectVerified code
 
+  describe "trivial capability which always fails" $ do
+    let code =
+          [text|
+            (defcap CAP (i:integer)
+              (enforce false "tx always fails"))
+
+            (defun test:bool ()
+              (with-capability (CAP 1)
+                true))
+          |]
+    expectPass code $ Valid Abort'
+
+  describe "trivial capability which always succeeds" $ do
+    let code =
+          [text|
+            (defcap CAP (i:integer)
+              true)
+
+            (defun test:bool ()
+              (with-capability (CAP 1)
+                true))
+          |]
+    expectPass code $ Valid Success'
+
   describe "enforce-one.1" $ do
     let code =
           [text|


### PR DESCRIPTION
- this includes the majority of the work necessary for capability support in analysis
- as far as concrete syntax goes, currently only `with-capability` is supported, but `require-capability` and `compose-capability` should follow pretty quickly
- this uses a _stack_ for tracking capabilities (unlike the current concrete implementation), which allows calling `with-capability` inside of a `defcap` with correct semantics

/cc @slpopejoy