### PR TITLE
Remove support for non-string keys in objects (also safe TObject)

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -898,7 +898,7 @@ pact> (= [1 2 3] [1 2 3])
 true
 pact> (= 'foo "foo")
 true
-pact> (= { 1: 2 } { 1: 2})
+pact> (= { 'a: 2 } { 'a: 2})
 true
 ```
 
@@ -1383,6 +1383,14 @@ Query gas state, or set it to GAS.
 
 
 Set environment gas limit to LIMIT.
+
+
+### env-gasmodel {#env-gasmodel}
+
+*model*&nbsp;`string` *&rarr;*&nbsp;`string`
+
+
+Update gas model to the model named MODEL.
 
 
 ### env-gasprice {#env-gasprice}

--- a/examples/accounts/accounts.pact
+++ b/examples/accounts/accounts.pact
@@ -20,7 +20,7 @@
      ccy:string
      rowguard:guard
      date:time
-     data
+     data:object
      )
 
   (deftable accounts:{account}
@@ -43,7 +43,7 @@
       , "ccy": ccy
       , "rowguard": guard
       , "date": date
-      , "data": "Created account"
+      , "data": { "note": "Created account" }
       }
     )))
 
@@ -82,7 +82,7 @@
               { "balance": amount
               , "amount": amount
               , "date": date
-              , "data": "Admin account funding" }
+              , "data": { "note": "Admin account funding" } }
       )))
 
   (defun read-all ()
@@ -96,18 +96,18 @@
         (debit payer amount date
           { "payee": payee
           , "payee-entity": payee-entity
-          , PACT_REF: (pact-id)
+          , "ref": (pact-id)
           }))
       (with-capability (TRANSFER)
         (credit payer amount date
-          { PACT_REF: (pact-id), "note": "rollback" })))
+          { "ref": (pact-id), "note": "rollback" })))
 
     (step payee-entity
       (with-capability (TRANSFER)
         (credit payee amount date
           { "payer": payer
           , "payer-entity": payer-entity
-          , PACT_REF: (pact-id)
+          , "ref": (pact-id)
           })))
   )
 
@@ -140,11 +140,6 @@
               , "data": data
               }
       )))
-
-  (defconst PACT_REF "ref")
-
-
-
 
 
   (defconst ESCROW_ACCT "escrow-account")
@@ -209,7 +204,7 @@
         , "ccy": ccy
         , "rowguard": (create-pact-guard pfx)
         , "date": (get-system-time)
-        , "data": "Created pact account"
+        , "data": { "note": "Created pact account" }
         }
       )
       a))

--- a/examples/accounts/accounts.repl
+++ b/examples/accounts/accounts.repl
@@ -15,7 +15,7 @@
 (load "accounts.pact")
 (commit-tx)
 (verify 'accounts)
-(expect "test const evaluation" "ref" accounts.PACT_REF)
+
 (env-data { "123-keyset": { "keys" : ["user123"], "pred": "keys-all" },
              "456-keyset": { "keys": ["user456"], "pred": "keys-any" } })
 (begin-tx)

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -250,7 +250,7 @@ pattern AST_Take node num list <- App node (NativeFunc SListTake) [num, list]
 pattern AST_MakeList :: a -> AST a -> AST a -> AST a
 pattern AST_MakeList node num val <- App node (NativeFunc SMakeList) [num, val]
 
-pattern AST_Obj :: forall a. a -> [(AST a, AST a)] -> AST a
+pattern AST_Obj :: forall a. a -> [(Lang.FieldKey, AST a)] -> AST a
 pattern AST_Obj objNode kvs <- Object objNode kvs
 
 pattern AST_List :: forall a. a -> [AST a] -> AST a

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -1069,13 +1069,9 @@ translateNode astNode = withAstContext astNode $ case astNode of
       _ -> throwError' $ TypeError node
 
   AST_Obj _node kvs -> do
-    kvs' <- for kvs $ \(k, v) -> do
-      k' <- case k of
-        AST_Lit (LString t) -> pure t
-        -- TODO: support non-const keys
-        _                   -> throwError' $ NonConstKey k
+    kvs' <- for kvs $ \(Pact.FieldKey k, v) -> do
       v' <- translateNode v
-      pure (k', v')
+      pure (k, v')
     Some objTy litObj
       <- mkLiteralObject (fmap throwError' . SortLiteralObjError) kvs'
     pure $ Some objTy $ CoreTerm litObj

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -300,11 +300,11 @@ listLiteral = withList Brackets $ \ListExp{..} -> do
 objectLiteral :: Compile (Term Name)
 objectLiteral = withList Braces $ \ListExp{..} -> do
   let pair = do
-        key <- valueLevel
+        key <- FieldKey <$> str
         val <- sep Colon *> valueLevel
         return (key,val)
   ps <- (pair `sepBy` sep Comma) <* eof
-  return $ TObject ps TyAny _listInfo
+  return $ TObject (Object ps TyAny _listInfo) _listInfo
 
 literal :: Compile (Term Name)
 literal = lit >>= \LiteralExp{..} ->

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -57,7 +57,7 @@ import qualified Data.Text as T (isInfixOf, length, all, splitOn, null, append, 
 import Safe hiding (atDef)
 import Control.Arrow hiding (app)
 import Data.Foldable
-import Data.Aeson hiding ((.=))
+import Data.Aeson hiding ((.=),Object)
 import Data.List
 import Data.Function (on)
 import Data.ByteString.Lazy (toStrict)
@@ -514,23 +514,29 @@ filter' i as = argsError' i as
 length' :: RNativeFun e
 length' _ [TList ls _ _] = return $ toTerm (length ls)
 length' _ [TLitString s] = return $ toTerm (T.length s)
-length' _ [TObject ps _ _] = return $ toTerm (length ps)
+length' _ [TObject (Object ps _ _) _] = return $ toTerm (length ps)
 length' i as = argsError i as
 
 take' :: RNativeFun e
 take' _ [TLitInteger c',TList l t _] = return $ TList (tord take c' l) t def
 take' _ [TLitInteger c',TLitString l] = return $ toTerm $ pack $ tord take c' (unpack l)
-take' _ [l@TList {},TObject {..}] =
-  return $ toTObject _tObjectType def $ (`filter` _tObject) $ \(k,_) -> searchTermList k (_tList l)
+take' _ [TList {..},TObject Object {..} _] = asKeyList _tList >>= \l ->
+  return $ toTObject _oObjectType def $ (`filter` _oObject) $ \(k,_) -> elem k l
 
 take' i as = argsError i as
 
 drop' :: RNativeFun e
 drop' _ [TLitInteger c',TList l t _] = return $ TList (tord drop c' l) t def
 drop' _ [TLitInteger c',TLitString l] = return $ toTerm $ pack $ tord drop c' (unpack l)
-drop' _ [l@TList {},TObject {..}] =
-  return $ toTObject _tObjectType def $ (`filter` _tObject) $ \(k,_) -> not $ searchTermList k (_tList l)
+drop' _ [TList {..},TObject Object {..} _] = asKeyList _tList >>= \l ->
+  return $ toTObject _oObjectType def $ (`filter` _oObject) $ \(k,_) -> not $ elem k l
 drop' i as = argsError i as
+
+asKeyList :: [Term Name] -> Eval e [FieldKey]
+asKeyList = mapM $ \t -> case t of
+  TLitString k -> return $ FieldKey k
+  _ -> evalError (_tInfo t) "String required"
+
 
 tord :: (Int -> [a] -> [a]) -> Integer -> [a] -> [a]
 tord f c' l | c' >= 0 = f (fromIntegral c') l
@@ -542,16 +548,18 @@ at' _ [li@(TLitInteger idx),TList ls _ _] =
       Just t -> return t
       Nothing -> evalError (_tInfo li) $ "at: bad index " <>
         pretty idx <> ", length " <> pretty (length ls)
-at' _ [idx,TObject ls _ _] = lookupObj idx ls
+at' _ [idx,TObject (Object ls _ _) _] = lookupObj idx ls
 at' i as = argsError i as
 
-lookupObj :: (Eq n, Pretty n) => Term n -> [(Term n, Term n)] -> Eval m (Term n)
-lookupObj idx ls = case lookup (unsetInfo idx) (map (first unsetInfo) ls) of
+lookupObj :: Term n -> [(FieldKey, Term n)] -> Eval m (Term n)
+lookupObj t@(TLitString idx) ls = case lookup (FieldKey idx) ls of
   Just v -> return v
-  Nothing -> evalError (_tInfo idx) $ "at: key not found: " <> pretty idx
+  Nothing -> evalError (_tInfo t) $ "key not found in object: " <> pretty idx
+lookupObj t _ = evalError (_tInfo t) $ "object lookup only supported with strings"
 
 remove :: RNativeFun e
-remove _ [key,TObject ps t _] = return $ TObject (filter (\(k,_) -> unsetInfo key /= unsetInfo k) ps) t def
+remove _ [TLitString key,TObject (Object ps t _) _] = return $ (`TObject` def) $
+  Object (filter (\(k,_) -> FieldKey key /= k) ps) t def
 remove i as = argsError i as
 
 compose :: NativeFun e
@@ -587,12 +595,8 @@ bind i as@[src,TBinding ps bd (BindSchema _) bi] = gasUnreduced i as $
 bind i as = argsError' i as
 
 bindObjectLookup :: Term Name -> Eval e (Text -> Maybe (Term Ref))
-bindObjectLookup TObject {..} = do
-  !m <- fmap M.fromList $ forM _tObject $ \(k,v) -> case k of
-    TLitString k' -> return (k',liftTerm v)
-    tk -> evalError _tInfo $
-      "Bad object (non-string key) in bind: " <> pretty tk
-  return (\s -> M.lookup s m)
+bindObjectLookup (TObject (Object o _ _) _) =
+  return $ \s -> M.lookup s $ M.fromList $ map (asString *** liftTerm) o
 bindObjectLookup t = evalError (_tInfo t) $
   "bind: expected object: " <> pretty t
 
@@ -604,10 +608,6 @@ listModules :: RNativeFun e
 listModules _ _ = do
   mods <- view $ eeRefStore.rsModules
   return $ toTermList tTyString $ map asString $ M.keys mods
-
-unsetInfo :: Term a -> Term a
-unsetInfo a' = set tInfo def a'
-{-# INLINE unsetInfo #-}
 
 yield :: RNativeFun e
 yield i [t@TObject {}] = do
@@ -629,7 +629,7 @@ resume i as = argsError' i as
 
 where' :: NativeFun e
 where' i as@[k',app@TApp{},r'] = gasUnreduced i as $ ((,) <$> reduce k' <*> reduce r') >>= \kr -> case kr of
-  (k,r@TObject {}) -> lookupObj k (_tObject r) >>= \v -> apply (_tApp app) [v]
+  (k,r@TObject {}) -> lookupObj k (_oObject $ _tObject r) >>= \v -> apply (_tApp app) [v]
   _ -> argsError' i as
 where' i as = argsError' i as
 
@@ -656,7 +656,7 @@ sort' _ [fields@TList{},l@TList{}]
       sortPairs <- forM (_tList l) $ \el -> case firstOf tObject el of
         Nothing -> evalError (_tInfo l) $ "Non-object found: " <> pretty el
         Just o -> fmap ((,el) . reverse) $ (\f -> foldM f [] (_tList fields)) $ \lits fld -> do
-          v <- lookupObj fld o
+          v <- lookupObj fld (_oObject o)
           case firstOf tLiteral v of
             Nothing -> evalError (_tInfo l) $
               "Non-literal found at field " <> pretty fld <>
@@ -693,9 +693,9 @@ enforceVersion i as = case as of
 
 contains :: RNativeFun e
 contains _i [val,TList {..}] = return $ toTerm $ searchTermList val _tList
-contains _i [k,TObject {..}] = return $ toTerm $ foldl search False _tObject
+contains _i [TLitString k,TObject (Object {..}) _] = return $ toTerm $ foldl search False _oObject
   where search True _ = True
-        search _ (t,_) = t `termEq` k
+        search _ (FieldKey t,_) = t == k
 contains _i [TLitString s,TLitString t] = return $ toTerm $ T.isInfixOf s t
 contains i as = argsError i as
 

--- a/src/Pact/Native/Ops.hs
+++ b/src/Pact/Native/Ops.hs
@@ -60,10 +60,10 @@ addDef = defRNative "+" plus plusTy
       (a <> b)
       (if aty == bty then aty else TyAny)
       def
-    plus _ [TObject as aty _,TObject bs bty _] =
+    plus _ [TObject (Object as aty _) _,TObject (Object bs bty _) _] =
       let reps (a,b) = (renderCompactText a,(a,b))
           mapit = M.fromList . map reps
-      in return $ TObject
+      in return $ (`TObject` def) $ Object
            (M.elems $ M.union (mapit as) (mapit bs))
            (if aty == bty then aty else TyAny)
            def
@@ -155,7 +155,7 @@ lteDef = defCmp "<=" (cmp (`elem` [LT,EQ]))
 
 eqDef :: NativeDef
 eqDef = defRNative "=" (eq id) eqTy
-  ["(= [1 2 3] [1 2 3])", "(= 'foo \"foo\")", "(= { 1: 2 } { 1: 2})"]
+  ["(= [1 2 3] [1 2 3])", "(= 'foo \"foo\")", "(= { 'a: 2 } { 'a: 2})"]
   "True if X equals Y."
 
 neqDef :: NativeDef

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -316,10 +316,10 @@ pactState i [] = do
   e <- use evalPactExec
   case e of
     Nothing -> evalError' i "pact-state: no pact exec in context"
-    Just PactExec{..} -> return $ (\o -> TObject o TyAny def)
-      [(tStr "yield",fromMaybe (toTerm False) _peYield)
-      ,(tStr "executed",toTerm _peExecuted)
-      ,(tStr "step",toTerm _peStep)]
+    Just PactExec{..} -> return $ toTObject TyAny def $
+      [("yield",fromMaybe (toTerm False) _peYield)
+      ,("executed",toTerm _peExecuted)
+      ,("step",toTerm _peStep)]
 pactState i as = argsError i as
 
 txmsg :: Maybe Text -> Maybe TxId -> Text -> Term Name

--- a/src/Pact/Types/Persistence.hs
+++ b/src/Pact/Types/Persistence.hs
@@ -37,7 +37,8 @@ import Control.Concurrent.MVar (MVar)
 import Control.DeepSeq (NFData)
 import Control.Lens (makeLenses)
 import Control.Monad (forM)
-import Data.Aeson
+import Data.Aeson hiding (Object)
+import qualified Data.Aeson as A
 import Data.Aeson.Types (Parser)
 import qualified Data.ByteString.Lazy.UTF8 as BSL
 import Data.Decimal (Decimal,DecimalRaw(..))
@@ -78,7 +79,7 @@ integerCodec = Codec encodeInteger decodeInteger
                         else object [ field .= show i ]
     {-# INLINE encodeInteger #-}
     decodeInteger (Number i) = return (round i)
-    decodeInteger (Object o) = do
+    decodeInteger (A.Object o) = do
       s <- o .: field
       case readMaybe (unpack s) of
         Just i -> return i
@@ -181,7 +182,7 @@ instance FromJSON Persistable where
     parseJSON (String s) = return (PLiteral (LString s))
     parseJSON (Number n) = return (PLiteral (LInteger (round n)))
     parseJSON (Bool b) = return (PLiteral (LBool b))
-    parseJSON v@Object {} = (PLiteral . LInteger <$> decoder integerCodec v) <|>
+    parseJSON v@A.Object {} = (PLiteral . LInteger <$> decoder integerCodec v) <|>
                             (PLiteral . LDecimal <$> decoder decimalCodec v) <|>
                             (PLiteral . LTime <$> decoder timeCodec v) <|>
                             (PValue <$> decoder valueCodec v) <|>

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -37,7 +37,6 @@ module Pact.Types.Runtime
    Capabilities(..),capGranted,capComposed,
    NamespacePolicy(..), nsPolicy,
    permissiveNamespacePolicy,
-   SPVSupport(..),
    module Pact.Types.Lang,
    module Pact.Types.Util,
    module Pact.Types.Persistence,
@@ -192,11 +191,6 @@ class PureNoDb e
 -- | Marker class for 'PReadOnly' environments.
 -- SysRead supports pure operations as well.
 class PureNoDb e => PureSysRead e
-
-
-newtype SPVSupport = SPVSupport {
-  _spvSupport :: Text -> (Term Name -> IO (Either Text (Term Name)))
-  }
 
 
 -- | Interpreter reader environment, parameterized over back-end MVar state type.

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -37,6 +37,7 @@ module Pact.Types.Runtime
    Capabilities(..),capGranted,capComposed,
    NamespacePolicy(..), nsPolicy,
    permissiveNamespacePolicy,
+   SPVSupport(..),
    module Pact.Types.Lang,
    module Pact.Types.Util,
    module Pact.Types.Persistence,
@@ -191,6 +192,11 @@ class PureNoDb e
 -- | Marker class for 'PReadOnly' environments.
 -- SysRead supports pure operations as well.
 class PureNoDb e => PureSysRead e
+
+
+newtype SPVSupport = SPVSupport {
+  _spvSupport :: Text -> (Term Name -> IO (Either Text (Term Name)))
+  }
 
 
 -- | Interpreter reader environment, parameterized over back-end MVar state type.

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -56,11 +56,13 @@ module Pact.Types.Term
    Def(..),dDefBody,dDefName,dDefType,dMeta,dFunType,dInfo,dModule,
    Example(..),
    derefDef,
+   Object(..),oObject,oObjectType,oInfo,
+   FieldKey(..),
    Term(..),
    tApp,tBindBody,tBindPairs,tBindType,tConstArg,tConstVal,
    tDef,tMeta,tFields,tFunTypes,tHash,tInfo,tGuard,
    tListType,tList,tLiteral,tModuleBody,tModuleDef,tModule,tUse,
-   tNativeDocs,tNativeFun,tNativeName,tNativeExamples,tNativeTopLevelOnly,tObjectType,tObject,tSchemaName,
+   tNativeDocs,tNativeFun,tNativeName,tNativeExamples,tNativeTopLevelOnly,tObject,tSchemaName,
    tStepEntity,tStepExec,tStepRollback,tTableName,tTableType,tValue,tVar,
    ToTerm(..),
    toTermList,toTObject,toTList,
@@ -82,7 +84,8 @@ import Bound
 import Data.Text (Text,pack)
 import qualified Data.Text as T
 import Data.Text.Encoding
-import Data.Aeson hiding (pairs)
+import Data.Aeson hiding (pairs,Object)
+import qualified Data.Aeson as A
 import qualified Data.ByteString.UTF8 as BS
 import Data.String
 import Data.Default
@@ -687,8 +690,8 @@ instance Show1 Term where
       . showsPrec 11 _tInfo
     TObject{..} ->
         showString "TObject"
-      . liftShowList2 shows1 showList1 shows1 showList1 _tObject
-      . shows2 11 _tObjectType
+      . shows1 11 _tObject
+      . showChar ' '
       . showsPrec 11 _tInfo
     TSchema{..} ->
         showString "TSchema "
@@ -770,6 +773,20 @@ instance Pretty Example where
 instance IsString Example where
   fromString = ExecExample . fromString
 
+newtype FieldKey = FieldKey Text
+  deriving (Eq,Ord,IsString,AsString,ToJSON,FromJSON,Show)
+instance Pretty FieldKey where
+  pretty (FieldKey k) = dquotes $ pretty k
+
+data Object n = Object
+  { _oObject :: ![(FieldKey,Term n)]
+  , _oObjectType :: !(Type (Term n))
+  , _oInfo :: !Info
+  } deriving (Functor,Foldable,Traversable,Eq,Show)
+instance Pretty n => Pretty (Object n) where
+  pretty (Object bs _ _) = annotate Val $ commaBraces $
+      fmap (\(a, b) -> pretty a <> ": " <> pretty b) bs
+
 -- | Pact evaluable term.
 data Term n =
     TModule {
@@ -817,8 +834,7 @@ data Term n =
     , _tInfo :: !Info
     } |
     TObject {
-      _tObject :: ![(Term n,Term n)]
-    , _tObjectType :: !(Type (Term n))
+      _tObject :: !(Object n)
     , _tInfo :: !Info
     } |
     TSchema {
@@ -891,8 +907,7 @@ instance Pretty n => Pretty (Term n) where
       [ commaBraces $ pairs <&> \(arg, body') -> pretty arg <+> pretty body'
       , pretty $ unscope body
       ]
-    TObject bs _ _ -> annotate Val $ commaBraces $
-      fmap (\(a, b) -> pretty a <> ": " <> pretty b) bs
+    TObject o _ -> pretty o
     TLiteral l _ -> annotate Val $ pretty l
     TGuard k _ -> pretty k
     TUse u _ -> pretty u
@@ -938,8 +953,8 @@ instance Eq1 Term where
   liftEq eq (TBinding a b c d) (TBinding m n o p) =
     liftEq (\(w,x) (y,z) -> liftEq (liftEq eq) w y && liftEq eq x z) a m &&
     liftEq eq b n && liftEq (liftEq (liftEq eq)) c o && d == p
-  liftEq eq (TObject a b c) (TObject m n o) =
-    liftEq (\(w,x) (y,z) -> liftEq eq w y && liftEq eq x z) a m && liftEq (liftEq eq) b n && c == o
+  liftEq eq (TObject (Object a b c) d) (TObject (Object m n o) p) =
+    liftEq (\(w,x) (y,z) -> w == y && liftEq eq x z) a m && liftEq (liftEq eq) b n && c == o && d == p
   liftEq _ (TLiteral a b) (TLiteral m n) =
     a == m && b == n
   liftEq _ (TGuard a b) (TGuard m n) =
@@ -971,7 +986,7 @@ instance Monad Term where
     TApp a i >>= f = TApp (fmap (>>= f) a) i
     TVar n i >>= f = (f n) { _tInfo = i }
     TBinding bs b c i >>= f = TBinding (map (fmap (>>= f) *** (>>= f)) bs) (b >>>= f) (fmap (fmap (>>= f)) c) i
-    TObject bs t i >>= f = TObject (map ((>>= f) *** (>>= f)) bs) (fmap (>>= f) t) i
+    TObject (Object bs t oi) i >>= f = TObject (Object (map (id *** (>>= f)) bs) (fmap (>>= f) t) oi) i
     TLiteral l i >>= _ = TLiteral l i
     TGuard k i >>= _ = TGuard k i
     TUse u i >>= _ = TUse u i
@@ -986,7 +1001,7 @@ instance FromJSON (Term n) where
     parseJSON (Bool b) = return $ toTerm b
     parseJSON (String s) = return $ toTerm s
     parseJSON (Array a) = toTList TyAny def . toList <$> mapM parseJSON a
-    parseJSON (Object o) = toTObject TyAny def <$> mapM (traverse parseJSON . first toTerm) (HM.toList o)
+    parseJSON (A.Object o) = toTObject TyAny def <$> mapM (traverse parseJSON . first FieldKey) (HM.toList o)
     parseJSON v = return $ toTerm v
     {-# INLINE parseJSON #-}
 
@@ -994,10 +1009,8 @@ instance Pretty n => ToJSON (Term n) where
     toJSON (TLiteral l _) = toJSON l
     toJSON (TValue v _) = v
     toJSON (TGuard k _) = toJSON k
-    toJSON (TObject kvs _ _) =
-        object $ map (kToJSON *** toJSON) kvs
-            where kToJSON (TLitString s) = s
-                  kToJSON t = renderCompactText t
+    toJSON (TObject (Object kvs _ _) _) =
+        object $ map (asString *** toJSON) kvs
     toJSON (TList ts _ _) = toJSON ts
     toJSON t = toJSON (renderCompactText t)
     {-# INLINE toJSON #-}
@@ -1016,8 +1029,8 @@ instance ToTerm Value where toTerm = (`TValue` def)
 instance ToTerm UTCTime where toTerm = tLit . LTime
 
 
-toTObject :: Type (Term n) -> Info -> [(Term n,Term n)] -> Term n
-toTObject ty i ps = TObject ps ty i
+toTObject :: Type (Term n) -> Info -> [(FieldKey,Term n)] -> Term n
+toTObject ty i ps = TObject (Object ps ty i) i
 
 toTList :: Type (Term n) -> Info -> [Term n] -> Term n
 toTList ty i vs = TList vs ty i
@@ -1048,7 +1061,7 @@ typeof t = case t of
       TBinding {..} -> case _tBindType of
         BindLet -> Left "let"
         BindSchema bt -> Right $ TySchema TyBinding bt def
-      TObject {..} -> Right $ TySchema TyObject _tObjectType def
+      TObject (Object {..}) _ -> Right $ TySchema TyObject _oObjectType def
       TGuard {..} -> Right $ TyPrim $ TyGuard $ Just $ guardTypeOf _tGuard
       TUse {} -> Left "use"
       TValue {} -> Right $ TyPrim TyValue
@@ -1080,9 +1093,9 @@ tStr = toTerm
 -- | Support pact `=` for value-level terms
 termEq :: Eq n => Term n -> Term n -> Bool
 termEq (TList a _ _) (TList b _ _) = length a == length b && and (zipWith termEq a b)
-termEq (TObject a _ _) (TObject b _ _) = length a == length b && all (lkpEq b) a
+termEq (TObject (Object a _ _) _) (TObject (Object b _ _) _) = length a == length b && all (lkpEq b) a
     where lkpEq [] _ = False
-          lkpEq ((k',v'):ts) p@(k,v) | termEq k k' && termEq v v' = True
+          lkpEq ((k',v'):ts) p@(k,v) | k == k' && termEq v v' = True
                                      | otherwise = lkpEq ts p
 termEq (TLiteral a _) (TLiteral b _) = a == b
 termEq (TGuard a _) (TGuard b _) = a == b
@@ -1104,6 +1117,7 @@ makeLenses ''App
 makeLenses ''Def
 makeLenses ''ModuleName
 makePrisms ''DefType
+makeLenses ''Object
 
 deriveEq1 ''App
 deriveEq1 ''BindType
@@ -1112,7 +1126,10 @@ deriveEq1 ''Def
 deriveEq1 ''ModuleDef
 deriveEq1 ''Module
 deriveEq1 ''Governance
+deriveEq1 ''Object
+
 deriveShow1 ''App
+deriveShow1 ''Object
 deriveShow1 ''BindType
 deriveShow1 ''ConstVal
 deriveShow1 ''Def

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -49,7 +49,7 @@ import Control.Monad.State
 import Data.Aeson hiding (Object)
 import Data.Foldable
 
-import Pact.Types.Lang hiding (App)
+import Pact.Types.Lang hiding (App,Object)
 import Pact.Types.Pretty
 import Pact.Types.Native
 
@@ -309,7 +309,7 @@ data AST n =
   } |
   Object {
   _aNode :: n,
-  _aObject :: [(AST n,AST n)]
+  _aObject :: [(FieldKey,AST n)]
   } |
   Prim {
   _aNode :: n,

--- a/tests/pact/ops.repl
+++ b/tests/pact/ops.repl
@@ -13,7 +13,7 @@
   (+ { "a": 4} {"a": true}))
 (expect-failure "+ integer string" (+ 2 "hello"))
 (expect-failure "+ list string" (+ [2] "hello"))
-(expect-failure "+ object decimal" (+ {3: 4} 1.0))
+(expect-failure "+ object decimal" (+ {'a: 4} 1.0))
 
 "===== -"
 (expect "- integer, - integer integer" (- 2) (- 0 2))


### PR DESCRIPTION
Fixes #47 

Came up trying to implement Show1, Eq1 for a safe TObject constructor. Decided it was time to bite the bullet.