### PR TITLE
Pact checking

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1385,6 +1385,14 @@ Query gas state, or set it to GAS.
 Set environment gas limit to LIMIT.
 
 
+### env-gasmodel {#env-gasmodel}
+
+*model*&nbsp;`string` *&rarr;*&nbsp;`string`
+
+
+Update gas model to the model named MODEL.
+
+
 ### env-gasprice {#env-gasprice}
 
 *price*&nbsp;`decimal` *&rarr;*&nbsp;`string`

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -29,6 +29,18 @@ pact> (bind { "a": 1, "b": 2 } { "a" := a-value } a-value)
 ```
 
 
+### chain-data {#chain-data}
+
+ *&rarr;*&nbsp;`object:[]<{o}>`
+
+
+Get transaction public metadata. Returns an object with 'chain-id', 'block-height', 'block-time', 'sender', 'gas-limit', 'gas-price', and 'gas-fee' fields.
+```lisp
+pact> (chain-data)
+{"chain-id": 0,"block-height": 0,"block-time": 0,"sender": "","gas-limit": 0,"gas-price": 0}
+```
+
+
 ### compose {#compose}
 
 *x*&nbsp;`x:<a> -> <b>` *y*&nbsp;`x:<b> -> <c>` *value*&nbsp;`<a>` *&rarr;*&nbsp;`<c>`
@@ -1367,6 +1379,18 @@ Continue previously-initiated pact identified by PACT-ID at STEP, optionally spe
 (continue-pact 2 1)
 (continue-pact 2 1 true)
 (continue-pact 2 1 false { "rate": 0.9 })
+```
+
+
+### env-chain-data {#env-chain-data}
+
+*new-data*&nbsp;`object:[]*` *&rarr;*&nbsp;`string`
+
+
+Update existing entries 'chain-data' with NEW-DATA, replacing those items only.
+```lisp
+pact> (env-chain-data { "chain-id": 2, "block-height": 20 })
+"Updated public metadata"
 ```
 
 

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -359,8 +359,8 @@ verifyFunctionProperty
   -> CheckableType
   -> Located Check
   -> IO (Either CheckFailure CheckSuccess)
-verifyFunctionProperty modName funName funInfo tables caps pactArgs body checkType (Located propInfo check) =
-  runExceptT $ do
+verifyFunctionProperty modName funName funInfo tables caps pactArgs body
+  checkType (Located propInfo check) = runExceptT $ do
     (args, nondets, tm, graph) <- hoist generalize $
       withExcept translateToCheckFailure $
         runTranslation modName funName funInfo caps pactArgs body checkType

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -18,6 +18,7 @@ module Pact.Analyze.Check
   , describeCheckFailure
   , describeParseFailure
   , describeVerificationWarnings
+  , describeVerificationFailure
   , falsifyingModel
   , showModel
   , CheckFailure(..)
@@ -65,6 +66,7 @@ import           Pact.Types.Lang           (pattern ColonExp, pattern CommaExp,
                                             Def (..), DefType (..), Info, dMeta,
                                             mModel, renderInfo, renderParsed,
                                             tDef, tInfo, tMeta, _tDef)
+import           Pact.Types.Pretty         (renderCompactText)
 import           Pact.Types.Runtime        (Exp, ModuleData (..), ModuleName,
                                             Ref (Ref),
                                             Term (TConst, TDef, TSchema, TTable),
@@ -153,6 +155,14 @@ data VerificationFailure
   | InvalidRefType
   | FailedConstTranslation String
   deriving Show
+
+describeVerificationFailure :: VerificationFailure -> Text
+describeVerificationFailure = \case
+  ModuleParseFailure pf         -> describeParseFailure pf
+  ModuleCheckFailure cf         -> describeCheckFailure cf
+  TypeTranslationFailure msg ty -> msg <> ": " <> renderCompactText ty
+  InvalidRefType                -> "invalid ref type"
+  FailedConstTranslation msg    -> "failed constant translation: " <> T.pack msg
 
 describeCheckSuccess :: CheckSuccess -> Text
 describeCheckSuccess = \case

--- a/src/Pact/Analyze/Eval.hs
+++ b/src/Pact/Analyze/Eval.hs
@@ -89,12 +89,13 @@ runAnalysis'
   -> [Table]
   -> [Capability]
   -> Map VarId AVal
+  -> Map VarId (SBV Bool)
   -> ETerm
   -> Path
   -> ModelTags 'Symbolic
   -> Info
   -> ExceptT AnalyzeFailure Symbolic (f AnalysisResult)
-runAnalysis' modName query tables caps args tm rootPath tags info = do
+runAnalysis' modName query tables caps args nondets tm rootPath tags info = do
   let --
       --
       -- TODO: pass this in (from a previous analysis) when we analyze >1
@@ -107,7 +108,7 @@ runAnalysis' modName query tables caps args tm rootPath tags info = do
       --
       pactMetadata = mkPactMetadata
 
-  aEnv <- case mkAnalyzeEnv modName pactMetadata reg tables caps args tags info of
+  aEnv <- case mkAnalyzeEnv modName pactMetadata reg tables caps args nondets tags info of
     Just env -> pure env
     Nothing  -> throwError $ AnalyzeFailure info $ fromString
       "Unable to make analyze env (couldn't translate schema)"
@@ -141,14 +142,15 @@ runPropertyAnalysis
   -> [Table]
   -> [Capability]
   -> Map VarId AVal
+  -> Map VarId (SBV Bool)
   -> ETerm
   -> Path
   -> ModelTags 'Symbolic
   -> Info
   -> ExceptT AnalyzeFailure Symbolic AnalysisResult
-runPropertyAnalysis modName check tables caps args tm rootPath tags info =
+runPropertyAnalysis modName check tables caps args nondets tm rootPath tags info =
   runIdentity <$>
-    runAnalysis' modName (Identity <$> analyzeCheck check) tables caps args tm
+    runAnalysis' modName (Identity <$> analyzeCheck check) tables caps args nondets tm
       rootPath tags info
 
 runInvariantAnalysis
@@ -156,11 +158,12 @@ runInvariantAnalysis
   -> [Table]
   -> [Capability]
   -> Map VarId AVal
+  -> Map VarId (SBV Bool)
   -> ETerm
   -> Path
   -> ModelTags 'Symbolic
   -> Info
   -> ExceptT AnalyzeFailure Symbolic (TableMap [Located AnalysisResult])
-runInvariantAnalysis modName tables caps args tm rootPath tags info =
+runInvariantAnalysis modName tables caps args nondets tm rootPath tags info =
   unInvariantsF <$>
-    runAnalysis' modName analyzeInvariants tables caps args tm rootPath tags info
+    runAnalysis' modName analyzeInvariants tables caps args nondets tm rootPath tags info

--- a/src/Pact/Analyze/Eval.hs
+++ b/src/Pact/Analyze/Eval.hs
@@ -95,7 +95,7 @@ runAnalysis'
   -> ModelTags 'Symbolic
   -> Info
   -> ExceptT AnalyzeFailure Symbolic (f AnalysisResult)
-runAnalysis' modName query tables caps args nondets tm rootPath tags info = do
+runAnalysis' modName query tables caps args stepChoices tm rootPath tags info = do
   let --
       --
       -- TODO: pass this in (from a previous analysis) when we analyze >1
@@ -108,7 +108,7 @@ runAnalysis' modName query tables caps args nondets tm rootPath tags info = do
       --
       pactMetadata = mkPactMetadata
 
-  aEnv <- case mkAnalyzeEnv modName pactMetadata reg tables caps args nondets tags info of
+  aEnv <- case mkAnalyzeEnv modName pactMetadata reg tables caps args stepChoices tags info of
     Just env -> pure env
     Nothing  -> throwError $ AnalyzeFailure info $ fromString
       "Unable to make analyze env (couldn't translate schema)"
@@ -148,9 +148,9 @@ runPropertyAnalysis
   -> ModelTags 'Symbolic
   -> Info
   -> ExceptT AnalyzeFailure Symbolic AnalysisResult
-runPropertyAnalysis modName check tables caps args nondets tm rootPath tags info =
+runPropertyAnalysis modName check tables caps args stepChoices tm rootPath tags info =
   runIdentity <$>
-    runAnalysis' modName (Identity <$> analyzeCheck check) tables caps args nondets tm
+    runAnalysis' modName (Identity <$> analyzeCheck check) tables caps args stepChoices tm
       rootPath tags info
 
 runInvariantAnalysis
@@ -164,6 +164,6 @@ runInvariantAnalysis
   -> ModelTags 'Symbolic
   -> Info
   -> ExceptT AnalyzeFailure Symbolic (TableMap [Located AnalysisResult])
-runInvariantAnalysis modName tables caps args nondets tm rootPath tags info =
+runInvariantAnalysis modName tables caps args stepChoices tm rootPath tags info =
   unInvariantsF <$>
-    runAnalysis' modName analyzeInvariants tables caps args nondets tm rootPath tags info
+    runAnalysis' modName analyzeInvariants tables caps args stepChoices tm rootPath tags info

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -635,7 +635,7 @@ evalTerm = \case
             tagFork successPath cancelPath (sansProv successChoice)
               (sansProv $ sNot cancel)
 
-            pure cancel
+            pure $ successChoice .&& cancel
 
         let -- Trigger the latest rollback if we cancel on this step
             rollbacks' = rollbacks & _head . _2 %~ (.|| cancel)

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -627,7 +627,7 @@ evalTerm = \case
           -- If this is the first step we just evaluate this term
           Nothing -> do
             void $ evalTermWithEntity mEntity tm
-            pure $ sNot successChoice
+            pure sFalse
 
           -- ... otherwise, we nondeterministically either succeed or cancel
           Just (cancelPath {- c_n -}, cancelVid) -> withReset $ do

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -726,14 +726,17 @@ evalTermWithEntity mEntity tm = do
       markFailure $ actualEntity ./= expectedEntity'
   evalTerm tm
 
--- | Reset to perform between different transactions
+-- | Reset to perform between different transactions.
+--
+-- This encompasses anything in 'AnalyzeState' or 'AnalyzeEnv' that could have
+-- changed between transactions.
 withReset :: Int -> Analyze a -> Analyze a
 withReset number action = do
-  tables    <- view $ analyzeEnv . aeTables
-  oldState  <- use id
-  oldEnv    <- ask
-  -- TODO: remove duplication with mkAnalyzeEnv
-  let txMetadata   = TxMetadata (mkFreeArray $ "txKeySets"  <> tShow number)
+  oldState <- use id
+  oldEnv   <- ask
+
+  let tables = oldEnv ^. aeTables
+      txMetadata   = TxMetadata (mkFreeArray $ "txKeySets"  <> tShow number)
                                 (mkFreeArray $ "txDecimals" <> tShow number)
                                 (mkFreeArray $ "txIntegers" <> tShow number)
 

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -637,9 +637,9 @@ evalTerm = \case
             tagFork successPath cancelPath (sansProv successChoice)
               (sansProv $ sNot cancel)
 
-            ite (successChoice .&& cancel)
-              (pure ())
+            ite (successChoice .&& sNot cancel)
               (void $ evalTermWithEntity mEntity tm)
+              (pure ())
             pure cancel
 
         let rollbacks' = case mRollback of

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -644,8 +644,8 @@ evalTerm = \case
                 -> rollbacks'
               Just (rollbackPath {- r_n -}, rollback)
                 -> (rollbackPath, sFalse, rollback):rollbacks'
-                --                ^ was rollback triggered on this step?
-                --                  (not yet)
+                --                ^ should we run this rollback, and every
+                --                  rollback before it?
 
             reachesStep = successChoice .&& sNot cancel
 

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -621,8 +621,6 @@ evalTerm = \case
         (Step (tm :< ty) successPath {- s_n -} mEntity mCancelVid mRollback) -> 
         withSing ty $ do
 
-        tagSubpathStart successPath $ sansProv successChoice
-
         -- The first step has no cancel var. All other steps do.
         cancel <- case mCancelVid of
 
@@ -636,6 +634,7 @@ evalTerm = \case
             cancel <- view (aeNondets . at cancelVid)
               ??? "couldn't find cancel var"
             
+            tagSubpathStart successPath $ sansProv successChoice
             tagSubpathStart cancelPath $ sansProv $ successChoice .&& cancel
 
             ite cancel

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -637,7 +637,7 @@ evalTerm = \case
             tagFork successPath cancelPath (sansProv successChoice)
               (sansProv $ sNot cancel)
 
-            ite cancel
+            ite (successChoice .&& cancel)
               (pure ())
               (void $ evalTermWithEntity mEntity tm)
             pure cancel

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -491,8 +491,7 @@ evalTerm = \case
   Let _name vid retTid eterm body -> do
     av <- evalETerm eterm
     tagVarBinding vid av
-    -- TODO: withVar
-    local (scope.at vid ?~ av) $ do
+    withVar vid av $ do
       res <- evalTerm body
       tagReturn retTid $ mkAVal res
       pure res

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -627,7 +627,7 @@ evalTerm = \case
           -- If this is the first step we just evaluate this term
           Nothing -> do
             void $ evalTermWithEntity mEntity tm
-            pure successChoice
+            pure $ sNot successChoice
 
           -- ... otherwise, we nondeterministically either succeed or cancel
           Just (cancelPath {- c_n -}, cancelVid) -> withReset $ do

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -628,13 +628,13 @@ evalTerm = \case
           -- all the existing rollbacks. Note that we use 'rollbacks', ie all
           -- rollbacks prior to this step, not 'rollbacks'', because we don't
           -- want to execute the rollback associated with this step.
-          Just (_rollback, failureVid) -> do
-            failure <- view (aeNondets . at failureVid)
-              ??? "couldn't find failure var"
+          Just (_rollback, cancelVid) -> do
+            cancel <- view (aeNondets . at cancelVid)
+              ??? "couldn't find cancel var"
 
-            ite failure
-              (void $ evalTermWithEntity mEntity tm)
+            ite cancel
               (for_ rollbacks (withReset . evalETerm))
+              (void $ evalTermWithEntity mEntity tm)
 
         let rollbacks' = case mRollback of
               Nothing               -> rollbacks

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -657,7 +657,7 @@ evalTerm = \case
 
           -- ... otherwise, we nondeterministically either succeed or cancel
           Just (cancelPath {- c_n -}, cancelVid) -> withReset stepNo $ do
-            cancel <- view (aeNondets . at cancelVid)
+            cancel <- view (aeStepChoices . at cancelVid)
               ??? "couldn't find cancel var"
 
             tagFork successPath cancelPath (sansProv successChoice)
@@ -699,7 +699,7 @@ evalTerm = \case
       sFalse
       rollbacks
 
-    pure "pact done"
+    pure "INTERNAL: pact done"
 
   -- Caution: yield / resume are not yet working pending #442
   Yield ty tm -> do

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -665,15 +665,15 @@ evalTerm = \case
       ([], sTrue)
       steps
 
-    void $ ifoldlM
-      (\rbNo alreadyRollingBack
+    void $ foldlM
+      (\alreadyRollingBack
         (path {- r_n -}, rollbackTriggered, rollback) -> do
         -- If this rollback was triggered, we execute this and all earlier
         -- rollbacks
         let nowRollingBack = alreadyRollingBack .|| rollbackTriggered
         tagSubpathStart path $ sansProv nowRollingBack
         ite nowRollingBack
-          (void $ withReset (length steps + rbNo) $ evalETerm rollback)
+          (void $ evalETerm rollback)
           (pure ())
         pure nowRollingBack)
       sFalse

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -625,9 +625,7 @@ evalTerm = \case
         cancel <- case mCancelVid of
 
           -- If this is the first step we just evaluate this term
-          Nothing -> do
-            void $ evalTermWithEntity mEntity tm
-            pure sFalse
+          Nothing -> pure sFalse
 
           -- ... otherwise, we nondeterministically either succeed or cancel
           Just (cancelPath {- c_n -}, cancelVid) -> withReset $ do

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -637,9 +637,6 @@ evalTerm = \case
             tagFork successPath cancelPath (sansProv successChoice)
               (sansProv $ sNot cancel)
 
-            ite (successChoice .&& sNot cancel)
-              (void $ evalTermWithEntity mEntity tm)
-              (pure ())
             pure cancel
 
         let rollbacks' = case mRollback of
@@ -649,7 +646,13 @@ evalTerm = \case
                 -> (rollbackPath, successChoice .&& cancel, rollback):rollbacks
                 --                ^ was rollback triggered on this step?
 
-        pure (rollbacks', successChoice .&& sNot cancel))
+            reachesStep = successChoice .&& sNot cancel
+
+        ite reachesStep
+          (void $ evalTermWithEntity mEntity tm)
+          (pure ())
+
+        pure (rollbacks', reachesStep))
       ([], sTrue)
       steps
 

--- a/src/Pact/Analyze/Model/Tags.hs
+++ b/src/Pact/Analyze/Model/Tags.hs
@@ -18,6 +18,7 @@
 module Pact.Analyze.Model.Tags
   ( allocArgs
   , allocModelTags
+  , allocNondets
   , saturateModel
   ) where
 
@@ -70,6 +71,10 @@ allocArgs args = fmap Map.fromList $ for args $ \(Arg nm vid node ety) -> do
   let info = node ^. TC.aId . TC.tiInfo
   av <- allocAVal (unmungedStr nm) ety <&> _AVal._1 ?~ FromInput nm
   pure (vid, Located info (nm, (ety, av)))
+
+allocNondets :: [VarId] -> Alloc (Map VarId (SBV Bool))
+allocNondets vids = fmap Map.fromList $ for vids $ \vid ->
+  (vid,) <$> allocSbv @'TyBool
 
 allocModelTags
   :: Map VarId (Located (Unmunged, TVal))

--- a/src/Pact/Analyze/Model/Tags.hs
+++ b/src/Pact/Analyze/Model/Tags.hs
@@ -74,7 +74,7 @@ allocArgs args = fmap Map.fromList $ for args $ \(Arg nm vid node ety) -> do
 
 allocNondets :: [VarId] -> Alloc (Map VarId (SBV Bool))
 allocNondets vids = fmap Map.fromList $ for vids $ \vid ->
-  (vid,) <$> allocSbv @'TyBool
+  (vid,) <$> allocSbv @'TyBool "nondet"
 
 allocModelTags
   :: Map VarId (Located (Unmunged, TVal))

--- a/src/Pact/Analyze/Model/Tags.hs
+++ b/src/Pact/Analyze/Model/Tags.hs
@@ -18,7 +18,7 @@
 module Pact.Analyze.Model.Tags
   ( allocArgs
   , allocModelTags
-  , allocNondets
+  , allocStepChoices
   , saturateModel
   ) where
 
@@ -72,8 +72,8 @@ allocArgs args = fmap Map.fromList $ for args $ \(Arg nm vid node ety) -> do
   av <- allocAVal (unmungedStr nm) ety <&> _AVal._1 ?~ FromInput nm
   pure (vid, Located info (nm, (ety, av)))
 
-allocNondets :: [VarId] -> Alloc (Map VarId (SBV Bool))
-allocNondets vids = fmap Map.fromList $ for vids $ \vid ->
+allocStepChoices :: [VarId] -> Alloc (Map VarId (SBV Bool))
+allocStepChoices vids = fmap Map.fromList $ for vids $ \vid ->
   (vid,) <$> allocSbv @'TyBool "nondet"
 
 allocModelTags

--- a/src/Pact/Analyze/Model/Text.hs
+++ b/src/Pact/Analyze/Model/Text.hs
@@ -198,6 +198,8 @@ showEvent ksProvs tags event = do
             "destructuring object" : displayVids showVar
           FunctionScope modName funName ->
             displayCallScope "function" modName funName
+          PactScope modName funName ->
+            displayCallScope "pact" modName funName
           CapabilityScope modName (CapName capName) ->
             displayCallScope "capability" modName $ T.pack capName
 
@@ -208,9 +210,10 @@ showEvent ksProvs tags event = do
               , emptyLine
               ]
         pure $ case scopeTy of
-          LetScope -> []
-          ObjectScope -> []
-          FunctionScope _ _ -> returnOutput
+          LetScope            -> []
+          ObjectScope         -> []
+          FunctionScope _ _   -> returnOutput
+          PactScope _ _       -> returnOutput
           CapabilityScope _ _ -> returnOutput
 
   where

--- a/src/Pact/Analyze/Model/Text.hs
+++ b/src/Pact/Analyze/Model/Text.hs
@@ -213,7 +213,7 @@ showEvent ksProvs tags event = do
           LetScope            -> []
           ObjectScope         -> []
           FunctionScope _ _   -> returnOutput
-          PactScope _ _       -> returnOutput
+          PactScope _ _       -> []
           CapabilityScope _ _ -> returnOutput
 
   where

--- a/src/Pact/Analyze/Parse/Prop.hs
+++ b/src/Pact/Analyze/Parse/Prop.hs
@@ -641,8 +641,8 @@ checkPreProp ty preProp
 
 typeError :: (HasCallStack, Pretty a, Pretty b) => PreProp -> a -> b -> PropCheck c
 typeError preProp a b = throwErrorIn preProp $
-  "type error: " <> pretty a <> " vs " <> pretty b <> "(" <>
-  pretty (prettyCallStack callStack) <> ")"
+  "type error: " <> pretty a <> " vs " <> pretty b <> " (" <>
+  prettyString (prettyCallStack callStack) <> ")"
 
 expectColumnType
   :: Prop TyTableName -> Prop TyColumnName -> SingTy a -> PropCheck ()

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -249,5 +249,5 @@ pattern AST_Obj objNode kvs <- Object objNode kvs
 pattern AST_List :: forall a. a -> [AST a] -> AST a
 pattern AST_List node elems <- List node elems
 
-pattern AST_Step :: AST a
-pattern AST_Step <- Step {}
+pattern AST_Step :: a -> Maybe (AST a) -> AST a -> Maybe (AST a) -> AST a
+pattern AST_Step node entity exec rollback <- Step node entity exec rollback

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -239,7 +239,9 @@ data TranslateState
       -- These three "success" edges all join together at the same vertex.
     , _tsFoundVars     :: [(VarId, Text, EType)]
 
-    , _tsNondets        :: ![VarId]
+      -- Vars representing nondeterministic choice between two branches. These
+      -- are used for continuing on or rolling back in evaluation of pacts.
+    , _tsNondets       :: ![VarId]
     }
 
 makeLenses ''TranslateFailure

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -540,9 +540,9 @@ translatePact nodes = do
   (sinkV, reverse -> cancels, reverse -> rollbacks) <- foldlM
     (\(rightV, cancels, rollbacks) (_step, leftV, mRollback) -> do
       tsPathHead .= leftV
-      cancelPath <- Path <$> genTagId
-      extendPathTo rightV
+      cancelPath <- startNewSubpath
       cancelVid <- genVarId
+      extendPathTo rightV
       let cancel = (cancelPath, cancelVid)
       case mRollback of
         Nothing

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -587,10 +587,7 @@ translateStep
 translateStep firstStep = \case
   AST_Step _node entity exec rollback -> do
     let genPath = Path <$> genTagId
-    p <- if firstStep then use tsCurrentPath else do
-      p <- genPath
-      startSubpath p
-      pure p
+    p <- if firstStep then use tsCurrentPath else startNewSubpath
     mEntity <- for entity $ \tm -> do
       Some SStr entity' <- translateNode tm
       pure entity'

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -1345,7 +1345,8 @@ runTranslation modName funName info caps pactArgs body checkType = do
               CheckDefpact ->
                 withNewScope (PactScope modName funName) bindingTs retTid $
                   Some SStr . Pact <$> translatePact body
-              _ -> throwError $ error "TODO"
+              CheckDefconst
+                -> error "invariant violation: this cannot be a constant"
             _ <- extendPath -- form final edge for any remaining events
             pure res
 

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -19,9 +19,6 @@
 -- execution graph to be used during symbolic analysis and model reporting.
 module Pact.Analyze.Translate where
 
-import Debug.Trace
--- import Pact.Types.Pretty (renderCompactString)
-
 import qualified Algebra.Graph              as Alga
 import           Control.Applicative        (Alternative (empty))
 import           Control.Lens               (Lens', at, cons, makeLenses, snoc,
@@ -518,22 +515,22 @@ translateBinding (Named unmunged' node _) = do
 makeSteps :: ETerm -> Maybe ETerm
 makeSteps (Some SStr steps@(Sequence (Some SStr Step{}) _))
   = Some SStr <$> makeSteps' steps
-makeSteps x@(Some _          (Sequence (Some SStr Step{}) _))
-  = trace ("x: " ++ show x) $ Nothing
+makeSteps (Some _          (Sequence (Some SStr Step{}) _))
+  = Nothing
 makeSteps tm
   = Just tm
 
 makeSteps' :: Term 'TyStr -> Maybe (Term 'TyStr)
 makeSteps' (Sequence (Some SStr (Step a b c Nothing)) steps)
   = Step a b c . Just <$> makeSteps' steps
-makeSteps' y@(Sequence (Some SStr Step{}) _)
-  = trace ("y: " ++ show y) $ Nothing
+makeSteps' (Sequence (Some SStr Step{}) _)
+  = Nothing
 makeSteps' step@Step{}
   = Just step
 makeSteps' (IntraStepReset vid step)
   = IntraStepReset vid <$> makeSteps' step
-makeSteps' z
-  = trace ("z: " ++ show z) $ Nothing
+makeSteps' _
+  = Nothing
 
 translateBody :: [AST Node] -> TranslateM ETerm
 translateBody = \case

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -467,8 +467,8 @@ extendPathTo toV = do
 extendPath :: TranslateM Vertex
 extendPath = do
   v' <- genVertex
-  tsPathHead .= v'
   extendPathTo v'
+  tsPathHead .= v'
   pure v'
 
 -- | Extends multiple separate paths to a single join point. Assumes that each

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -461,6 +461,7 @@ extendPathTo toV = do
   let e = (v, toV)
   tsEdgeEvents.at e ?= edgeTrace
   addPathEdge path e
+  tsPathHead .= v'
 
 -- | Extends the previous path head to a new 'Vertex', flushing accumulated
 -- events to 'tsEdgeEvents'.
@@ -468,7 +469,6 @@ extendPath :: TranslateM Vertex
 extendPath = do
   v' <- genVertex
   extendPathTo v'
-  tsPathHead .= v'
   pure v'
 
 -- | Extends multiple separate paths to a single join point. Assumes that each

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -15,6 +15,8 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE ViewPatterns               #-}
 
+{-# LANGUAGE TupleSections              #-}
+
 -- | Translation from typechecked 'AST' to 'Term', while accumulating an
 -- execution graph to be used during symbolic analysis and model reporting.
 module Pact.Analyze.Translate where
@@ -523,21 +525,23 @@ translateBody = \case
     pure $ Some ty $ Sequence someExpr exprs
 
 translatePact :: [AST Node] -> TranslateM [PactStep]
-translatePact = do
-  -- steps <- go True
-  preStepsPath <- use tsCurrentPath
+translatePact = undefined
 
-  _todo
+-- nodes = do
+--   -- steps <- go True
+--   preStepsPath <- use tsCurrentPath
 
-  -- TODO: loop edge from after final step to the sink should have the same path
-  --       as the final step
+--   _todo
 
-  where
-    -- We don't generate a cancel var on the first step but we do for all
-    -- subsequent steps.
-    go firstStep = \case
-      []       -> pure []
-      ast:asts -> (:) <$> translateStep firstStep ast <*> go False asts
+--   -- TODO: loop edge from after final step to the sink should have the same path
+--   --       as the final step
+
+--   where
+--     -- We don't generate a cancel var on the first step but we do for all
+--     -- subsequent steps.
+--     go firstStep = \case
+--       []       -> pure []
+--       ast:asts -> (:) <$> translateStep firstStep ast <*> go False asts
 
 translateLet :: ScopeType -> [(Named Node, AST Node)] -> [AST Node] -> TranslateM ETerm
 translateLet scopeTy (unzip -> (bindingAs, rhsAs)) body = do
@@ -663,7 +667,9 @@ translateStep firstStep = \case
         tsNondets %= (cancelVid:)
         pure $ Just cancelVid
     mRollback <- traverse translateNode rollback
-    pure $ Step (exec' :< ty) mEntity mCancelVid mRollback
+    pure $ Step (exec' :< ty) (error "TODO") mEntity 
+      ((error "TODO",) <$> mCancelVid)
+      ((error "TODO",) <$> mRollback)
   astNode -> throwError' $ UnexpectedPactNode astNode
 
 translateNode :: AST Node -> TranslateM ETerm

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -461,7 +461,7 @@ extendPathTo toV = do
   let e = (v, toV)
   tsEdgeEvents.at e ?= edgeTrace
   addPathEdge path e
-  tsPathHead .= v'
+  tsPathHead .= toV
 
 -- | Extends the previous path head to a new 'Vertex', flushing accumulated
 -- events to 'tsEdgeEvents'.
@@ -535,7 +535,7 @@ translatePact nodes = do
   postSnVertex <- use tsPathHead
   snPath <- use tsCurrentPath
 
-  postLastCancelV <- extendPath
+  postLastCancelV <- genVertex
 
   (sinkV, reverse -> cancels, reverse -> rollbacks) <- foldlM
     (\(rightV, cancels, rollbacks) (_step, leftV, mRollback) -> do
@@ -586,7 +586,6 @@ translateStep
   :: Bool -> AST Node -> TranslateM (PactStep, Vertex, Maybe (AST Node))
 translateStep firstStep = \case
   AST_Step _node entity exec rollback -> do
-    let genPath = Path <$> genTagId
     p <- if firstStep then use tsCurrentPath else startNewSubpath
     mEntity <- for entity $ \tm -> do
       Some SStr entity' <- translateNode tm

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -530,7 +530,7 @@ translatePact :: [AST Node] -> TranslateM [PactStep]
 translatePact nodes = do
   preStepsPath <- use tsCurrentPath
 
-  preSteps <- go True nodes
+  protoSteps <- go True nodes
 
   postSnVertex <- use tsPathHead
   snPath <- use tsCurrentPath
@@ -555,10 +555,10 @@ translatePact nodes = do
           pure (postRollback, cancel:cancels, Just rollback : rollbacks)
       )
     (postLastCancelV, [], [])
-    (tail $ reverse preSteps)
+    (tail $ reverse protoSteps)
 
   let steps =
-        zip3 (preSteps ^.. traverse . _1)
+        zip3 (protoSteps ^.. traverse . _1)
              (Nothing : fmap Just cancels) (rollbacks <> [Nothing]) <&>
           \(Step exec p mEntity _ _, mCancel, mRollback)
             -> Step exec p mEntity mCancel mRollback

--- a/src/Pact/Analyze/Types.hs
+++ b/src/Pact/Analyze/Types.hs
@@ -86,7 +86,7 @@ data Table = Table
   { _tableName       :: Text
   , _tableType       :: TC.UserType
   , _tableInvariants :: [Located (Invariant 'TyBool)]
-  }
+  } deriving Show
 
 pattern TableNameLit :: String -> Prop TyTableName
 pattern TableNameLit str = StrLit str

--- a/src/Pact/Analyze/Types.hs
+++ b/src/Pact/Analyze/Types.hs
@@ -20,6 +20,7 @@ module Pact.Analyze.Types
   , HasVarId(varId)
   , Quantifier(..)
   , Table(..)
+  , CheckableType(..)
 
   , checkGoal
   , genId
@@ -93,5 +94,11 @@ pattern TableNameLit str = StrLit str
 
 pattern ColumnNameLit :: String -> Prop TyColumnName
 pattern ColumnNameLit str = StrLit str
+
+-- | The three things we can check properties of
+data CheckableType
+  = CheckDefun
+  | CheckDefpact
+  | CheckDefconst
 
 makeLenses ''Table

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -157,7 +157,7 @@ data AnalyzeEnv
     , _aeRegistry     :: !Registry
     , _aeTxMetadata   :: !TxMetadata
     , _aeScope        :: !(Map VarId AVal) -- used as a stack
-    , _aeNondets      :: !(Map VarId (SBV Bool))
+    , _aeStepChoices  :: !(Map VarId (SBV Bool))
     , _aeGuardPasses  :: !(SFunArray Guard Bool)
     , _invariants     :: !(TableMap [Located (Invariant 'TyBool)])
     , _aeColumnIds    :: !(TableMap (Map Text VarId))
@@ -182,7 +182,7 @@ mkAnalyzeEnv
   -> ModelTags 'Symbolic
   -> Info
   -> Maybe AnalyzeEnv
-mkAnalyzeEnv modName pactMetadata registry tables caps args nondets tags info = do
+mkAnalyzeEnv modName pactMetadata registry tables caps args stepChoices tags info = do
   let txMetadata   = TxMetadata (mkFreeArray "txKeySets")
                                 (mkFreeArray "txDecimals")
                                 (mkFreeArray "txIntegers")
@@ -213,9 +213,9 @@ mkAnalyzeEnv modName pactMetadata registry tables caps args nondets tags info = 
       emptyGrants  = mkTokenGrants caps
       activeGrants = emptyGrants
 
-  pure $ AnalyzeEnv modName pactMetadata registry txMetadata args nondets guardPasses
-    invariants' columnIds' tags info (sansProv trivialGuard) emptyGrants
-    activeGrants tables
+  pure $ AnalyzeEnv modName pactMetadata registry txMetadata args
+    stepChoices guardPasses invariants' columnIds' tags info
+    (sansProv trivialGuard) emptyGrants activeGrants tables
 
 mkFreeArray :: (SymVal a, HasKind b) => Text -> SFunArray a b
 mkFreeArray = mkSFunArray . uninterpret . T.unpack . sbvIdentifier

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -133,8 +133,6 @@ data AnalyzeEnv
     -- ^ the default, blank slate of grants, where no token is granted.
     , _aeActiveGrants :: !TokenGrants
     -- ^ the current set of tokens that are granted, manipulated as a stack
-    , _aeRollbacks    :: ![ETerm]
-    -- ^ the stack of rollbacks to perform on failure
     , _aeTables       :: ![Table]
     } deriving Show
 
@@ -181,7 +179,7 @@ mkAnalyzeEnv modName pactMetadata registry tables caps args tags info = do
 
   pure $ AnalyzeEnv modName pactMetadata registry txMetadata args guardPasses
     invariants' columnIds' tags info (sansProv trivialGuard) emptyGrants
-    activeGrants [] tables
+    activeGrants tables
 
 mkFreeArray :: (SymVal a, HasKind b) => Text -> SFunArray a b
 mkFreeArray = mkSFunArray . uninterpret . T.unpack . sbvIdentifier
@@ -258,6 +256,8 @@ data GlobalAnalyzeState
   = GlobalAnalyzeState
     { _gasGuardProvenances :: Map TagId Provenance -- added as we accum guard info
     , _gasNextUninterpId   :: Integer
+    , _gasRollbacks        :: ![ETerm]
+    -- ^ the stack of rollbacks to perform on failure
     }
   deriving (Show)
 
@@ -337,6 +337,7 @@ mkInitialAnalyzeState tables caps = AnalyzeState
     , _globalState = GlobalAnalyzeState
         { _gasGuardProvenances = mempty
         , _gasNextUninterpId   = 0
+        , _gasRollbacks        = []
         }
     }
 

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -80,6 +80,19 @@ class (MonadError AnalyzeFailure m, S :*<: TermOf m) => Analyzer m where
         ) => b)
     -> b
 
+(??)
+  :: Analyzer m
+  => Maybe a -> AnalyzeFailureNoLoc -> m a
+Just a  ?? _   = pure a
+Nothing ?? err = throwErrorNoLoc err
+infix 0 ??
+
+(???) :: Analyzer m => m (Maybe a) -> AnalyzeFailureNoLoc -> m a
+m ??? err = do
+  m' <- m
+  m' ?? err
+infix 0 ???
+
 data PactMetadata
   = PactMetadata
     { _pmInPact :: !(S Bool)

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -123,6 +123,7 @@ data AnalyzeEnv
     , _aeRegistry     :: !Registry
     , _aeTxMetadata   :: !TxMetadata
     , _aeScope        :: !(Map VarId AVal) -- used as a stack
+    , _aeNondets      :: !(Map VarId (SBV Bool))
     , _aeGuardPasses  :: !(SFunArray Guard Bool)
     , _invariants     :: !(TableMap [Located (Invariant 'TyBool)])
     , _aeColumnIds    :: !(TableMap (Map Text VarId))
@@ -143,10 +144,11 @@ mkAnalyzeEnv
   -> [Table]
   -> [Capability]
   -> Map VarId AVal
+  -> Map VarId (SBV Bool)
   -> ModelTags 'Symbolic
   -> Info
   -> Maybe AnalyzeEnv
-mkAnalyzeEnv modName pactMetadata registry tables caps args tags info = do
+mkAnalyzeEnv modName pactMetadata registry tables caps args nondets tags info = do
   let txMetadata   = TxMetadata (mkFreeArray "txKeySets")
                                 (mkFreeArray "txDecimals")
                                 (mkFreeArray "txIntegers")
@@ -177,7 +179,7 @@ mkAnalyzeEnv modName pactMetadata registry tables caps args tags info = do
       emptyGrants  = mkTokenGrants caps
       activeGrants = emptyGrants
 
-  pure $ AnalyzeEnv modName pactMetadata registry txMetadata args guardPasses
+  pure $ AnalyzeEnv modName pactMetadata registry txMetadata args nondets guardPasses
     invariants' columnIds' tags info (sansProv trivialGuard) emptyGrants
     activeGrants tables
 

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -81,6 +81,7 @@ class (MonadError AnalyzeFailure m, S :*<: TermOf m) => Analyzer m where
         ) => b)
     -> b
 
+-- | Expect a 'Just' in an 'Analyzer'.
 (??)
   :: Analyzer m
   => Maybe a -> AnalyzeFailureNoLoc -> m a
@@ -88,6 +89,7 @@ Just a  ?? _   = pure a
 Nothing ?? err = throwErrorNoLoc err
 infix 1 ??
 
+-- | Expect a computation to evaluate to a 'Just' in an 'Analyzer'.
 (???) :: Analyzer m => m (Maybe a) -> AnalyzeFailureNoLoc -> m a
 m ??? err = do
   m' <- m

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -87,7 +87,7 @@ import           Text.Show                     (showListWith)
 import           Pact.Types.Pretty             (commaBraces, commaBrackets,
                                                 parens, parensSep,
                                                 Pretty(pretty), Doc, viaShow,
-                                                vsep)
+                                                vsep, prettyString)
 import           Pact.Types.Persistence        (WriteType)
 
 import           Pact.Analyze.Feature          hiding (Doc, Sym, Var, col, str,
@@ -401,7 +401,7 @@ singPrettyObject SObjectNil (Object SNil) = [""]
 singPrettyObject
   (SObjectUnsafe (SingList (SCons _ _ objty)))
   (Object (SCons k (Column vTy v) obj))
-    = (pretty (symbolVal k) <> ": " <> singPrettyTm vTy v)
+    = ("'" <> prettyString (symbolVal k) <> ": " <> singPrettyTm vTy v)
       : singPrettyObject (SObjectUnsafe (SingList objty)) (Object obj)
 singPrettyObject _ _ = error "malformed object"
 
@@ -1539,7 +1539,7 @@ prettyTerm ty = \case
   MkPactGuard name     -> parensSep ["create-pact-guard", pretty name]
   MkUserGuard ty' o n  -> parensSep ["create-user-guard", singPrettyTm ty' o, pretty n]
   Step mEntity (exec :< execTy) mRollback
-    -> parensSep $ ["step"]
+    -> parensSep $ maybe ["step"] (\_ -> ["step-with-rollback"]) mRollback
       ++ maybe [] (\entity -> [prettyTm entity]) mEntity
       ++ [singPrettyTm execTy exec]
       ++ maybe [] (\(Some  ty' tm) -> [singPrettyTm ty' tm]) mRollback

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -1352,17 +1352,17 @@ data Term (a :: Ty) where
 
 data PactStep where
   Step
-    :: Term a :< SingTy a  -- ^ exec
-    -> Path                -- ^ corresponds to the graph edge for this step
-    -> Maybe (Term 'TyStr) -- ^ entity
+    :: Term a :< SingTy a  -- exec
+    -> Path                -- corresponds to the graph edge for this step
+    -> Maybe (Term 'TyStr) -- entity
     -- first:  Nothing
     -- others: Just
-    -> Maybe (Path, VarId) -- ^ does this step cancel. invariant: the first
+    -> Maybe (Path, VarId) -- does this step cancel. invariant: the first
                            -- step does not have this vid. all other steps do.
                            -- "C"
     -- last:   Nothing
     -- others: Just or Nothing
-    -> Maybe (Path, ETerm) -- ^ rollback (R1)
+    -> Maybe (Path, ETerm) -- rollback (R1)
     -> PactStep
 
 showsTerm :: SingTy ty -> Int -> Term ty -> ShowS

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -1346,6 +1346,7 @@ data Term (a :: Ty) where
   ParseTime       :: Maybe (Term 'TyStr) -> Term 'TyStr  -> Term 'TyTime
   Hash            :: ETerm                               -> Term 'TyStr
 
+  -- Pacts
   Pact   :: [PactStep] -> Term 'TyStr
   Yield  :: SingTy a -> Term a -> Term a
   Resume ::                       Term a

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -1348,10 +1348,12 @@ data Term (a :: Ty) where
 data PactStep where
   Step
     :: Term a :< SingTy a  -- ^ exec
+    -> Path                -- ^ corresponds to the graph edge for this step
     -> Maybe (Term 'TyStr) -- ^ entity
-    -> Maybe VarId         -- ^ does this step cancel. invariant: the first
+    -> Maybe (Path, VarId) -- ^ does this step cancel. invariant: the first
                            -- step does not have this vid. all other steps do.
-    -> Maybe ETerm         -- ^ rollback
+                           -- "C"
+    -> Maybe (Path, ETerm) -- ^ rollback (R1)
     -> PactStep
 
 showsTerm :: SingTy ty -> Int -> Term ty -> ShowS

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -1470,9 +1470,11 @@ showsTerm ty p tm = withSing ty $ showParen (p > 10) $ case tm of
   Pact steps -> showString "Pact " . showList steps
 
 instance Show PactStep where
-  showsPrec _ (Step (exec :< execTy) mEntity mCancelVid mRollback) =
+  showsPrec _ (Step (exec :< execTy) path mEntity mCancelVid mRollback) =
      showString "Step "
    . withSing execTy (showsTm 11 exec)
+   . showChar ' '
+   . showsPrec 11 path
    . showChar ' '
    . showsPrec 11 mEntity
    . showChar ' '
@@ -1550,11 +1552,11 @@ prettyTerm ty = \case
   Pact steps -> vsep (pretty <$> steps)
 
 instance Pretty PactStep where
-  pretty (Step (exec :< execTy) mEntity _ mRollback) = parensSep $
+  pretty (Step (exec :< execTy) _ mEntity _ mRollback) = parensSep $
     maybe ["step"] (\_ -> ["step-with-rollback"]) mRollback
       ++ maybe [] (\entity -> [prettyTm entity]) mEntity
       ++ [singPrettyTm execTy exec]
-      ++ maybe [] (\(Some  ty' tm) -> [singPrettyTm ty' tm]) mRollback
+      ++ maybe [] (\(_path, Some  ty' tm) -> [singPrettyTm ty' tm]) mRollback
 
 eqTerm :: SingTy ty -> Term ty -> Term ty -> Bool
 eqTerm ty (CoreTerm a1) (CoreTerm a2) = singEqTm ty a1 a2

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -1350,9 +1350,13 @@ data PactStep where
     :: Term a :< SingTy a  -- ^ exec
     -> Path                -- ^ corresponds to the graph edge for this step
     -> Maybe (Term 'TyStr) -- ^ entity
+    -- first:  Nothing
+    -- others: Just
     -> Maybe (Path, VarId) -- ^ does this step cancel. invariant: the first
                            -- step does not have this vid. all other steps do.
                            -- "C"
+    -- last:   Nothing
+    -- others: Just or Nothing
     -> Maybe (Path, ETerm) -- ^ rollback (R1)
     -> PactStep
 

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -75,6 +75,7 @@ data ScopeType
   = LetScope
   | ObjectScope
   | FunctionScope Pact.ModuleName Text
+  | PactScope Pact.ModuleName Text
   | CapabilityScope Pact.ModuleName CapName
   deriving (Eq, Show)
 

--- a/tests/Analyze/Eval.hs
+++ b/tests/Analyze/Eval.hs
@@ -97,10 +97,11 @@ analyzeEval etm@(Some ty _tm) gs = analyzeEval' etm ty gs
 analyzeEval' :: ETerm -> SingTy a -> GenState -> IO (Either String ETerm)
 analyzeEval' etm ty (GenState _ registryKSs txKSs txDecs txInts) = do
   -- analyze setup
-  let tables = []
-      caps   = []
-      args   = Map.empty
-      state0 = mkInitialAnalyzeState tables caps
+  let tables  = []
+      caps    = []
+      args    = Map.empty
+      nondets = Map.empty
+      state0  = mkInitialAnalyzeState tables caps
 
       tags = ModelTags Map.empty Map.empty Map.empty Map.empty Map.empty
         -- this 'Located TVal' is never forced so we don't provide it
@@ -111,7 +112,7 @@ analyzeEval' etm ty (GenState _ registryKSs txKSs txDecs txInts) = do
       pactMd  = mkPactMetadata
       reg     = mkRegistry
 
-  Just aEnv <- pure $ mkAnalyzeEnv modName pactMd reg tables caps args tags dummyInfo
+  Just aEnv <- pure $ mkAnalyzeEnv modName pactMd reg tables caps args nondets tags dummyInfo
 
   let writeArray' k v env = writeArray env k v
 

--- a/tests/Analyze/Eval.hs
+++ b/tests/Analyze/Eval.hs
@@ -97,11 +97,11 @@ analyzeEval etm@(Some ty _tm) gs = analyzeEval' etm ty gs
 analyzeEval' :: ETerm -> SingTy a -> GenState -> IO (Either String ETerm)
 analyzeEval' etm ty (GenState _ registryKSs txKSs txDecs txInts) = do
   -- analyze setup
-  let tables  = []
-      caps    = []
-      args    = Map.empty
-      nondets = Map.empty
-      state0  = mkInitialAnalyzeState tables caps
+  let tables      = []
+      caps        = []
+      args        = Map.empty
+      stepChoices = Map.empty
+      state0      = mkInitialAnalyzeState tables caps
 
       tags = ModelTags Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty
         -- this 'Located TVal' is never forced so we don't provide it
@@ -112,7 +112,8 @@ analyzeEval' etm ty (GenState _ registryKSs txKSs txDecs txInts) = do
       pactMd  = mkPactMetadata
       reg     = mkRegistry
 
-  Just aEnv <- pure $ mkAnalyzeEnv modName pactMd reg tables caps args nondets tags dummyInfo
+  Just aEnv <- pure $ mkAnalyzeEnv modName pactMd reg tables caps args
+    stepChoices tags dummyInfo
 
   let writeArray' k v env = writeArray env k v
 

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -3097,12 +3097,12 @@ spec = describe "analyze" $ do
                       (= (column-delta accounts 'balance) 0)))
                 ]
               (step-with-rollback payer-entity
-                (update-bal payer (- payer-bal amount))
-                (update-bal payer payer-bal))
+                (update-bal payer (- payer-bal amount) "step 1")
+                (update-bal payer payer-bal "rollback 1"))
               (step payee-entity
-                (update-bal payee (+ payee-bal amount))))
+                (update-bal payee (+ payee-bal amount) "step 2")))
 
-            (defun update-bal (acct balance)
+            (defun update-bal (acct balance msg:string)
               (enforce (>= balance 0)    "Non-positive balance")
               (update accounts acct { "balance": balance }))
             |]

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -216,7 +216,6 @@ pattern Result' = PropSpecific Result
 
 spec :: Spec
 spec = describe "analyze" $ do
-  {-
   describe "decimal arithmetic" $ do
     let unlit :: S Decimal -> Decimal
         unlit = fromJust . unliteralS
@@ -1364,11 +1363,9 @@ spec = describe "analyze" $ do
         case results of
           Left failure -> it "unexpectedly failed verification" $
             expectationFailure $ show failure
-          Right (ModuleChecks propResults invariantResults pactResults _) -> do
+          Right (ModuleChecks propResults invariantResults _) -> do
             it "should have no prop results" $
               propResults `shouldBe` HM.singleton "test" []
-            it "should have no prop results" $
-              pactResults `shouldBe` HM.singleton "test" []
 
             case invariantResults ^.. ix "test" . ix "accounts" . ix 0 . _Left of
               -- see https://github.com/Z3Prover/z3/issues/1819
@@ -3042,7 +3039,6 @@ spec = describe "analyze" $ do
               )
             |]
       expectVerified code
--}
 
   describe "checking pacts" $ do
     -- TODO:
@@ -3124,7 +3120,7 @@ spec = describe "analyze" $ do
       expectVerified code''
 
       -- many step pact:
-      let code'' = [text|
+      let code''' = [text|
             (defpact payment ()
               @doc "this is a pact"
               @model
@@ -3142,10 +3138,10 @@ spec = describe "analyze" $ do
                   (with-read accounts acct { "balance" := bal }
                     (update accounts acct { "balance": (+ bal amt) }))))
             |]
-      expectVerified code''
+      expectVerified code'''
 
       -- nontrivial many step pact:
-      let code'' = [text|
+      let code'''' = [text|
             (defpact payment ()
               @doc "this is a pact"
               @model
@@ -3176,6 +3172,6 @@ spec = describe "analyze" $ do
                   (with-read accounts acct { "balance" := bal }
                     (update accounts acct { "balance": (+ bal amt) }))))
             |]
-      expectVerified code''
+      expectVerified code''''
 
       it "checks yield / resume" $ pendingWith "yield / resume typechecking"

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -3046,11 +3046,13 @@ spec = describe "analyze" $ do
 
   describe "checking pacts" $ do
     -- TODO:
-    -- * longer pacts
-    -- * shorter pacts?
+    -- X longer pacts
+    -- X shorter pacts?
     -- * steps with / without rollbacks
     -- * public / private
     -- * steps with / without specified entities
+    -- * yield / resume
+    -- * pact-id
 
     describe "translating a pact" $ do
       let code = [text|
@@ -3107,3 +3109,30 @@ spec = describe "analyze" $ do
               (update accounts acct { "balance": balance }))
             |]
       expectVerified code'
+
+      -- single step pact:
+      let code'' = [text|
+            (defpact payment (payer)
+              @doc "this is a pact"
+              @model
+                [ (property (= (column-delta accounts 'balance) 0))
+                ]
+              (step (update accounts acct { "balance": (- bal 0) })))
+            |]
+      expectVerified code''
+
+      -- many step pact:
+      let code'' = [text|
+            (defpact payment (payer)
+              @doc "this is a pact"
+              @model
+                [ (property (= (column-delta accounts 'balance) 0))
+                ]
+              (step (update accounts acct { "balance": (- bal 1) }))
+              (step (update accounts acct { "balance": (+ bal 1) }))
+              (step (update accounts acct { "balance": (- bal 2) }))
+              (step (update accounts acct { "balance": (+ bal 2) }))
+              (step (update accounts acct { "balance": (- bal 3) }))
+              (step (update accounts acct { "balance": (+ bal 3) })))
+            |]
+      expectVerified code''

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -142,15 +142,13 @@ runVerification code = do
       results <- verifyModule (HM.fromList [("test", moduleData)]) moduleData
       case results of
         Left failure -> pure $ Just $ VerificationFailure failure
-        Right (ModuleChecks propResults invariantResults pactResults _) -> pure $
+        Right (ModuleChecks propResults invariantResults _) -> pure $
           case findOf (traverse . traverse) isLeft propResults of
             Just (Left failure) -> Just $ TestCheckFailure failure
-            _ -> case findOf (traverse . traverse) isLeft pactResults of
+            _ -> case findOf (traverse . traverse . traverse) isLeft invariantResults of
               Just (Left failure) -> Just $ TestCheckFailure failure
-              _ -> case findOf (traverse . traverse . traverse) isLeft invariantResults of
-                Just (Left failure) -> Just $ TestCheckFailure failure
-                Just (Right _)      -> error "impossible: result of isLeft"
-                Nothing             -> Nothing
+              Just (Right _)      -> error "impossible: result of isLeft"
+              Nothing             -> Nothing
 
 runCheck :: Text -> Check -> IO (Maybe TestFailure)
 runCheck code check = do

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -116,7 +116,7 @@ renderTestFailure = \case
     pure $ T.unpack (describeCheckFailure cf) ++ svgInfo
   NoTestModule -> pure "example is missing a module named 'test'"
   ReplError err -> pure $ "ReplError: " ++ err
-  VerificationFailure vf -> pure $ "VerificationFailure: " ++ show vf
+  VerificationFailure vf -> pure $ T.unpack $ describeVerificationFailure vf
 
 --
 -- TODO: use ExceptT

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -3225,134 +3225,142 @@ spec = describe "analyze" $ do
     -- TODO:
     -- * yield / resume
     -- * pact-id
-    -- * shorter pacts (0 / 1 steps)
+    let code1 = [text|
+          (defpact payment (payer payer-entity payee
+                            payee-entity amount)
+            @doc "this is a pact"
+            @model
+              [ (property (= (column-delta accounts 'balance) 0))
+              ]
+            (step-with-rollback payer-entity
+              (debit payer amount)
+              (credit payer amount))
+            (step payee-entity
+              (credit payee amount)))
 
-    describe "translating a pact" $ do
-      let code = [text|
-            (defpact payment (payer payer-entity payee
-                              payee-entity amount)
-              @doc "this is a pact"
-              @model
-                [ (property (= (column-delta accounts 'balance) 0))
-                ]
-              (step-with-rollback payer-entity
-                (debit payer amount)
-                (credit payer amount))
-              (step payee-entity
-                (credit payee amount)))
+          (defun debit (acct amount)
+            (let ((bal (at 'balance (read accounts acct))))
+              (enforce (> amount 0)    "Non-positive amount")
+              (enforce (>= bal amount) "Insufficient Funds")
+              (update accounts acct { "balance": (- bal amount) })))
 
-            (defun debit (acct amount)
-              (let ((bal (at 'balance (read accounts acct))))
-                (enforce (> amount 0)    "Non-positive amount")
-                (enforce (>= bal amount) "Insufficient Funds")
-                (update accounts acct { "balance": (- bal amount) })))
+          (defun credit (acct amount)
+            (let ((bal (at 'balance (read accounts acct))))
+              (enforce (> amount 0)    "Non-positive amount")
+              (update accounts acct { "balance": (+ bal amount) })))
+          |]
+    expectVerified code1
 
-            (defun credit (acct amount)
-              (let ((bal (at 'balance (read accounts acct))))
-                (enforce (> amount 0)    "Non-positive amount")
-                (update accounts acct { "balance": (+ bal amount) })))
-            |]
-      expectVerified code
+    let code2 = [text|
+          (defpact payment (payer:string payer-entity:string payee:string
+                            payee-entity:string amount:integer
+                            payer-bal:integer payee-bal:integer)
+            @doc "this is a pact"
+            @model
+              [ (property
+                  (when
+                    ; assumptions
+                    (and (>= payer-bal amount)
+                    (and (= payer-bal (at 'balance (read accounts payer 'before)))
+                    (and (= payee-bal (at 'balance (read accounts payee 'before)))
+                         (!= payer payee))))
 
-      let code' = [text|
-            (defpact payment (payer:string payer-entity:string payee:string
-                              payee-entity:string amount:integer
-                              payer-bal:integer payee-bal:integer)
-              @doc "this is a pact"
-              @model
-                [ (property
-                    (when
-                      ; assumptions
-                      (and (>= payer-bal amount)
-                      (and (= payer-bal (at 'balance (read accounts payer 'before)))
-                      (and (= payee-bal (at 'balance (read accounts payee 'before)))
-                           (!= payer payee))))
+                    ; conclusion
+                    (= (column-delta accounts 'balance) 0)))
+              ]
+            (step-with-rollback payer-entity
+              (update-bal payer (- payer-bal amount) "step 1")
+              (update-bal payer payer-bal "rollback 1"))
+            (step payee-entity
+              (update-bal payee (+ payee-bal amount) "step 2")))
 
-                      ; conclusion
-                      (= (column-delta accounts 'balance) 0)))
-                ]
-              (step-with-rollback payer-entity
-                (update-bal payer (- payer-bal amount) "step 1")
-                (update-bal payer payer-bal "rollback 1"))
-              (step payee-entity
-                (update-bal payee (+ payee-bal amount) "step 2")))
+          (defun update-bal (acct balance msg:string)
+            (enforce (>= balance 0)    "Non-positive balance")
+            (update accounts acct { "balance": balance }))
+          |]
+    -- TODO: check trace
+    expectFalsified code2
 
-            (defun update-bal (acct balance msg:string)
-              (enforce (>= balance 0)    "Non-positive balance")
-              (update accounts acct { "balance": balance }))
-            |]
-      -- TODO: check trace
-      expectFalsified code'
+    -- single step pact:
+    let code3 = [text|
+          (defpact payment ()
+            @doc "this is a pact"
+            @model
+              [ (property (= (column-delta accounts 'balance) 0))
+              ]
+            (step (doit 0)))
 
-      -- single step pact:
-      let code'' = [text|
-            (defpact payment ()
-              @doc "this is a pact"
-              @model
-                [ (property (= (column-delta accounts 'balance) 0))
-                ]
-              (step (doit 0)))
+          (defun doit (amt:integer)
+            (let ((acct "joel"))
+              (with-read accounts acct { "balance" := bal }
+                (update accounts acct { "balance": (+ bal amt) }))))
+          |]
+    expectVerified code3
 
-              (defun doit (amt:integer)
-                (let ((acct "joel"))
-                  (with-read accounts acct { "balance" := bal }
-                    (update accounts acct { "balance": (+ bal amt) }))))
-            |]
-      expectVerified code''
+    -- many step pact:
+    let code4 = [text|
+          (defpact payment ()
+            @doc "this is a pact"
+            @model
+              [ (property (= (column-delta accounts 'balance) 0))
+              ]
+            (step (doit 0))
+            (step (doit 0))
+            (step (doit 0))
+            (step (doit 0))
+            (step (doit 0))
+            (step (doit 0)))
 
-      -- many step pact:
-      let code''' = [text|
-            (defpact payment ()
-              @doc "this is a pact"
-              @model
-                [ (property (= (column-delta accounts 'balance) 0))
-                ]
-              (step (doit 0))
-              (step (doit 0))
-              (step (doit 0))
-              (step (doit 0))
-              (step (doit 0))
-              (step (doit 0)))
+          (defun doit (amt:integer)
+            (let ((acct "joel"))
+              (with-read accounts acct { "balance" := bal }
+                (update accounts acct { "balance": (+ bal amt) }))))
+          |]
+    expectVerified code4
 
-              (defun doit (amt:integer)
-                (let ((acct "joel"))
-                  (with-read accounts acct { "balance" := bal }
-                    (update accounts acct { "balance": (+ bal amt) }))))
-            |]
-      expectVerified code'''
+    -- nontrivial many step pact:
+    let code5 = [text|
+          (defpact payment ()
+            @doc "this is a pact"
+            @model
+              [ (property (= (column-delta accounts 'balance) 0))
+              ]
+            (step-with-rollback
+              (doit (- 1))
+              (doit 1))
+            (step-with-rollback
+              (doit (- 2))
+              (doit 2))
+            (step (doit 0))
+            (step-with-rollback
+              (doit (- 3))
+              (doit 3))
+            (step (doit 0))
+            (step-with-rollback
+              (doit (- 4))
+              (doit 4))
+            (step (doit 0))
+            (step-with-rollback
+              (doit (- 5))
+              (doit 5))
+            (step (doit 15)))
 
-      -- nontrivial many step pact:
-      let code'''' = [text|
-            (defpact payment ()
-              @doc "this is a pact"
-              @model
-                [ (property (= (column-delta accounts 'balance) 0))
-                ]
-              (step-with-rollback
-                (doit (- 1))
-                (doit 1))
-              (step-with-rollback
-                (doit (- 2))
-                (doit 2))
-              (step (doit 0))
-              (step-with-rollback
-                (doit (- 3))
-                (doit 3))
-              (step (doit 0))
-              (step-with-rollback
-                (doit (- 4))
-                (doit 4))
-              (step (doit 0))
-              (step-with-rollback
-                (doit (- 5))
-                (doit 5))
-              (step (doit 15)))
+          (defun doit (amt:integer)
+            (let ((acct "joel"))
+              (with-read accounts acct { "balance" := bal }
+                (update accounts acct { "balance": (+ bal amt) }))))
+          |]
+    expectVerified code5
 
-              (defun doit (amt:integer)
-                (let ((acct "joel"))
-                  (with-read accounts acct { "balance" := bal }
-                    (update accounts acct { "balance": (+ bal amt) }))))
-            |]
-      expectVerified code''''
+    -- checking a pact with only one step
+    -- Note: there is a vestigial rollback step here. something should probably
+    -- disallow this, but it's not exactly clear what stage should be
+    -- responsible.
+    let code6 = [text|
+          (defpact payment ()
+            @model [ (property (= (column-delta accounts 'balance) 0)) ]
+            (step-with-rollback "foo" "bar"))
+          |]
+    expectVerified code6
 
-      it "checks yield / resume" $ pendingWith "yield / resume typechecking"
+    it "checks yield / resume" $ pendingWith "yield / resume typechecking"

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -3085,16 +3085,16 @@ spec = describe "analyze" $ do
                               payer-bal:integer payee-bal:integer)
               @doc "this is a pact"
               @model
-                ; assumptions
-                [ (property (>= payer-bal amount))
-                , (property (= payer-bal (at 'balance (read accounts payer 'before))))
-                , (property (= payee-bal (at 'balance (read accounts payee 'before))))
+                [ (property
+                    (when
+                      ; assumptions
+                      (and (>= payer-bal amount)
+                      (and (= payer-bal (at 'balance (read accounts payer 'before)))
+                      (and (= payee-bal (at 'balance (read accounts payee 'before)))
+                           (!= payer payee))))
 
-                ; dubious assumptions
-                , (property (!= payer payee))
-
-                ; conclusion
-                , (property (= (column-delta accounts 'balance) 0))
+                      ; conclusion
+                      (= (column-delta accounts 'balance) 0)))
                 ]
               (step-with-rollback payer-entity
                 (update-bal payer (- payer-bal amount))
@@ -3103,7 +3103,7 @@ spec = describe "analyze" $ do
                 (update-bal payee (+ payee-bal amount))))
 
             (defun update-bal (acct balance)
-              (enforce (> balance 0)    "Non-positive balance")
+              (enforce (>= balance 0)    "Non-positive balance")
               (update accounts acct { "balance": balance }))
             |]
       expectVerified code'

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -3053,7 +3053,7 @@ spec = describe "analyze" $ do
                               payee-entity amount)
               @doc "this is a pact"
               @model
-                [ (property (= (column-delta accounts 'balance) 1))
+                [ (property (= (column-delta accounts 'balance) 0))
                 ]
               (step-with-rollback payer-entity
                 (debit payer amount)

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -3046,13 +3046,9 @@ spec = describe "analyze" $ do
 
   describe "checking pacts" $ do
     -- TODO:
-    -- X longer pacts
-    -- X shorter pacts?
-    -- * steps with / without rollbacks
-    -- * public / private
-    -- * steps with / without specified entities
     -- * yield / resume
     -- * pact-id
+    -- * shorter pacts (0 / 1 steps)
 
     describe "translating a pact" $ do
       let code = [text|
@@ -3108,7 +3104,8 @@ spec = describe "analyze" $ do
               (enforce (>= balance 0)    "Non-positive balance")
               (update accounts acct { "balance": balance }))
             |]
-      expectVerified code'
+      -- TODO: check trace
+      expectFalsified code'
 
       -- single step pact:
       let code'' = [text|
@@ -3147,7 +3144,7 @@ spec = describe "analyze" $ do
             |]
       expectVerified code''
 
-      -- many step pact:
+      -- nontrivial many step pact:
       let code'' = [text|
             (defpact payment ()
               @doc "this is a pact"
@@ -3160,12 +3157,15 @@ spec = describe "analyze" $ do
               (step-with-rollback
                 (doit (- 2))
                 (doit 2))
+              (step (doit 0))
               (step-with-rollback
                 (doit (- 3))
                 (doit 3))
+              (step (doit 0))
               (step-with-rollback
                 (doit (- 4))
                 (doit 4))
+              (step (doit 0))
               (step-with-rollback
                 (doit (- 5))
                 (doit 5))
@@ -3177,3 +3177,5 @@ spec = describe "analyze" $ do
                     (update accounts acct { "balance": (+ bal amt) }))))
             |]
       expectVerified code''
+
+      it "checks yield / resume" $ pendingWith "yield / resume typechecking"

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -148,8 +148,6 @@
     (let ((partial { "name": "dave" }))
       (update persons "foo" partial)
       partial))
-
-
 )
 
 (create-table persons)


### PR DESCRIPTION
Feedback please. Things that still need to be done:

* Emit trace steps for resets (@bts I started working on this but had some trouble with it -- if you want to tackle it that would be amazing. If not I can continue with your guidance). Edit: now done
* The method we currently use for resets is pretty lame -- we just free everything that could be changed between steps, without considering what could actually be changed with the API presented by the module. This is pretty weak (in terms of what we can prove). It would be better to take the closure of sequences of operations available in the module. Unfortunately I'm not sure how to do this. Also I'm not sure which things need to be freed between steps in the current method.
* If someone declares `(property (= (column-delta accounts 'balance) 1))` for a pact, does that mean that the sum of that column is the same when the pact finishes executing, or that the code in the pact itself doesn't change the sum of the column? Edit: we're going with the latter
* Need to do a lot of testing. This is partly dependent on questions like the previous.
* Note: please ignore that I commented out all the other tests