### PR TITLE
Add State Param to 'eval(Exec|Continuation)'

### DIFF
--- a/src-ghc/Pact/Interpreter.hs
+++ b/src-ghc/Pact/Interpreter.hs
@@ -12,7 +12,23 @@
 -- enforce transaction rollback (and then re-thrown). It is
 -- the responsibility of the calling context to catch exceptions.
 --
-module Pact.Interpreter where
+module Pact.Interpreter
+  ( PactDbEnv(..)
+  , MsgData(..)
+  , EvalResult(..)
+  , initMsgData
+  , evalExec
+  , evalExecState
+  , evalContinuation
+  , evalContinuationState
+  , setupEvalEnv
+  , initRefStore
+  , mkSQLiteEnv
+  , mkPureEnv
+  , mkPactDbEnv
+  , initSchema
+  , interpret
+  ) where
 
 import Control.Concurrent
 import qualified Data.Set as S

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -72,7 +72,7 @@ import Pact.Gas
 
 
 evalBeginTx :: Info -> Eval e ()
-evalBeginTx i = revokeAllCapabilities >> view eeTxId >>= beginTx i
+evalBeginTx i = view eeTxId >>= beginTx i
 {-# INLINE evalBeginTx #-}
 
 evalRollbackTx :: Info -> Eval e ()

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -87,7 +87,7 @@ import Pact.Types.Scheme (PPKScheme(..), defPPKScheme)
 -- In 'Command ByteString', the 'ByteString' payload is hashed and signed; the ByteString
 -- being the JSON serialization of 'Payload Text', where the 'Text' is the pact code; when
 -- executed this is parsed to 'ParsedCode'.
--- Thus, 'Command (Payload ParsedCode)' is the fully executable specialization.
+-- Thus, 'Command (Payload PublicMeta ParsedCode)' is the fully executable specialization.
 data Command a = Command
   { _cmdPayload :: !a
   , _cmdSigs :: ![UserSig]

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -87,7 +87,8 @@ import Pact.Types.Scheme (PPKScheme(..), defPPKScheme)
 -- In 'Command ByteString', the 'ByteString' payload is hashed and signed; the ByteString
 -- being the JSON serialization of 'Payload Text', where the 'Text' is the pact code; when
 -- executed this is parsed to 'ParsedCode'.
--- Thus, 'Command (Payload PublicMeta ParsedCode)' is the fully executable specialization.
+-- Thus, 'Command (Payload m ParsedCode)' (with m representing platform-specific metadata)
+-- is the fully executable specialization.
 data Command a = Command
   { _cmdPayload :: !a
   , _cmdSigs :: ![UserSig]


### PR DESCRIPTION
Additionally, remove unnecessary `begin-tx` capabilities revocation. This is needed for the coin-contract work on Chainweb (See PR 169)