### PR TITLE
Pact.Types.Crypto: use either ed25519-donna or cryptonite

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -16,6 +16,11 @@ category:            Language
 build-type:          Simple
 cabal-version:       >=1.22
 
+flag cryptonite-ed25519
+  description: use cryptonite instead of ed25519-donna
+  default:     False
+  manual:      True
+
 library
   exposed-modules:     Pact.Analyze.Remote.Types
                      , Pact.Compile
@@ -197,6 +202,14 @@ library
 
   if !impl(ghcjs) && !os(windows)
     build-depends: unix
+
+  if !impl(ghcjs) && !os(windows) && !flag(cryptonite-ed25519)
+    build-depends:
+        crypto-api
+      , ed25519-donna
+
+  if !impl(ghcjs) && (os(windows) || flag(cryptonite-ed25519))
+    cpp-options: -DCRYPTONITE_ED25519
 
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/pact.cabal
+++ b/pact.cabal
@@ -182,10 +182,8 @@ library
     build-depends:
         async
       , criterion >= 1.1.4 && < 1.5
-      , crypto-api
       , cryptonite
       , direct-sqlite
-      , ed25519-donna
       , fast-logger
       , haskeline >= 0.7.3 && < 0.8
       , memory
@@ -274,8 +272,6 @@ test-suite hspec
         neat-interpolation
       , sbv
       , async
-      , ed25519-donna
-      , crypto-api
       , cryptonite
       , http-client
       , servant-client

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,7 @@ extra-deps:
   - crackNum-2.3
   - FloatingHex-0.4
   - compactable-0.1.2.2
+  - ed25519-donna-0.1.1
   - hw-hspec-hedgehog-0.1.0.5
   - git: https://github.com/kadena-io/thyme.git
     commit: 6ee9fcb026ebdb49b810802a981d166680d867c9

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,6 @@ extra-deps:
   - crackNum-2.3
   - FloatingHex-0.4
   - compactable-0.1.2.2
-  - ed25519-donna-0.1.1
   - hw-hspec-hedgehog-0.1.0.5
   - git: https://github.com/kadena-io/thyme.git
     commit: 6ee9fcb026ebdb49b810802a981d166680d867c9


### PR DESCRIPTION
This addresses https://github.com/kadena-io/pact/issues/416. Working with `ByteString`s is usually fiddly enough that I usually break a few things, but the test suite passed as soon as I got everything typechecking, which makes me suspicious that this area of the code might not be well exercised by the tests. I'd especially appreciate review on this change.