### PR TITLE
More capability analysis support

### DIFF
--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -505,13 +505,17 @@ evalTerm = \case
     --
     pure $ literalS "Write succeeded"
 
-  Let _name vid retTid eterm body -> do
+  Let _name vid eterm body -> do
     av <- evalETerm eterm
     tagVarBinding vid av
     local (scope.at vid ?~ av) $ do
       res <- evalTerm body
-      tagReturn retTid $ mkAVal res
       pure res
+
+  Return tid body -> do
+    res <- evalTerm body
+    tagReturn tid $ mkAVal res
+    pure res
 
   -- Read values from tx metadata
   ReadKeySet  nameT -> readKeySet  =<< evalTerm nameT

--- a/src/Pact/Analyze/Model/Graph.hs
+++ b/src/Pact/Analyze/Model/Graph.hs
@@ -79,6 +79,9 @@ linearize model = go traceEvents
              TraceGuard recov (_located -> tid) ->
                handleEnforce recov $
                  mtGuardEnforcements.at tid._Just.located.geSuccess
+             TraceRequireGrant recov _ _ (_located -> tid) ->
+               handleEnforce recov $
+                 mtGrantRequests.at tid._Just.located.grSuccess
              TraceRead _schema (Located _i tid) ->
                handleDbAccess $ mtReads.at tid._Just.located.accSuccess
              TraceWrite _writeType _schema (Located _i tid) ->

--- a/src/Pact/Analyze/Model/Text.hs
+++ b/src/Pact/Analyze/Model/Text.hs
@@ -155,6 +155,15 @@ showGE recov mProv (_located -> GuardEnforcement sg sbool) =
       Just (FromMetadata sName) ->
         guard <> " from tx metadata attribute named " <> showS sName
 
+showGR :: Recoverability -> Located GrantRequest -> Text
+showGR recov (_located -> GrantRequest (CapName (T.pack -> capName)) sbool) =
+  let requirement = "requirement of capability " <> capName
+  in
+    case SBV.unliteral sbool of
+      Nothing    -> "[ERROR:symbolic grant request]"
+      Just True  -> "satisfied " <> requirement
+      Just False -> showFailure recov <> " to satisfy " <> requirement
+
 -- TODO: after factoring Location out of TraceEvent, include source locations
 --       in trace
 showEvent
@@ -174,6 +183,8 @@ showEvent ksProvs tags event = do
         pure [display mtAsserts tid (showAssert recov)]
       TraceGuard recov (_located -> tid) ->
         pure [display mtGuardEnforcements tid (showGE recov $ tid `Map.lookup` ksProvs)]
+      TraceRequireGrant recov _capName _bindings (_located -> tid) ->
+        pure [display mtGrantRequests tid (showGR recov)]
       TraceSubpathStart _ ->
         pure [] -- not shown to end-users
       TracePushScope _ scopeTy locatedBindings -> do
@@ -185,11 +196,17 @@ showEvent ksProvs tags event = do
             displayCallScope :: Text -> Pact.ModuleName -> Text -> [Text]
             displayCallScope noun modName funName =
               -- TODO(joel): convert all of this to Doc
-              let header = renderCompactText' $
-                           "entering " <> pretty noun <> " " <> pretty modName
-                        <> "." <> pretty funName <> " with "
-                        <> if length vids == 1 then "argument" else "arguments"
-              in header : (displayVids showArg ++ [emptyLine])
+              let withArgs = case length vids of
+                               0 -> ""
+                               1 -> " with argument"
+                               _ -> " with arguments"
+                  headerLine = renderCompactText' $ "entering " <> pretty noun
+                            <> " " <> pretty modName <> "." <> pretty funName
+                            <> withArgs
+                  argLines = case length vids of
+                               0 -> []
+                               _ -> displayVids showArg ++ [emptyLine]
+              in headerLine : argLines
 
         pure $ case scopeTy of
           LetScope ->

--- a/src/Pact/Analyze/Model/Text.hs
+++ b/src/Pact/Analyze/Model/Text.hs
@@ -188,7 +188,7 @@ showEvent ksProvs tags event = do
               let header = renderCompactText' $
                            "entering " <> pretty noun <> " " <> pretty modName
                         <> "." <> pretty funName <> " with "
-                        <> if length vids > 1 then "arguments" else "argument"
+                        <> if length vids == 1 then "argument" else "arguments"
               in header : (displayVids showArg ++ [emptyLine])
 
         pure $ case scopeTy of

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -205,6 +205,10 @@ pattern AST_WithCapability app body <-
       (NativeFuncSpecial "with-capability" (List _ body))
       [app]
 
+pattern AST_RequireCapability :: forall a. AST a -> AST a
+pattern AST_RequireCapability app <-
+  App _node (NativeFunc "require-capability") [app]
+
 -- pattern RawTableName :: Text -> AST Node
 -- pattern RawTableName t <- Table (Node (TcId _ t _) _) _
 

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -205,9 +205,9 @@ pattern AST_WithCapability app body <-
       (NativeFuncSpecial "with-capability" (List _ body))
       [app]
 
-pattern AST_RequireCapability :: forall a. AST a -> AST a
-pattern AST_RequireCapability app <-
-  App _node (NativeFunc "require-capability") [app]
+pattern AST_RequireCapability :: Node -> AST Node -> AST Node
+pattern AST_RequireCapability node app <-
+  App node (NativeFunc "require-capability") [app]
 
 -- pattern RawTableName :: Text -> AST Node
 -- pattern RawTableName t <- Table (Node (TcId _ t _) _) _

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -209,6 +209,10 @@ pattern AST_RequireCapability :: Node -> AST Node -> AST Node
 pattern AST_RequireCapability node app <-
   App node (NativeFunc "require-capability") [app]
 
+pattern AST_ComposeCapability :: AST Node -> AST Node
+pattern AST_ComposeCapability app <-
+  App _node (NativeFunc "compose-capability") [app]
+
 -- pattern RawTableName :: Text -> AST Node
 -- pattern RawTableName t <- Table (Node (TcId _ t _) _) _
 

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -197,12 +197,11 @@ pattern AST_Bind node object bindings schema body <-
       [object]
 
 pattern AST_WithCapability
-  :: Node
-  -> AST Node
+  :: AST Node
   -> [AST Node]
   -> AST Node
-pattern AST_WithCapability node app body <-
-  App node
+pattern AST_WithCapability app body <-
+  App _node
       (NativeFuncSpecial "with-capability" (List _ body))
       [app]
 

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -985,7 +985,7 @@ translateNode astNode = withAstContext astNode $ case astNode of
     objectT               <- translateNode objectA
     withNodeContext node $ translateObjBinding bindings objTy body objectT
 
-  AST_WithCapability _ appA bodyA -> do
+  AST_WithCapability appA bodyA -> do
     appET <- translateNode appA
     Some ty bodyT <- translateBody bodyA
     pure $ Some ty $ WithCapability appET bodyT

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -353,7 +353,7 @@ withNodeVars namedNodes bindings = local (teNodeVars %~ Map.union nodeVars)
     nodeVars :: Map Node (Munged, VarId)
     nodeVars = Map.fromList
       [ (node, (munged, vid))
-      | ((Named _ node _), _located -> Binding vid _ munged _)
+      | ((Named _ node _), Located _ (Binding vid _ munged _))
           <- zip namedNodes bindings
       ]
 

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -346,13 +346,13 @@ tagGuard node = do
 
 -- Note: uses left-biased union to prefer new vars
 withNodeVars :: [Named Node] -> [Located Binding] -> TranslateM a -> TranslateM a
-withNodeVars bindingAs bindingTs = local (teNodeVars %~ Map.union nodeVars)
+withNodeVars namedNodes bindings = local (teNodeVars %~ Map.union nodeVars)
   where
     nodeVars :: Map Node (Munged, VarId)
     nodeVars = Map.fromList
       [ (node, (munged, vid))
       | ((Named _ node _), _located -> Binding vid _ munged _)
-          <- zip bindingAs bindingTs
+          <- zip namedNodes bindings
       ]
 
 maybeTranslateUserType

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -985,6 +985,14 @@ translateNode astNode = withAstContext astNode $ case astNode of
     Some ty withBodyT <- translateBody withBodyA
     pure $ Some ty $ WithCapability appET withBodyT
 
+  AST_RequireCapability (AST_InlinedApp _ funName bindings _) -> do
+    let capName = CapName $ T.unpack funName
+    cap <- lookupCapability capName
+    withTranslatedBindings bindings $ \bindingTs _retTid -> do
+      let vars = (\b -> (_mungedName . _bmName $ b, _bVid b)) . _located <$>
+            bindingTs
+      pure $ Some SBool $ Enforce Nothing $ HasGrant cap vars
+
   AST_AddTime time seconds
     | seconds ^. aNode . aTy == TyPrim Pact.TyInteger ||
       seconds ^. aNode . aTy == TyPrim Pact.TyDecimal -> do

--- a/src/Pact/Analyze/Types/Capability.hs
+++ b/src/Pact/Analyze/Types/Capability.hs
@@ -13,6 +13,8 @@ import qualified Data.Map.Strict              as Map
 import           Data.SBV                     (Mergeable(..), sFalse)
 import           Data.Type.Equality           ((:~:) (Refl))
 
+import           Pact.Types.Pretty
+
 import           Pact.Analyze.LegacySFunArray (eitherArray, mkSFunArray)
 import           Pact.Analyze.Types.Shared
 import           Pact.Analyze.Types.Types
@@ -27,6 +29,9 @@ instance Show Capability where
     . showsPrec 11 sch
     . showChar ' '
     . showsPrec 11 capName
+
+instance Pretty Capability where
+  pretty (Capability _ (CapName cn)) = pretty cn
 
 -- | The index into the family that is a 'Capability'. Think of this of the
 -- arguments to a particular call of a capability.

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -431,6 +431,9 @@ class HasAnalyzeEnv a where
   currentPactId :: Lens' a (S Integer)
   currentPactId = analyzeEnv.aePactMetadata.pmPactId
 
+  activeGrants :: Lens' a TokenGrants
+  activeGrants = analyzeEnv.aeActiveGrants
+
 instance HasAnalyzeEnv AnalyzeEnv where analyzeEnv = id
 instance HasAnalyzeEnv QueryEnv   where analyzeEnv = qeAnalyzeEnv
 

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -1309,7 +1309,7 @@ data Term (a :: Ty) where
   -- Capabilities
   WithCapability  :: ETerm      -> Term a            -> Term a
   Granting        :: Capability -> [VarId] -> Term a -> Term a
-  HasGrant        :: Capability -> [(Text, VarId)] -> Term 'TyBool
+  HasGrant        :: TagId -> Capability -> [(Text, VarId)] -> Term 'TyBool
 
   -- Reading from environment
   ReadKeySet      :: Term 'TyStr -> Term 'TyGuard
@@ -1389,11 +1389,13 @@ showsTerm ty p tm = withSing ty $ showParen (p > 10) $ case tm of
     . showsPrec 11 b
     . showChar ' '
     . showsPrec 11 c
-  HasGrant a b ->
+  HasGrant a b c ->
       showString "HasGrant "
     . showsPrec 11 a
     . showChar ' '
     . showsPrec 11 b
+    . showChar ' '
+    . showsPrec 11 c
   MkKsRefGuard a ->
       showString "MkKsRefGuard "
     . showsPrec 11 a
@@ -1502,18 +1504,15 @@ prettyTerm ty = \case
     , pretty $ fmap snd x
     ]
 
-  --
-  -- TODO: perhaps track whether -guard or -keyset was used for this?
-  --
   Enforce _ (GuardPasses _ x) -> parensSep ["enforce-guard", pretty x]
-  Enforce _ (HasGrant c vs)   -> parensSep ["require-capability", parensSep (pretty c : map (pretty . fst) vs)]
+  Enforce _ (HasGrant _ c vs) -> parensSep ["require-capability", parensSep (pretty c : map (pretty . fst) vs)]
   Enforce _ x                 -> parensSep ["enforce", pretty x]
   GuardPasses _ _
     -> error "GuardPasses should only appear inside of an Enforce"
 
   WithCapability a x   -> parensSep ["with-capability", pretty a, prettyTerm ty x]
   Granting _ _ x       -> prettyTerm ty x
-  HasGrant _ _         -> error "HasGrant should only appear inside of an Enforce"
+  HasGrant _ _ _       -> error "HasGrant should only appear inside of an Enforce"
   Read _ _ tab x       -> parensSep ["read", pretty tab, pretty x]
   Write ty' _ _ tab x y -> parensSep ["write", pretty tab, pretty x, singPrettyTm ty' y]
   PactVersion          -> parensSep ["pact-version"]

--- a/src/Pact/Analyze/Types/Model.hs
+++ b/src/Pact/Analyze/Types/Model.hs
@@ -86,6 +86,7 @@ data TraceEvent
   | TraceSubpathStart Path
   | TracePushScope Natural ScopeType [Located Binding]
   | TracePopScope Natural ScopeType TagId EType
+  | TraceRequireGrant Recoverability CapName [Located Binding] (Located TagId)
   deriving (Eq, Show)
 
 -- | An @ExecutionGraph@ is produced by translation, and contains all
@@ -122,6 +123,14 @@ data GuardEnforcement
     }
   deriving (Eq, Show)
 
+data GrantRequest
+  = GrantRequest
+    { _grCapability :: CapName
+    -- TODO: args, probably.
+    , _grSuccess    :: SBV Bool
+    }
+  deriving (Eq, Show)
+
 data ModelTags (c :: Concreteness)
   = ModelTags
     { _mtVars              :: Map VarId (Located (Unmunged, TVal))
@@ -134,6 +143,8 @@ data ModelTags (c :: Concreteness)
     -- ^ one per non-keyset enforcement
     , _mtGuardEnforcements :: Map TagId (Located GuardEnforcement)
     -- ^ one per each guard enforcement.
+    , _mtGrantRequests     :: Map TagId (Located GrantRequest)
+    -- ^ one per each require-capability call
     , _mtResult            :: (TagId, Located TVal)
     -- ^ return value of the function being checked
     , _mtPaths             :: Map Path (SBV Bool)
@@ -178,5 +189,6 @@ makePrisms ''TraceEvent
 makeLenses ''ExecutionGraph
 makeLenses ''Access
 makeLenses ''GuardEnforcement
+makeLenses ''GrantRequest
 makeLenses ''ModelTags
 makeLenses ''Model

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -699,8 +699,11 @@ newtype VarId
 -- unique identifier. These names are generated upstream in the typechecker
 -- (using 'freshId').
 newtype Munged
-  = Munged Text
+  = Munged { _mungedName :: Text }
   deriving (Eq, Show)
+
+instance Pretty Munged where
+  pretty (Munged nm) = pretty nm
 
 -- | A user-supplied (i.e. non-unique) identifer name.
 newtype Unmunged

--- a/tests/Analyze/Eval.hs
+++ b/tests/Analyze/Eval.hs
@@ -102,7 +102,7 @@ analyzeEval' etm ty (GenState _ registryKSs txKSs txDecs txInts) = do
       args   = Map.empty
       state0 = mkInitialAnalyzeState tables caps
 
-      tags = ModelTags Map.empty Map.empty Map.empty Map.empty Map.empty
+      tags = ModelTags Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty
         -- this 'Located TVal' is never forced so we don't provide it
         (error "analyzeEval: Located TVal unexpectedly forced")
         Map.empty Map.empty

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -919,6 +919,53 @@ spec = describe "analyze" $ do
           |]
     expectPass code $ Valid Success'
 
+  describe "compose-capability grants a capability" $ do
+    let code =
+          [text|
+            (defcap FOO (i:integer)
+              (if (> i 0)
+                (compose-capability (BAR false))
+                false))
+
+            (defcap BAR (b:bool)
+              true)
+
+            (defun test:bool ()
+              (with-capability (FOO 2)
+                (require-capability (BAR false))))
+          |]
+    expectPass code $ Valid Success'
+
+  describe "compose-capability can fail" $ do
+    let code =
+          [text|
+            (defcap FOO (i:integer)
+              (compose-capability (BAR false)))
+
+            (defcap BAR (b:bool)
+              (enforce b "enforce failed"))
+
+            (defun test:bool ()
+              (with-capability (FOO 2)
+                (require-capability (BAR false))))
+          |]
+    expectPass code $ Valid Abort'
+
+  describe "compose-capability only grants for specific arguments" $ do
+    let code =
+          [text|
+            (defcap FOO (i:integer)
+              (compose-capability (BAR i)))
+
+            (defcap BAR (i:integer)
+              true)
+
+            (defun test:bool ()
+              (with-capability (FOO 2)
+                (require-capability (BAR 3))))
+          |]
+    expectPass code $ Valid Abort'
+
   describe "enforce-one.1" $ do
     let code =
           [text|

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -919,7 +919,7 @@ spec = describe "analyze" $ do
           |]
     expectPass code $ Valid Success'
 
-  describe "compose-capability grants a capability" $ do
+  describe "compose-capability grants an additional capability" $ do
     let code =
           [text|
             (defcap FOO (i:integer)
@@ -932,6 +932,7 @@ spec = describe "analyze" $ do
 
             (defun test:bool ()
               (with-capability (FOO 2)
+                (require-capability (FOO 2))
                 (require-capability (BAR false))))
           |]
     expectPass code $ Valid Success'

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -858,13 +858,10 @@ spec = describe "analyze" $ do
               (require-capability (CAP 100)))
 
             (defun test:bool ()
-              @model [(property (authorized-by "foo"))]
               (with-capability (CAP 100)
                 (do-require)))
           |]
-    expectPass code $ Satisfiable Success'
-    expectPass code $ Valid $ Success' .=> Inj (GuardPassed "foo")
-    expectVerified code
+    expectPass code $ Valid $ Inj (GuardPassed "foo") .=> Success'
 
   describe "enforce-one.1" $ do
     let code =

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -11,7 +11,6 @@
 
 module AnalyzeSpec (spec) where
 
-
 import           Control.Lens                 (at, findOf, ix, matching, (&),
                                                (.~), (^.), (^..), _Left)
 import           Control.Monad                (unless)
@@ -983,6 +982,21 @@ spec = describe "analyze" $ do
                 ; FOO and BAR are granted here.
                 true))
           |]
+    expectPass code $ Valid Abort'
+
+  describe "compose-capability calls produce return values" $ do
+    let code =
+          [text|
+            (defcap BAR ()
+              false)
+            (defcap FOO ()
+              (enforce (compose-capability (BAR)) "BAR returned false"))
+
+            (defun test:bool ()
+              (with-capability (FOO)
+                true))
+          |]
+
     expectPass code $ Valid Abort'
 
   describe "enforce-one.1" $ do

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -967,6 +967,24 @@ spec = describe "analyze" $ do
           |]
     expectPass code $ Valid Abort'
 
+  describe "capabilities are not granted until the body of with-capability" $ do
+    let code =
+          [text|
+            (defcap BAR ()
+              true)
+
+            (defcap FOO ()
+              (compose-capability (BAR))
+              ; BAR is not yet granted here:
+              (require-capability (BAR)))
+
+            (defun test:bool ()
+              (with-capability (FOO)
+                ; FOO and BAR are granted here.
+                true))
+          |]
+    expectPass code $ Valid Abort'
+
   describe "enforce-one.1" $ do
     let code =
           [text|

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -863,6 +863,18 @@ spec = describe "analyze" $ do
           |]
     expectPass code $ Valid $ Inj (GuardPassed "foo") .=> Success'
 
+  describe "requesting token that was not granted for the same args" $ do
+    let code =
+          [text|
+            (defcap CAP (i:integer)
+              true)
+
+            (defun test:bool ()
+              (with-capability (CAP 2)
+                (require-capability (CAP 1))))
+          |]
+    expectPass code $ Valid Abort'
+
   describe "enforce-one.1" $ do
     let code =
           [text|


### PR DESCRIPTION
- `compose-capability` support
- `require-capability` support
- tagging and model output for `require-capability` calls
- fix return value tagging for scopes which have zero bindings
- refactor binding translation to use continuation-passing style
