### PR TITLE
SPV support with configurable backend

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1532,12 +1532,12 @@ Load and evaluate FILE, resetting repl state beforehand if optional RESET is tru
 
 ### mock-spv {#mock-spv}
 
-*type*&nbsp;`string` *output*&nbsp;`object:[]*` *&rarr;*&nbsp;`string`
+*type*&nbsp;`string` *payload*&nbsp;`object:[]*` *output*&nbsp;`object:[]*` *&rarr;*&nbsp;`string`
 
 
-Instrument a hardcoded return OUTPUT for a particular spv prover TYPE.
+Mock a successful call to 'spv-verify' with TYPE and PAYLOAD to return OUTPUT.
 ```lisp
-(mock-spv "TXOUT" { 'amount: 10.0, 'account: "Dave", 'chainId: 1 })
+(mock-spv "TXOUT" { 'proof: "a54f54de54c54d89e7f" } { 'amount: 10.0, 'account: "Dave", 'chainId: 1 })
 ```
 
 

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1301,6 +1301,18 @@ Specifies and requests grant of CAPABILITY which is an application of a 'defcap'
 (with-capability (UPDATE-USERS id) (update users id { salary: new-salary }))
 ```
 
+## SPV {#SPV}
+
+### verify-spv {#verify-spv}
+
+*type*&nbsp;`string` *payload*&nbsp;`object:[]<in>` *&rarr;*&nbsp;`object:[]<out>`
+
+
+Performs a platform-specific spv proof of type TYPE on PAYLOAD. The format of the PAYLOAD object depends on TYPE, as does the format of the return object. Platforms such as Chainweb will document the specific payload types and return values.
+```lisp
+(verify-spv "TXOUT" (read-msg "proof"))
+```
+
 ## REPL-only functions {#repl-lib}
 
 The following functions are loaded automatically into the interactive REPL, or within script files with a `.repl` extension. They are not available for blockchain-based execution.
@@ -1515,6 +1527,17 @@ pact> (json [{ "name": "joe", "age": 10 } {"name": "mary", "age": 25 }])
 Load and evaluate FILE, resetting repl state beforehand if optional RESET is true.
 ```lisp
 (load "accounts.repl")
+```
+
+
+### mock-spv {#mock-spv}
+
+*type*&nbsp;`string` *output*&nbsp;`object:[]*` *&rarr;*&nbsp;`string`
+
+
+Instrument a hardcoded return OUTPUT for a particular spv prover TYPE.
+```lisp
+(mock-spv "TXOUT" { 'amount: 10.0, 'account: "Dave", 'chainId: 1 })
 ```
 
 

--- a/pact.cabal
+++ b/pact.cabal
@@ -31,6 +31,7 @@ library
                      , Pact.Native.Capabilities
                      , Pact.Native.Db
                      , Pact.Native.Internal
+                     , Pact.Native.SPV
                      , Pact.Native.Time
                      , Pact.Native.Ops
                      , Pact.Native.Keysets

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -75,7 +75,10 @@ loadBenchModule db = do
            (object ["keyset" .= object ["keys" .= ["benchadmin"::Text], "pred" .= (">"::Text)]])
            Nothing
            (initialHashTx H.Blake2b_512)
-  _erRefStore <$> evalExec (setupEvalEnv db entity (Transactional 1) md initRefStore freeGasEnv permissiveNamespacePolicy) pc
+  _erRefStore <$>
+    evalExec (setupEvalEnv db entity (Transactional 1) md initRefStore
+              freeGasEnv permissiveNamespacePolicy noSPVSupport)
+    pc
 
 parseCode :: Text -> IO ParsedCode
 parseCode m = ParsedCode m <$> eitherDie (parseExprs m)
@@ -86,7 +89,10 @@ benchNFIO bname = bench bname . nfIO
 runPactExec :: PactDbEnv e -> RefStore -> ParsedCode -> IO Value
 runPactExec dbEnv refStore pc = do
   t <- Transactional . fromIntegral <$> getCPUTime
-  toJSON . _erOutput <$> evalExec (setupEvalEnv dbEnv entity t (initMsgData (initialHashTx H.Blake2b_512)) refStore freeGasEnv permissiveNamespacePolicy) pc
+  toJSON . _erOutput <$>
+    evalExec (setupEvalEnv dbEnv entity t (initMsgData (initialHashTx H.Blake2b_512))
+              refStore freeGasEnv permissiveNamespacePolicy noSPVSupport)
+    pc
 
 benchKeySet :: KeySet
 benchKeySet = KeySet [PublicKey "benchadmin"] (Name ">" def)

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -75,10 +75,9 @@ loadBenchModule db = do
            (object ["keyset" .= object ["keys" .= ["benchadmin"::Text], "pred" .= (">"::Text)]])
            Nothing
            (initialHashTx H.Blake2b_512)
-  _erRefStore <$>
-    evalExec (setupEvalEnv db entity (Transactional 1) md initRefStore
-              freeGasEnv permissiveNamespacePolicy noSPVSupport)
-    pc
+  let e = setupEvalEnv db entity (Transactional 1) md initRefStore
+          freeGasEnv permissiveNamespacePolicy noSPVSupport
+  _erRefStore <$> evalExec e pc
 
 parseCode :: Text -> IO ParsedCode
 parseCode m = ParsedCode m <$> eitherDie (parseExprs m)
@@ -89,10 +88,9 @@ benchNFIO bname = bench bname . nfIO
 runPactExec :: PactDbEnv e -> RefStore -> ParsedCode -> IO Value
 runPactExec dbEnv refStore pc = do
   t <- Transactional . fromIntegral <$> getCPUTime
-  toJSON . _erOutput <$>
-    evalExec (setupEvalEnv dbEnv entity t (initMsgData (initialHashTx H.Blake2b_512))
-              refStore freeGasEnv permissiveNamespacePolicy noSPVSupport)
-    pc
+  let e = setupEvalEnv dbEnv entity t (initMsgData (initialHashTx H.Blake2b_512))
+          refStore freeGasEnv permissiveNamespacePolicy noSPVSupport
+  toJSON . _erOutput <$> evalExec e pc
 
 benchKeySet :: KeySet
 benchKeySet = KeySet [PublicKey "benchadmin"] (Name ">" def)

--- a/src-ghc/Pact/Interpreter.hs
+++ b/src-ghc/Pact/Interpreter.hs
@@ -99,8 +99,9 @@ setupEvalEnv
   -> RefStore
   -> GasEnv
   -> NamespacePolicy
+  -> SPVSupport
   -> EvalEnv e
-setupEvalEnv dbEnv ent mode msgData refStore gasEnv np =
+setupEvalEnv dbEnv ent mode msgData refStore gasEnv np spv =
   EvalEnv {
     _eeRefStore = refStore
   , _eeMsgSigs = mdSigs msgData
@@ -114,6 +115,7 @@ setupEvalEnv dbEnv ent mode msgData refStore gasEnv np =
   , _eeHash = mdHash msgData
   , _eeGasEnv = gasEnv
   , _eeNamespacePolicy = np
+  , _eeSPVSupport = spv
   }
   where modeToTx (Transactional t) = Just t
         modeToTx Local = Nothing

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -94,7 +94,7 @@ applyExec rk (ExecMsg parsedCode edata) Command{..} = do
   (CommandState refStore pacts) <- liftIO $ readMVar _ceState
   let sigs = userSigsToPactKeySet _cmdSigs
       evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode
-                (MsgData sigs edata Nothing _cmdHash) refStore _ceGasEnv permissiveNamespacePolicy
+                (MsgData sigs edata Nothing _cmdHash) refStore _ceGasEnv permissiveNamespacePolicy noSPVSupport
   EvalResult{..} <- liftIO $ evalExec evalEnv parsedCode
   newCmdPact <- join <$> mapM (handlePactExec _erInput) _erExec
   let newPacts = case newCmdPact of
@@ -138,7 +138,7 @@ applyContinuation rk msg@ContMsg{..} Command{..} = do
               pactStep = Just $ PactStep _cmStep _cmRollback (PactId $ pack $ show _cmTxId) _cpYield
               evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode
                         (MsgData sigs _cmData pactStep _cmdHash) _csRefStore
-                        _ceGasEnv permissiveNamespacePolicy
+                        _ceGasEnv permissiveNamespacePolicy noSPVSupport
           res <- tryAny (liftIO  $ evalContinuation evalEnv _cpContinuation)
 
           -- Update pacts state

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -71,6 +71,7 @@ import Pact.Native.Time
 import Pact.Native.Ops
 import Pact.Native.Keysets
 import Pact.Native.Capabilities
+import Pact.Native.SPV
 import Pact.Types.Runtime
 import Pact.Parse
 import Pact.Types.Version
@@ -85,7 +86,8 @@ natives = [
   timeDefs,
   opDefs,
   keyDefs,
-  capDefs]
+  capDefs,
+  spvDefs]
 
 
 -- | Production native modules as a dispatch map.

--- a/src/Pact/Native/SPV.hs
+++ b/src/Pact/Native/SPV.hs
@@ -4,7 +4,7 @@
 
 
 -- |
--- Module      :  Pact.Native.Capabilities
+-- Module      :  Pact.Native.SPV
 -- Copyright   :  (C) 2019 Stuart Popejoy
 -- License     :  BSD-style (see the file LICENSE)
 -- Maintainer  :  Stuart Popejoy <stuart@kadena.io>

--- a/src/Pact/Native/SPV.hs
+++ b/src/Pact/Native/SPV.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+
+
+-- |
+-- Module      :  Pact.Native.Capabilities
+-- Copyright   :  (C) 2019 Stuart Popejoy
+-- License     :  BSD-style (see the file LICENSE)
+-- Maintainer  :  Stuart Popejoy <stuart@kadena.io>
+--
+-- Builtins for working with SPV proofs.
+--
+
+module Pact.Native.SPV
+  ( spvDefs
+  ) where
+
+import Control.Monad.IO.Class (liftIO)
+import Control.Lens (view)
+import Pact.Native.Internal
+import Pact.Types.Runtime
+import Pact.Types.Pretty
+import Data.Default
+
+
+spvDefs :: NativeModule
+spvDefs =
+  ("SPV",
+   [ verifySPV
+   ])
+
+verifySPV :: NativeDef
+verifySPV =
+  defRNative "verify-spv" verifySPV'
+  (funType (tTyObject (mkTyVar' "out"))
+   [("type", tTyString),
+    ("payload", tTyObject (mkTyVar' "in"))])
+  [LitExample "(verify-spv \"TXOUT\" (read-msg \"proof\"))"]
+  "Performs a platform-specific spv proof of type TYPE on PAYLOAD. \
+  \The format of the PAYLOAD object depends on TYPE, as does the \
+  \format of the return object. Platforms such as Chainweb will \
+  \document the specific payload types and return values."
+  where
+    verifySPV' i [TLitString proofType, TObject{..}] = do
+      view eeSPVSupport >>= \(SPVSupport f) -> liftIO (f proofType _tObject) >>= \r -> case r of
+        Left err -> evalError' i $ "SPV verify failed: " <> pretty err
+        Right o -> return $ TObject o def
+    verifySPV' i as = argsError i as

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -107,9 +107,10 @@ initPureEvalEnv verifyUri = do
   return $ EvalEnv (RefStore nativeDefs mempty) def Null (Just 0)
     def def mv repldb def initialHash freeGasEnv permissiveNamespacePolicy (SPVSupport $ spv mv)
 
+
 spv :: MVar (LibState) -> Text -> Object Name -> IO (Either Text (Object Name))
-spv mv ty _ = readMVar mv >>= \LibState{..} -> case M.lookup ty _rlsMockSPV of
-  Nothing -> return $ Left $ "Unsupported SPV proof type: " <> ty
+spv mv ty pay = readMVar mv >>= \LibState{..} -> case M.lookup (SPVMockKey (ty,pay)) _rlsMockSPV of
+  Nothing -> return $ Left $ "SPV verification failure"
   Just o -> return $ Right o
 
 errToUnit :: Functor f => f (Either e a) -> f (Either () a)

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -45,7 +45,7 @@ import Control.Applicative
 import Control.Lens hiding (op)
 import Control.Monad.Catch
 import Control.Monad.State.Strict
-import Data.Aeson hiding ((.=))
+import Data.Aeson hiding ((.=),Object)
 import qualified Data.Aeson as A
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.UTF8 as BS
@@ -53,6 +53,7 @@ import Data.Char
 import Data.Default
 import Data.List
 import qualified Data.HashMap.Strict as HM
+import qualified Data.Map.Strict as M
 import Prelude hiding (exp)
 import Text.Trifecta as TF hiding (line,err,try,newline)
 import qualified Data.Text as Text
@@ -104,8 +105,12 @@ initPureEvalEnv :: Maybe String -> IO (EvalEnv LibState)
 initPureEvalEnv verifyUri = do
   mv <- initLibState neverLog verifyUri >>= newMVar
   return $ EvalEnv (RefStore nativeDefs mempty) def Null (Just 0)
-    def def mv repldb def initialHash freeGasEnv permissiveNamespacePolicy
+    def def mv repldb def initialHash freeGasEnv permissiveNamespacePolicy (SPVSupport $ spv mv)
 
+spv :: MVar (LibState) -> Text -> Object Name -> IO (Either Text (Object Name))
+spv mv ty _ = readMVar mv >>= \LibState{..} -> case M.lookup ty _rlsMockSPV of
+  Nothing -> return $ Left $ "Unsupported SPV proof type: " <> ty
+  Just o -> return $ Right o
 
 errToUnit :: Functor f => f (Either e a) -> f (Either () a)
 errToUnit a = either (const (Left ())) Right <$> a

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -67,7 +67,7 @@ initLibState loggers verifyUri = do
                 (newLogger loggers "Repl")
                 def def)
   createSchema m
-  return (LibState m Noop def def verifyUri)
+  return (LibState m Noop def def verifyUri M.empty)
 
 -- | Native function with no gas consumption.
 type ZNativeFun e = FunApp -> [Term Ref] -> Eval e (Term Name)
@@ -177,6 +177,10 @@ replDefs = ("Repl",
      "Specify and request grant of CAPABILITY. Once granted, CAPABILITY and any composed capabilities are in scope " <>
      "for the rest of the transaction. Allows direct invocation of capabilities, which is not available in the " <>
      "blockchain environment."
+     ,defZRNative "mock-spv" mockSPV
+      (funType tTyString [("type",tTyString),("output",tTyObject TyAny)])
+      [LitExample "(mock-spv \"TXOUT\" { 'amount: 10.0, 'account: \"Dave\", 'chainId: 1 })"]
+      "Instrument a hardcoded return OUTPUT for a particular spv prover TYPE."
      ])
      where
        json = mkTyVar "a" [tTyInteger,tTyString,tTyTime,tTyDecimal,tTyBool,
@@ -224,10 +228,11 @@ setop v = setLibState $ set rlsOp v
 setenv :: Setter' (EvalEnv LibState) a -> a -> Eval LibState ()
 setenv l v = setop $ UpdateEnv $ Endo (set l v)
 
-{-
-overenv :: Setter' (EvalEnv LibState) a -> (a -> a) -> Eval LibState ()
-overenv l f = setop $ UpdateEnv $ Endo (over l f)
--}
+mockSPV :: RNativeFun LibState
+mockSPV _i [TLitString spvType, TObject out _] = do
+  setLibState $ over rlsMockSPV (M.insert spvType out)
+  return $ tStr $ "Added mock SPV for " <> spvType
+mockSPV i as = argsError i as
 
 formatAddr :: RNativeFun LibState
 #if !defined(ghcjs_HOST_OS)

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -178,9 +178,9 @@ replDefs = ("Repl",
      "for the rest of the transaction. Allows direct invocation of capabilities, which is not available in the " <>
      "blockchain environment."
      ,defZRNative "mock-spv" mockSPV
-      (funType tTyString [("type",tTyString),("output",tTyObject TyAny)])
-      [LitExample "(mock-spv \"TXOUT\" { 'amount: 10.0, 'account: \"Dave\", 'chainId: 1 })"]
-      "Instrument a hardcoded return OUTPUT for a particular spv prover TYPE."
+      (funType tTyString [("type",tTyString),("payload",tTyObject TyAny),("output",tTyObject TyAny)])
+      [LitExample "(mock-spv \"TXOUT\" { 'proof: \"a54f54de54c54d89e7f\" } { 'amount: 10.0, 'account: \"Dave\", 'chainId: 1 })"]
+      "Mock a successful call to 'spv-verify' with TYPE and PAYLOAD to return OUTPUT."
      ])
      where
        json = mkTyVar "a" [tTyInteger,tTyString,tTyTime,tTyDecimal,tTyBool,
@@ -229,8 +229,8 @@ setenv :: Setter' (EvalEnv LibState) a -> a -> Eval LibState ()
 setenv l v = setop $ UpdateEnv $ Endo (set l v)
 
 mockSPV :: RNativeFun LibState
-mockSPV _i [TLitString spvType, TObject out _] = do
-  setLibState $ over rlsMockSPV (M.insert spvType out)
+mockSPV _i [TLitString spvType, TObject payload _, TObject out _] = do
+  setLibState $ over rlsMockSPV (M.insert (SPVMockKey (spvType,payload)) out)
   return $ tStr $ "Added mock SPV for " <> spvType
 mockSPV i as = argsError i as
 

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -33,13 +33,13 @@ import Data.Aeson (eitherDecode,toJSON)
 import qualified Data.Text as Text
 import Data.Text.Encoding
 import Data.Maybe
+import qualified Data.Map as M
 #if defined(ghcjs_HOST_OS)
 import qualified Pact.Analyze.Remote.Client as RemoteClient
 #else
 import Control.Monad.State.Strict (get)
 import Criterion
 import Criterion.Types
-import qualified Data.Map as M
 import qualified Pact.Analyze.Check as Check
 import Statistics.Types (Estimate(..))
 import qualified Pact.Types.Crypto as Crypto

--- a/src/Pact/Repl/Types.hs
+++ b/src/Pact/Repl/Types.hs
@@ -6,7 +6,7 @@ module Pact.Repl.Types
   , TestResult(..)
   , Repl
   , LibOp(..)
-  , LibState(..),rlsPure,rlsOp,rlsTxName,rlsTests,rlsVerifyUri
+  , LibState(..),rlsPure,rlsOp,rlsTxName,rlsTests,rlsVerifyUri,rlsMockSPV
   , Tx(..)
   ) where
 
@@ -17,8 +17,9 @@ import Control.Monad.State.Strict (StateT)
 import Control.Concurrent (MVar)
 import Pact.PersistPactDb (DbEnv)
 import Pact.Persist.Pure (PureDb)
-import Pact.Types.Runtime (EvalEnv,EvalState,Term,Name,FunApp,Info)
+import Pact.Types.Runtime (EvalEnv,EvalState,Term,Name,FunApp,Info,Object)
 import Data.Text (Text)
+import qualified Data.Map.Strict as M
 
 data ReplMode =
     Interactive |
@@ -65,6 +66,7 @@ data LibState = LibState {
     , _rlsTxName :: Maybe Text
     , _rlsTests :: [TestResult]
     , _rlsVerifyUri :: Maybe String
+    , _rlsMockSPV :: M.Map Text (Object Name)
 }
 
 

--- a/src/Pact/Repl/Types.hs
+++ b/src/Pact/Repl/Types.hs
@@ -8,6 +8,7 @@ module Pact.Repl.Types
   , LibOp(..)
   , LibState(..),rlsPure,rlsOp,rlsTxName,rlsTests,rlsVerifyUri,rlsMockSPV
   , Tx(..)
+  , SPVMockKey(..)
   ) where
 
 import Control.Lens (makeLenses)
@@ -17,9 +18,10 @@ import Control.Monad.State.Strict (StateT)
 import Control.Concurrent (MVar)
 import Pact.PersistPactDb (DbEnv)
 import Pact.Persist.Pure (PureDb)
-import Pact.Types.Runtime (EvalEnv,EvalState,Term,Name,FunApp,Info,Object)
+import Pact.Types.Runtime (EvalEnv,EvalState,Term,Name,FunApp,Info,Object,Term(..))
 import Data.Text (Text)
 import qualified Data.Map.Strict as M
+import Pact.Types.Pretty (Pretty,pretty,renderCompactText)
 
 data ReplMode =
     Interactive |
@@ -60,13 +62,21 @@ instance Default LibOp where def = Noop
 
 data Tx = Begin|Commit|Rollback deriving (Eq,Show,Bounded,Enum,Ord)
 
+newtype SPVMockKey = SPVMockKey (Text,Object Name) deriving Show
+instance Pretty SPVMockKey where
+  pretty (SPVMockKey (t,o)) = pretty t <> pretty o
+instance Eq SPVMockKey where
+  a == b = renderCompactText a == renderCompactText b
+instance Ord SPVMockKey where
+  a `compare` b = renderCompactText a `compare` renderCompactText b
+
 data LibState = LibState {
       _rlsPure :: MVar (DbEnv PureDb)
     , _rlsOp :: LibOp
     , _rlsTxName :: Maybe Text
     , _rlsTests :: [TestResult]
     , _rlsVerifyUri :: Maybe String
-    , _rlsMockSPV :: M.Map Text (Object Name)
+    , _rlsMockSPV :: M.Map SPVMockKey (Object Name)
 }
 
 

--- a/tests/pact/spv.repl
+++ b/tests/pact/spv.repl
@@ -1,0 +1,2 @@
+(mock-spv "TXOUT" { "foo": "bar" })
+(expect "exercise mock spv" { "foo": "bar" } (verify-spv "TXOUT" { "baz": "quux" }))

--- a/tests/pact/spv.repl
+++ b/tests/pact/spv.repl
@@ -1,2 +1,4 @@
-(mock-spv "TXOUT" { "foo": "bar" })
-(expect "exercise mock spv" { "foo": "bar" } (verify-spv "TXOUT" { "baz": "quux" }))
+(mock-spv "TXOUT" { "baz": "quux" } { "foo": "bar" })
+(expect-failure "fail on unmocked type" (verify-spv "BLAH" { "baz": "quux" }))
+(expect-failure "fail on unmocked payload" (verify-spv "TXOUT" { "here": "gone" }))
+(expect "succeed with mock" { "foo": "bar" } (verify-spv "TXOUT" { "baz": "quux" }))


### PR DESCRIPTION
Adds builtin `verify-spv` which utilizes supplied backend to operate on an Object payload, and return an object with the proof payload upon success.