### PR TITLE
Fix continuations, integer pact ID

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1353,6 +1353,22 @@ Commit transaction.
 ```
 
 
+### continue-pact {#continue-pact}
+
+*pact-id*&nbsp;`integer` *step*&nbsp;`integer` *&rarr;*&nbsp;`string`
+
+*pact-id*&nbsp;`integer` *step*&nbsp;`integer` *rollback*&nbsp;`bool` *&rarr;*&nbsp;`string`
+
+*pact-id*&nbsp;`integer` *step*&nbsp;`integer` *rollback*&nbsp;`bool` *yielded*&nbsp;`object:[]<{y}>` *&rarr;*&nbsp;`string`
+
+
+Continue previously-initiated pact identified by PACT-ID at STEP, optionally specifying ROLLBACK (default is false), and YIELDED value to be read with 'resume' (if not specified, uses yield in most recent pact exec, if any).
+```lisp
+(continue-pact 2 1 true)
+(continue-pact 2 1 false { "rate": 0.9 })
+```
+
+
 ### env-data {#env-data}
 
 *json*&nbsp;`<a[integer,string,time,decimal,bool,[<l>],object:[]<{o}>,keyset,value]>` *&rarr;*&nbsp;`string`
@@ -1372,7 +1388,7 @@ pact> (env-data { "keyset": { "keys": ["my-key" "admin-key"], "pred": "keys-any"
 *entity*&nbsp;`string` *&rarr;*&nbsp;`string`
 
 
-Set environment confidential ENTITY id, or unset with no argument. Clears any previous pact execution state.
+Set environment confidential ENTITY id, or unset with no argument.
 ```lisp
 (env-entity "my-org")
 (env-entity)
@@ -1442,34 +1458,6 @@ Set transaction signature KEYS.
 ```lisp
 pact> (env-keys ["my-key" "admin-key"])
 "Setting transaction keys"
-```
-
-
-### env-pactid {#env-pactid}
-
- *&rarr;*&nbsp;`string`
-
-*id*&nbsp;`string` *&rarr;*&nbsp;`string`
-
-
-Query environment pact id, or set to ID.
-
-
-### env-step {#env-step}
-
- *&rarr;*&nbsp;`string`
-
-*step-idx*&nbsp;`integer` *&rarr;*&nbsp;`string`
-
-*step-idx*&nbsp;`integer` *rollback*&nbsp;`bool` *&rarr;*&nbsp;`string`
-
-*step-idx*&nbsp;`integer` *rollback*&nbsp;`bool` *resume*&nbsp;`object:[]<{y}>` *&rarr;*&nbsp;`string`
-
-
-Set pact step state. With no arguments, unset step. With STEP-IDX, set step index to execute. ROLLBACK instructs to execute rollback expression, if any. RESUME sets a value to be read via 'resume'.Clears any previous pact execution state.
-```lisp
-(env-step 1)
-(env-step 0 true)
 ```
 
 
@@ -1545,10 +1533,13 @@ Mock a successful call to 'spv-verify' with TYPE and PAYLOAD to return OUTPUT.
 
  *&rarr;*&nbsp;`object:[]*`
 
+*clear*&nbsp;`bool` *&rarr;*&nbsp;`object:[]*`
 
-Inspect state from previous pact execution. Returns object with fields 'yield': yield result or 'false' if none; 'step': executed step; 'executed': indicates if step was skipped because entity did not match.
+
+Inspect state from most recent pact execution. Returns object with fields 'pactId': pact ID; 'yield': yield result or 'false' if none; 'step': executed step; 'executed': indicates if step was skipped because entity did not match. With CLEAR argument, erases pact from repl state.
 ```lisp
 (pact-state)
+(pact-state true)
 ```
 
 

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1364,6 +1364,7 @@ Commit transaction.
 
 Continue previously-initiated pact identified by PACT-ID at STEP, optionally specifying ROLLBACK (default is false), and YIELDED value to be read with 'resume' (if not specified, uses yield in most recent pact exec, if any).
 ```lisp
+(continue-pact 2 1)
 (continue-pact 2 1 true)
 (continue-pact 2 1 false { "rate": 0.9 })
 ```

--- a/examples/accounts/accounts.repl
+++ b/examples/accounts/accounts.repl
@@ -43,52 +43,53 @@
 
 (env-keys ["user123" "accountadmin"])
 (env-entity "us")
+
+; initiate pact with normal execution
 (payment "123" "us" "456" "them" 12.0 (time "2016-07-22T11:26:35Z"))
 (expect "balance of 123 after debit step" 217.0 (with-read accounts "123" { "balance" := b } b))
 
-(env-step 0 true)
-(payment "123" "us" "456" "them" 12.0 (time "2016-07-22T11:26:35Z"))
+; test rollback
+(continue-pact 6 0 true)
 (expect "balance of 123 after rollback" 229.0 (with-read accounts "123" { "balance" := b } b))
 
-(env-step 1)
-(payment "123" "us" "456" "them" 12.0 (time "2016-07-22T11:26:35Z"))
+; test success step 1
+(continue-pact 6 1)
 (expect "balance of 456 unchanged" 5.0 (with-read accounts "456" { "balance" := b } b))
 
 (env-entity "them")
-(payment "123" "us" "456" "them" 12.0 (time "2016-07-22T11:26:35Z"))
+(continue-pact 6 1)
 (expect "balance of 456 after credit step" 17.0 (with-read accounts "456" { "balance" := b } b))
 (commit-tx)
 
 ;; test public pact escrow
 (begin-tx)
 (module test 'k
-  (defconst TIMEOUT (time "2017-01-01T13:00:00Z"))
-  (defun run-escrow () (accounts.two-party-escrow "123" "456" 2.00 TIMEOUT))
-  (defun reset-time () (system.set-system-time (time "2017-01-01T12:00:00Z")))
-  (defun get-balance (acct) (at "balance" (accounts.read-account-user acct)))
-  )
+   (defconst TIMEOUT (time "2017-01-01T13:00:00Z"))
+   (defun run-escrow () (accounts.two-party-escrow "123" "456" 2.00 TIMEOUT))
+   (defun reset-time () (system.set-system-time (time "2017-01-01T12:00:00Z")))
+   (defun get-balance (acct) (at "balance" (accounts.read-account-user acct)))
+   )
 (commit-tx)
 
 (env-keys ["user123"])
-(env-step 0)
 
 (begin-tx)
 (test.reset-time)
 (test.run-escrow)
+
 (expect "2.0 escrowed" 227.0 (test.get-balance "123"))
 (commit-tx)
 
 
 ;;test cancel
 (begin-tx)
-(env-step 0 true)
 ;; debtor cannot cancel
-(expect-failure "creditor cancel pre-timeout" (test.run-escrow))
+(expect-failure "creditor cancel pre-timeout" (continue-pact 8 0 true))
 (expect "still escrowed" 227.0 (test.get-balance "123"))
 
 (system.set-system-time test.TIMEOUT)
 ;; debtor can cancel
-(test.run-escrow)
+(continue-pact 8 0 true)
 (expect "escrow canceled" 229.0 (test.get-balance "123"))
 
 (rollback-tx) ; back to first step
@@ -97,29 +98,26 @@
 ;; creditor can cancel immediately
 (test.reset-time)
 (env-keys ["user456"])
-(env-step 0 true)
-(test.run-escrow)
+(continue-pact 8 0 true)
 (env-keys ["user123"]) ; for balance check
 (expect "escrow canceled" 229.0 (test.get-balance "123"))
 
 (rollback-tx) ; back to first step
 ;; creditor cannot finish alone
-(env-step 1)
 (env-keys ["user456"])
-(expect-failure "creditor cannot finish alone" (test.run-escrow))
+(expect-failure "creditor cannot finish alone" (continue-pact 8 1))
+
 ;; debtor cannot finish alone
-(env-step 1)
 (env-keys ["user123"])
-(expect-failure "debtor cannot finish alone" (test.run-escrow))
+(expect-failure "debtor cannot finish alone" (continue-pact 8 1))
+
 ;; both can, but price cannot be nego'd up
-(env-step 1)
 (env-keys ["user123" "user456"])
 (env-data { "final-price": 2.75 })
-(expect-failure "price cannot nego up" (test.run-escrow))
+(expect-failure "price cannot nego up" (continue-pact 8 1))
 
-(env-step 1)
 (env-data { "final-price": 1.75 })
-(test.run-escrow)
+(continue-pact 8 1)
 (expect "seller paid 1.75" 18.75 (test.get-balance "456"))
 (expect "buyer refunded .25" 227.25 (test.get-balance "123"))
 

--- a/examples/cp/cp.repl
+++ b/examples/cp/cp.repl
@@ -101,19 +101,15 @@
 (runpact-scenario-1 "order2" "cusip2")
 (expect "agent has inventory" 1 (at "qty" (cp.read-inventory "agent" "cusip2")))
 
-(env-step 1)
 (env-keys ["trader-key"])
-(runpact-scenario-1 "order2" "cusip2")
+(continue-pact 5 1)
 (expect "order NEW" ORDER_NEW (at "status" (read-order "order2")))
 
-(env-step 2)
 (env-keys ["agent-key"])
-(runpact-scenario-1 "order2" "cusip2")
+(continue-pact 5 2)
 (expect "trader inventory" 1 (at "qty" (read-inventory "trader" "cusip2")))
 
-(env-step 3)
 (env-keys ["trader-key"])
-(runpact-scenario-1 "order2" "cusip2")
-(env-step 4)
-(runpact-scenario-1 "order2" "cusip2")
+(continue-pact 5 3)
+(continue-pact 5 4)
 (expect "order paid" ORDER_PAID (at "status" (read-order "order2")))

--- a/src-ghc/Pact/ApiReq.hs
+++ b/src-ghc/Pact/ApiReq.hs
@@ -61,7 +61,7 @@ instance FromJSON ApiKeyPair where parseJSON = lensyParseJSON 4
 
 data ApiReq = ApiReq {
   _ylType :: Maybe String,
-  _ylTxId :: Maybe TxId,
+  _ylPactId :: Maybe PactId,
   _ylStep :: Maybe Int,
   _ylRollback :: Maybe Bool,
   _ylResume :: Maybe Value,
@@ -128,7 +128,7 @@ mkExec code mdata pubMeta kps ridm = do
 
 mkApiReqCont :: ApiReq -> [SomeKeyPair] -> FilePath -> IO ((ApiReq,String,Value,PublicMeta),Command Text)
 mkApiReqCont ar@ApiReq{..} kps fp = do
-  txId <- case _ylTxId of
+  txId <- case _ylPactId of
     Just t  -> return t
     Nothing -> dieAR "Expected a 'txid' entry"
 
@@ -151,7 +151,7 @@ mkApiReqCont ar@ApiReq{..} kps fp = do
   let pubMeta = def
   ((ar,"",cdata,pubMeta),) <$> mkCont txId step rollback cdata pubMeta kps _ylNonce
 
-mkCont :: TxId -> Int -> Bool  -> Value -> PublicMeta -> [SomeKeyPair]
+mkCont :: PactId -> Int -> Bool  -> Value -> PublicMeta -> [SomeKeyPair]
   -> Maybe String -> IO (Command Text)
 mkCont txid step rollback mdata pubMeta kps ridm = do
   rid <- maybe (show <$> getCurrentTime) return ridm
@@ -185,7 +185,7 @@ mkKeyPairs keyPairs = traverse mkPair keyPairs
               (expectAddr, actualAddr)
                 | expectAddr == actualAddr  -> return kp
                 | otherwise                 -> dieAR $ "Address provided "
-                                               ++ (show $ toB16Text $ expectAddr)
+                                               ++ show (toB16Text expectAddr)
                                                ++ " does not match actual Address "
                                                ++ show (toB16Text actualAddr)
 

--- a/src-ghc/Pact/Types/Server.hs
+++ b/src-ghc/Pact/Types/Server.hs
@@ -24,7 +24,6 @@
 module Pact.Types.Server
   ( userSigToPactPubKey, userSigsToPactKeySet
   , CommandConfig(..), ccSqlite, ccEntity, ccGasLimit, ccGasRate
-  , CommandPact(..), cpTxId, cpContinuation, cpStepCount, cpStep, cpYield
   , CommandState(..), csRefStore, csPacts
   , CommandEnv(..), ceEntity, ceMode, ceDbEnv, ceState, ceLogger, ceGasEnv
   , CommandM, runCommand, throwCmdEx
@@ -83,18 +82,10 @@ data CommandConfig = CommandConfig {
 $(makeLenses ''CommandConfig)
 
 
-data CommandPact = CommandPact
-  { _cpTxId :: TxId
-  , _cpContinuation :: Term Name
-  , _cpStepCount :: Int
-  , _cpStep :: Int
-  , _cpYield :: Maybe (Term Name)
-  } deriving Show
-$(makeLenses ''CommandPact)
 
 data CommandState = CommandState {
        _csRefStore :: RefStore
-     , _csPacts :: M.Map TxId CommandPact -- comment copied from Kadena code: TODO need hashable for TxId mebbe
+     , _csPacts :: M.Map PactId PactExec
      } deriving Show
 $(makeLenses ''CommandState)
 

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -42,6 +42,7 @@ module Pact.Eval
     ,revokeCapability,revokeAllCapabilities
     ,computeUserAppGas,prepareUserAppArgs,evalUserAppBody
     ,evalByName
+    ,evalContinuation
     ) where
 
 import Control.Lens hiding (DefName)
@@ -273,6 +274,10 @@ eval (TModule (MDInterface m) bod i) =
     writeRow i Write Modules (_interfaceName mangledI) (derefDef <$> govI)
     return (g, msg $ "Loaded interface " <> pretty (_interfaceName mangledI))
 eval t = enscope t >>= reduce
+
+
+evalContinuation :: PactContinuation -> Eval e (Term Name)
+evalContinuation (PactContinuation app) = reduceApp app
 
 
 evalUse :: Use -> Eval e ()
@@ -581,13 +586,13 @@ appCall fa ai as = call (StackFrame (_faName fa) ai (Just (fa,map abbrev as)))
 reduceApp :: App (Term Ref) -> Eval e (Term Name)
 reduceApp (App (TVar (Direct t) _) as ai) = reduceDirect t as ai
 reduceApp (App (TVar (Ref r) _) as ai) = reduceApp (App r as ai)
-reduceApp (App (TDef d@Def{..} _) as ai) = do
+reduceApp (App td@(TDef d@Def{..} _) as ai) = do
   g <- computeUserAppGas d ai
   af <- prepareUserAppArgs d as
   evalUserAppBody d af ai g $ \bod' ->
     case _dDefType of
       Defun -> reduceBody bod'
-      Defpact -> applyPact bod'
+      Defpact -> applyPact (App td (map liftTerm $ fst af) ai) bod'
       Defcap -> evalError ai "Cannot directly evaluate defcap"
 reduceApp (App (TLitString errMsg) _ i) = evalError i $ pretty errMsg
 reduceApp (App r _ ai) = evalError ai $ "Expected def: " <> pretty r
@@ -632,14 +637,15 @@ reduceDirect r _ ai = evalError ai $ "Unexpected non-native direct ref: " <> pre
 
 -- | Apply a pactdef, which will execute a step based on env 'PactStep'
 -- defaulting to the first step.
-applyPact ::  Term Ref ->  Eval e (Term Name)
-applyPact (TList steps _ i) = do
+applyPact :: App (Term Ref) -> Term Ref -> Eval e (Term Name)
+applyPact app (TList steps _ i) = do
   -- only one pact allowed in a transaction
   use evalPactExec >>= \bad -> unless (isNothing bad) $ evalError i "Nested pact execution, aborting"
   -- get step from environment or create a new one
   PactStep{..} <- view eePactStep >>= \ps -> case ps of
-    Nothing -> view eeTxId >>= \tid ->
-      return $ PactStep 0 False (PactId $ maybe "[localPactId]" (pack . show) tid) Nothing
+    Nothing -> view eeTxId >>= \tid -> case tid of
+      Just (TxId t) -> return $ PactStep 0 False (PactId t) Nothing
+      Nothing -> evalError i $ "applyPact: pacts not executable in local context"
     Just v -> return v
   -- retrieve indicated step from code
   s <- maybe (evalError i $ "applyPact: step not found: " <> pretty _psStep) return $ steps `atMay` _psStep
@@ -647,7 +653,8 @@ applyPact (TList steps _ i) = do
     step@TStep {} -> do
       stepEntity <- traverse reduce (_tStepEntity step)
       let
-        initExec executing = evalPactExec .= Just (PactExec (length steps) Nothing executing _psStep _psPactId)
+        initExec executing = evalPactExec .=
+          Just (PactExec (length steps) Nothing executing _psStep _psPactId (PactContinuation app))
         execStep = do
           initExec True
           case (_psRollback,_tStepRollback step) of
@@ -663,7 +670,7 @@ applyPact (TList steps _ i) = do
         Just t -> evalError (_tInfo t) "step entity must be String value"
         Nothing -> execStep -- "public" step exec
     t -> evalError (_tInfo t) "expected step"
-applyPact t = evalError (_tInfo t) "applyPact: expected list of steps"
+applyPact _ t = evalError (_tInfo t) "applyPact: expected list of steps"
 
 
 -- | Create special error form handled in 'reduceApp'

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -194,6 +194,10 @@ pureEval ei e = do
   case r of
     Right a -> do
         doOut ei mode a
+        case _evalPactExec es of
+          Nothing -> return ()
+          Just pe -> do
+            use (rEnv.eePactDbVar) >>= \mv -> liftIO $ modifyMVar_ mv $ return . over rlsPacts (M.insert (_pePactId pe) pe)
         rEvalState .= es
         updateForOp a
     Left err -> do

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -103,7 +103,8 @@ replDefs = ("Repl",
       (funType tTyString [("pact-id",tTyInteger),("step",tTyInteger)] <>
        funType tTyString [("pact-id",tTyInteger),("step",tTyInteger),("rollback",tTyBool)] <>
        funType tTyString [("pact-id",tTyInteger),("step",tTyInteger),("rollback",tTyBool),("yielded",tTyObject (mkSchemaVar "y"))])
-      [LitExample "(continue-pact 2 1 true)", LitExample "(continue-pact 2 1 false { \"rate\": 0.9 })"]
+      [LitExample "(continue-pact 2 1)", LitExample "(continue-pact 2 1 true)",
+       LitExample "(continue-pact 2 1 false { \"rate\": 0.9 })"]
       ("Continue previously-initiated pact identified by PACT-ID at STEP, " <>
        "optionally specifying ROLLBACK (default is false), and " <>
        "YIELDED value to be read with 'resume' (if not specified, uses yield in most recent pact exec, if any).")

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -67,7 +67,7 @@ initLibState loggers verifyUri = do
                 (newLogger loggers "Repl")
                 def def)
   createSchema m
-  return (LibState m Noop def def verifyUri M.empty)
+  return (LibState m Noop def def verifyUri M.empty M.empty)
 
 -- | Native function with no gas consumption.
 type ZNativeFun e = FunApp -> [Term Ref] -> Eval e (Term Name)
@@ -98,30 +98,28 @@ replDefs = ("Repl",
      ,defZRNative "env-data" setmsg (funType tTyString [("json",json)])
       ["(env-data { \"keyset\": { \"keys\": [\"my-key\" \"admin-key\"], \"pred\": \"keys-any\" } })"]
       "Set transaction JSON data, either as encoded string, or as pact types coerced to JSON."
-     ,defZRNative "env-step"
-      setstep (funType tTyString [] <>
-               funType tTyString [("step-idx",tTyInteger)] <>
-               funType tTyString [("step-idx",tTyInteger),("rollback",tTyBool)] <>
-               funType tTyString [("step-idx",tTyInteger),("rollback",tTyBool),
-                                  ("resume",TySchema TyObject (mkSchemaVar "y") def)])
-      [LitExample "(env-step 1)", LitExample "(env-step 0 true)"]
-      ("Set pact step state. With no arguments, unset step. With STEP-IDX, set step index to execute. " <>
-       "ROLLBACK instructs to execute rollback expression, if any. RESUME sets a value to be read via 'resume'." <>
-       "Clears any previous pact execution state.")
-     ,defZRNative "env-pactid" envPactId
-      (funType tTyString [] <>
-       funType tTyString [("id",tTyString)]) []
-       "Query environment pact id, or set to ID."
-     ,defZRNative "pact-state" pactState (funType (tTyObject TyAny) [])
-      [LitExample "(pact-state)"]
-      ("Inspect state from previous pact execution. Returns object with fields " <>
-      "'yield': yield result or 'false' if none; 'step': executed step; " <>
-      "'executed': indicates if step was skipped because entity did not match.")
+
+     ,defZRNative "continue-pact" continuePact
+      (funType tTyString [("pact-id",tTyInteger),("step",tTyInteger)] <>
+       funType tTyString [("pact-id",tTyInteger),("step",tTyInteger),("rollback",tTyBool)] <>
+       funType tTyString [("pact-id",tTyInteger),("step",tTyInteger),("rollback",tTyBool),("yielded",tTyObject (mkSchemaVar "y"))])
+      [LitExample "(continue-pact 2 1 true)", LitExample "(continue-pact 2 1 false { \"rate\": 0.9 })"]
+      ("Continue previously-initiated pact identified by PACT-ID at STEP, " <>
+       "optionally specifying ROLLBACK (default is false), and " <>
+       "YIELDED value to be read with 'resume' (if not specified, uses yield in most recent pact exec, if any).")
+
+     ,defZRNative "pact-state" pactState
+      (funType (tTyObject TyAny) [] <> funType (tTyObject TyAny) [("clear",tTyBool)])
+      [LitExample "(pact-state)", LitExample "(pact-state true)"]
+      ("Inspect state from most recent pact execution. Returns object with fields " <>
+      "'pactId': pact ID; 'yield': yield result or 'false' if none; 'step': executed step; " <>
+      "'executed': indicates if step was skipped because entity did not match. " <>
+      "With CLEAR argument, erases pact from repl state.")
+
      ,defZRNative "env-entity" setentity
       (funType tTyString [] <> funType tTyString [("entity",tTyString)])
       [LitExample "(env-entity \"my-org\")", LitExample "(env-entity)"]
-      ("Set environment confidential ENTITY id, or unset with no argument. " <>
-      "Clears any previous pact execution state.")
+      ("Set environment confidential ENTITY id, or unset with no argument.")
      ,defZRNative "begin-tx" (tx Begin) (funType tTyString [] <>
                                         funType tTyString [("name",tTyString)])
       [LitExample "(begin-tx \"load module\")"] "Begin transaction with optional NAME."
@@ -275,57 +273,56 @@ setmsg i [TLitString j] =
 setmsg _ [a] = setenv eeMsgBody (toJSON a) >> return (tStr "Setting transaction data")
 setmsg i as = argsError i as
 
-
-setstep :: RNativeFun LibState
-setstep i as = case as of
-  [] -> setstep' Nothing >> return (tStr "Un-setting step")
-  [TLitInteger j] -> do
-    setstep' (Just $ PactStep (fromIntegral j) False def def)
-    return $ tStr "Setting step"
-  [TLitInteger j,TLiteral (LBool b) _] -> do
-    setstep' (Just $ PactStep (fromIntegral j) b def def)
-    return $ tStr "Setting step and rollback"
-  [TLitInteger j,TLiteral (LBool b) _,o@TObject{}] -> do
-    setstep' (Just $ PactStep (fromIntegral j) b def (Just o))
-    return $ tStr "Setting step, rollback, and resume value"
+continuePact :: RNativeFun LibState
+continuePact i as = case as of
+  [TLitInteger pid,TLitInteger step] -> go pid step False Nothing
+  [TLitInteger pid,TLitInteger step,TLitBool rollback] -> go pid step rollback Nothing
+  [TLitInteger pid,TLitInteger step,TLitBool rollback,o@TObject {}] -> go pid step rollback (Just o)
   _ -> argsError i as
   where
-    setstep' s = do
-      setenv eePactStep s
-      evalPactExec .= Nothing
+    go :: Integer -> Integer -> Bool -> Maybe (Term Name) -> Eval LibState (Term Name)
+    go pid step rollback userResume = do
+      resume <- case userResume of
+        Just r -> return $ Just r
+        Nothing -> use evalPactExec >>= \pe -> case pe of
+          Nothing -> return Nothing
+          Just PactExec{..} -> return $ _peYield
+      let pactId = (PactId $ fromIntegral pid)
+          pactStep = PactStep (fromIntegral step) rollback pactId resume
+      viewLibState (view rlsPacts) >>= \pacts -> case M.lookup pactId pacts of
+        Nothing -> evalError' i $ "Invalid pact id: " <> pretty pactId
+        Just PactExec{..} -> do
+          evalPactExec .= Nothing
+          local (set eePactStep $ Just pactStep) $ evalContinuation _peContinuation
 
-envPactId :: RNativeFun LibState
-envPactId i as = view eePactStep >>= \psm -> case psm of
-  Nothing -> evalError' i "no pact state set currently"
-  Just ps@PactStep{..} -> case as of
-    [] -> return $ toTerm _psPactId
-    [TLitString pid] -> do
-      setenv eePactStep $ Just $ set psPactId (PactId pid) ps
-      return $ tStr $ "Setting pact id to " <> tShow pid
-    _ -> argsError i as
 
 setentity :: RNativeFun LibState
 setentity i as = case as of
   [TLitString s] -> do
     setenv eeEntity $ Just (EntityName s)
-    evalPactExec .= Nothing
     return (tStr $ "Set entity to " <> s)
   [] -> do
     setenv eeEntity Nothing
-    evalPactExec .= Nothing
     return (tStr "Unset entity")
   _ -> argsError i as
 
 pactState :: RNativeFun LibState
-pactState i [] = do
-  e <- use evalPactExec
-  case e of
-    Nothing -> evalError' i "pact-state: no pact exec in context"
-    Just PactExec{..} -> return $ toTObject TyAny def $
-      [("yield",fromMaybe (toTerm False) _peYield)
-      ,("executed",toTerm _peExecuted)
-      ,("step",toTerm _peStep)]
-pactState i as = argsError i as
+pactState i as = case as of
+  [] -> go False
+  [TLitBool clear] -> go clear
+  _ -> argsError i as
+  where
+    go clear = do
+      e <- use evalPactExec
+      when clear $ evalPactExec .= Nothing
+      case e of
+        Nothing -> evalError' i "pact-state: no pact exec in context"
+        Just PactExec{..} -> return $ toTObject TyAny def $
+          [("yield",fromMaybe (toTerm False) _peYield)
+          ,("executed",toTerm _peExecuted)
+          ,("step",toTerm _peStep)
+          ,("pactId",toTerm _pePactId)]
+
 
 txmsg :: Maybe Text -> Maybe TxId -> Text -> Term Name
 txmsg n tid s = tStr $ s <> " Tx " <> pack (show tid) <> maybe "" (": " <>) n

--- a/src/Pact/Repl/Types.hs
+++ b/src/Pact/Repl/Types.hs
@@ -6,7 +6,7 @@ module Pact.Repl.Types
   , TestResult(..)
   , Repl
   , LibOp(..)
-  , LibState(..),rlsPure,rlsOp,rlsTxName,rlsTests,rlsVerifyUri,rlsMockSPV
+  , LibState(..),rlsPure,rlsOp,rlsTxName,rlsTests,rlsVerifyUri,rlsMockSPV,rlsPacts
   , Tx(..)
   , SPVMockKey(..)
   ) where
@@ -18,7 +18,7 @@ import Control.Monad.State.Strict (StateT)
 import Control.Concurrent (MVar)
 import Pact.PersistPactDb (DbEnv)
 import Pact.Persist.Pure (PureDb)
-import Pact.Types.Runtime (EvalEnv,EvalState,Term,Name,FunApp,Info,Object,Term(..))
+import Pact.Types.Runtime (EvalEnv,EvalState,Term,Name,FunApp,Info,Object,Term(..),PactId,PactExec)
 import Data.Text (Text)
 import qualified Data.Map.Strict as M
 import Pact.Types.Pretty (Pretty,pretty,renderCompactText)
@@ -77,6 +77,7 @@ data LibState = LibState {
     , _rlsTests :: [TestResult]
     , _rlsVerifyUri :: Maybe String
     , _rlsMockSPV :: M.Map SPVMockKey (Object Name)
+    , _rlsPacts :: M.Map PactId PactExec
 }
 
 

--- a/src/Pact/Types/RPC.hs
+++ b/src/Pact/Types/RPC.hs
@@ -67,7 +67,7 @@ instance ToJSON c => ToJSON (ExecMsg c) where
     toJSON (ExecMsg c d) = object [ "code" .= c, "data" .= d]
 
 data ContMsg = ContMsg
-  { _cmTxId :: !TxId
+  { _cmPactId :: !PactId
   , _cmStep :: !Int
   , _cmRollback :: !Bool
   , _cmData :: !Value
@@ -77,9 +77,9 @@ instance NFData ContMsg
 instance FromJSON ContMsg where
     parseJSON =
         withObject "ContMsg" $ \o ->
-            ContMsg <$> o .: "txid" <*> o .: "step" <*> o .: "rollback" <*> o .: "data"
+            ContMsg <$> o .: "pactId" <*> o .: "step" <*> o .: "rollback" <*> o .: "data"
     {-# INLINE parseJSON #-}
 
 instance ToJSON ContMsg where
     toJSON ContMsg{..} = object
-      [ "txid" .= _cmTxId, "step" .= _cmStep, "rollback" .= _cmRollback, "data" .= _cmData]
+      [ "pactId" .= _cmPactId, "step" .= _cmStep, "rollback" .= _cmRollback, "data" .= _cmData]

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -27,7 +27,7 @@ module Pact.Types.Runtime
    eePactDb,eePurity,eeHash,eeGasEnv,eeNamespacePolicy,eeSPVSupport,
    Purity(..),PureNoDb,PureSysRead,EnvNoDb(..),EnvReadOnly(..),mkNoDbEnv,mkReadOnlyEnv,
    StackFrame(..),sfName,sfLoc,sfApp,
-   PactExec(..),peStepCount,peYield,peExecuted,pePactId,peStep,
+   PactExec(..),peStepCount,peYield,peExecuted,pePactId,peStep,peContinuation,
    RefState(..),rsLoaded,rsLoadedModules,rsNewModules,rsNamespace,
    EvalState(..),evalRefs,evalCallStack,evalPactExec,evalGas,evalCapabilities,
    Eval(..),runEval,runEval',
@@ -39,6 +39,7 @@ module Pact.Types.Runtime
    NamespacePolicy(..), nsPolicy,
    permissiveNamespacePolicy,
    SPVSupport(..),noSPVSupport,
+   PactContinuation(..),
    module Pact.Types.Lang,
    module Pact.Types.Util,
    module Pact.Types.Persistence,
@@ -166,14 +167,23 @@ newtype EntityName = EntityName Text
   deriving (IsString,AsString,Eq,Ord,Hashable,Serialize,NFData,ToJSON,FromJSON,Default)
 instance Show EntityName where show (EntityName t) = show t
 
+newtype PactContinuation = PactContinuation (App (Term Ref))
+  deriving (Eq,Show)
 
 -- | Runtime capture of pact execution.
 data PactExec = PactExec
-  { _peStepCount :: Int
+  { -- | Count of steps in pact (discovered when code is executed)
+    _peStepCount :: Int
+    -- | Yield value if invoked
   , _peYield :: !(Maybe (Term Name))
+    -- | Whether step was executed (in private cases, it can be skipped)
   , _peExecuted :: Bool
+    -- | Step that was executed or skipped
   , _peStep :: Int
+    -- | Pact id. On a new pact invocation, is copied from tx id.
   , _pePactId :: PactId
+    -- | Strict (in arguments) application of pact, for future step invocations.
+  , _peContinuation :: PactContinuation
   } deriving (Eq,Show)
 makeLenses ''PactExec
 

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -170,7 +170,7 @@ instance Show EntityName where show (EntityName t) = show t
 newtype PactContinuation = PactContinuation (App (Term Ref))
   deriving (Eq,Show)
 
--- | Runtime capture of pact execution.
+-- | Result of evaluation of a 'defpact'.
 data PactExec = PactExec
   { -- | Count of steps in pact (discovered when code is executed)
     _peStepCount :: Int

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -104,6 +104,7 @@ import Data.Int (Int64)
 import Data.Serialize (Serialize)
 import Data.Eq.Deriving
 import Text.Show.Deriving
+import Data.Word (Word64)
 
 
 import Pact.Types.Parser
@@ -179,10 +180,11 @@ newtype KeySetName = KeySetName Text
 
 instance Pretty KeySetName where pretty (KeySetName s) = "'" <> pretty s
 
-newtype PactId = PactId Text
-    deriving (Eq,Ord,IsString,ToTerm,AsString,ToJSON,FromJSON,Default,Show)
-
-instance Pretty PactId where pretty (PactId s) = pretty s
+newtype PactId = PactId Word64
+    deriving (Eq,Ord,Enum,Num,Real,Integral,Bounded,Default,FromJSON,ToJSON,Generic)
+instance Show PactId where show (PactId p) = show p
+instance Pretty PactId where pretty = viaShow
+instance NFData PactId
 
 data PactGuard = PactGuard
   { _pgPactId :: !PactId
@@ -1027,6 +1029,7 @@ instance ToTerm Guard where toTerm = (`TGuard` def)
 instance ToTerm Literal where toTerm = tLit
 instance ToTerm Value where toTerm = (`TValue` def)
 instance ToTerm UTCTime where toTerm = tLit . LTime
+instance ToTerm PactId where toTerm = tLit . LInteger . fromIntegral
 
 
 toTObject :: Type (Term n) -> Info -> [(FieldKey,Term n)] -> Term n

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -94,8 +94,8 @@ testCorrectNextStep mgr = do
 
   moduleCmd       <- makeExecCmdWith (T.unpack (threeStepPactCode moduleName))
   executePactCmd  <- makeExecCmdWith ("(" ++ moduleName ++ ".tester)")
-  contNextStepCmd <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
-  checkStateCmd   <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test4")
+  contNextStepCmd <- mkCont (PactId 1) 1 False Null def [adminKeys] (Just "test3")
+  checkStateCmd   <- mkCont (PactId 1) 1 False Null def [adminKeys] (Just "test4")
   allResults      <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd, checkStateCmd]
 
   let moduleCheck       = makeCheck moduleCmd False Nothing
@@ -116,8 +116,8 @@ testIncorrectNextStep mgr = do
 
   moduleCmd         <- makeExecCmdWith (T.unpack (threeStepPactCode moduleName))
   executePactCmd    <- makeExecCmdWith ("(" ++ moduleName ++ ".tester)")
-  incorrectStepCmd  <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test3")
-  checkStateCmd     <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test4")
+  incorrectStepCmd  <- mkCont (PactId 1) 2 False Null def [adminKeys] (Just "test3")
+  checkStateCmd     <- mkCont (PactId 1) 1 False Null def [adminKeys] (Just "test4")
   allResults        <- runAll mgr [moduleCmd, executePactCmd, incorrectStepCmd, checkStateCmd]
 
   let moduleCheck        = makeCheck moduleCmd False Nothing
@@ -138,9 +138,9 @@ testLastStep mgr = do
 
   moduleCmd        <- makeExecCmdWith (T.unpack (threeStepPactCode moduleName))
   executePactCmd   <- makeExecCmdWith ("(" ++ moduleName ++ ".tester)")
-  contNextStep1Cmd <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
-  contNextStep2Cmd <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test4")
-  checkStateCmd    <- mkCont (TxId 1) 3 False Null def [adminKeys] (Just "test5")
+  contNextStep1Cmd <- mkCont (PactId 1) 1 False Null def [adminKeys] (Just "test3")
+  contNextStep2Cmd <- mkCont (PactId 1) 2 False Null def [adminKeys] (Just "test4")
+  checkStateCmd    <- mkCont (PactId 1) 3 False Null def [adminKeys] (Just "test5")
   allResults       <- runAll mgr [moduleCmd, executePactCmd, contNextStep1Cmd,
                               contNextStep2Cmd, checkStateCmd]
 
@@ -149,7 +149,7 @@ testLastStep mgr = do
       contNextStep1Check = makeCheck contNextStep1Cmd False $ Just "step 1"
       contNextStep2Check = makeCheck contNextStep2Cmd False $ Just "step 2"
       checkStateCheck    = makeCheck checkStateCmd True
-                           (Just "applyContinuation: txid not found: 1")
+                           (Just "applyContinuation: pact ID not found: 1")
       allChecks          = [moduleCheck, executePactCheck, contNextStep1Check,
                             contNextStep2Check, checkStateCheck]
 
@@ -164,8 +164,8 @@ testErrStep mgr = do
 
   moduleCmd        <- makeExecCmdWith (T.unpack (errorStepPactCode moduleName))
   executePactCmd   <- makeExecCmdWith ("(" ++ moduleName ++ ".tester)")
-  contErrStepCmd   <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
-  checkStateCmd    <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test4")
+  contErrStepCmd   <- mkCont (PactId 1) 1 False Null def [adminKeys] (Just "test3")
+  checkStateCmd    <- mkCont (PactId 1) 2 False Null def [adminKeys] (Just "test4")
   allResults       <- runAll mgr [moduleCmd, executePactCmd, contErrStepCmd, checkStateCmd]
 
   let moduleCheck        = makeCheck moduleCmd False Nothing
@@ -208,9 +208,9 @@ testCorrectRollbackStep mgr = do
 
   moduleCmd       <- makeExecCmdWith (T.unpack (pactWithRollbackCode moduleName))
   executePactCmd  <- makeExecCmdWith ("(" ++ moduleName ++ ".tester)")
-  contNextStepCmd <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
-  rollbackStepCmd <- mkCont (TxId 1) 1 True Null def [adminKeys] (Just "test4") -- rollback = True
-  checkStateCmd   <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test5")
+  contNextStepCmd <- mkCont (PactId 1) 1 False Null def [adminKeys] (Just "test3")
+  rollbackStepCmd <- mkCont (PactId 1) 1 True Null def [adminKeys] (Just "test4") -- rollback = True
+  checkStateCmd   <- mkCont (PactId 1) 2 False Null def [adminKeys] (Just "test5")
   allResults      <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd,
                              rollbackStepCmd, checkStateCmd]
 
@@ -219,7 +219,7 @@ testCorrectRollbackStep mgr = do
       contNextStepCheck = makeCheck contNextStepCmd False $ Just "step 1"
       rollbackStepCheck = makeCheck rollbackStepCmd False $ Just "rollback 1"
       checkStateCheck   = makeCheck checkStateCmd True
-                          (Just "applyContinuation: txid not found: 1")
+                          (Just "applyContinuation: pact ID not found: 1")
       allChecks         = [moduleCheck, executePactCheck, contNextStepCheck,
                            rollbackStepCheck, checkStateCheck]
 
@@ -234,9 +234,9 @@ testIncorrectRollbackStep mgr = do
 
   moduleCmd       <- makeExecCmdWith (T.unpack (pactWithRollbackCode moduleName))
   executePactCmd  <- makeExecCmdWith ("(" ++ moduleName ++ ".tester)")
-  contNextStepCmd <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
-  incorrectRbCmd  <- mkCont (TxId 1) 2 True Null def [adminKeys] (Just "test4")
-  checkStateCmd   <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test5")
+  contNextStepCmd <- mkCont (PactId 1) 1 False Null def [adminKeys] (Just "test3")
+  incorrectRbCmd  <- mkCont (PactId 1) 2 True Null def [adminKeys] (Just "test4")
+  checkStateCmd   <- mkCont (PactId 1) 2 False Null def [adminKeys] (Just "test5")
   allResults      <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd,
                              incorrectRbCmd, checkStateCmd]
 
@@ -260,9 +260,9 @@ testRollbackErr mgr = do
 
   moduleCmd        <- makeExecCmdWith (T.unpack (pactWithRollbackErrCode moduleName))
   executePactCmd   <- makeExecCmdWith ("(" ++ moduleName ++ ".tester)")
-  contNextStepCmd  <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
-  rollbackErrCmd   <- mkCont (TxId 1) 1 True Null def [adminKeys] (Just "test4")
-  checkStateCmd    <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test5")
+  contNextStepCmd  <- mkCont (PactId 1) 1 False Null def [adminKeys] (Just "test3")
+  rollbackErrCmd   <- mkCont (PactId 1) 1 True Null def [adminKeys] (Just "test4")
+  checkStateCmd    <- mkCont (PactId 1) 2 False Null def [adminKeys] (Just "test5")
   allResults       <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd,
                               rollbackErrCmd, checkStateCmd]
 
@@ -285,9 +285,9 @@ testNoRollbackFunc mgr = do
 
   moduleCmd        <- makeExecCmdWith (T.unpack (threeStepPactCode moduleName))
   executePactCmd   <- makeExecCmdWith ("(" ++ moduleName ++ ".tester)")
-  contNextStepCmd  <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
-  noRollbackCmd    <- mkCont (TxId 1) 1 True Null def [adminKeys] (Just "test4")
-  checkStateCmd    <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test5")
+  contNextStepCmd  <- mkCont (PactId 1) 1 False Null def [adminKeys] (Just "test3")
+  noRollbackCmd    <- mkCont (PactId 1) 1 True Null def [adminKeys] (Just "test4")
+  checkStateCmd    <- mkCont (PactId 1) 2 False Null def [adminKeys] (Just "test5")
   allResults       <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd,
                               noRollbackCmd, checkStateCmd]
 
@@ -296,7 +296,7 @@ testNoRollbackFunc mgr = do
       contNextStepCheck  = makeCheck contNextStepCmd False $ Just "step 1"
       noRollbackCheck    = makeCheck noRollbackCmd False $ Just "No rollback on step 1" -- not a failure
       checkStateCheck    = makeCheck checkStateCmd True
-                           (Just "applyContinuation: txid not found: 1")
+                           (Just "applyContinuation: pact ID not found: 1")
       allChecks          = [moduleCheck, executePactCheck, contNextStepCheck,
                             noRollbackCheck, checkStateCheck]
 
@@ -329,9 +329,9 @@ testValidYield mgr = do
   moduleCmd          <- makeExecCmdWith (T.unpack (pactWithYield moduleName))
   executePactCmd     <- makeExecCmdWith ("(" ++ moduleName ++ ".tester \"testing\")")
                         -- pact takes an input
-  resumeAndYieldCmd  <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
-  resumeOnlyCmd      <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test4")
-  checkStateCmd      <- mkCont (TxId 1) 3 False Null def [adminKeys] (Just "test5")
+  resumeAndYieldCmd  <- mkCont (PactId 1) 1 False Null def [adminKeys] (Just "test3")
+  resumeOnlyCmd      <- mkCont (PactId 1) 2 False Null def [adminKeys] (Just "test4")
+  checkStateCmd      <- mkCont (PactId 1) 3 False Null def [adminKeys] (Just "test5")
   allResults         <- runAll mgr [moduleCmd, executePactCmd, resumeAndYieldCmd,
                                 resumeOnlyCmd, checkStateCmd]
 
@@ -340,7 +340,7 @@ testValidYield mgr = do
       resumeAndYieldCheck = makeCheck resumeAndYieldCmd False $ Just "testing->Step0->Step1"
       resumeOnlyCheck     = makeCheck resumeOnlyCmd False $ Just "testing->Step0->Step1->Step2"
       checkStateCheck     = makeCheck checkStateCmd True
-                            (Just "applyContinuation: txid not found: 1")
+                            (Just "applyContinuation: pact ID not found: 1")
       allChecks           = [moduleCheck, executePactCheck, resumeAndYieldCheck,
                              resumeOnlyCheck, checkStateCheck]
 
@@ -355,9 +355,9 @@ testNoYield mgr = do
 
   moduleCmd      <- makeExecCmdWith (T.unpack (pactWithYieldErr moduleName))
   executePactCmd <- makeExecCmdWith ("(" ++ moduleName ++ ".tester \"testing\")") -- pact takes an input
-  noYieldStepCmd <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
-  resumeErrCmd   <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test3")
-  checkStateCmd  <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test5")
+  noYieldStepCmd <- mkCont (PactId 1) 1 False Null def [adminKeys] (Just "test3")
+  resumeErrCmd   <- mkCont (PactId 1) 2 False Null def [adminKeys] (Just "test3")
+  checkStateCmd  <- mkCont (PactId 1) 1 False Null def [adminKeys] (Just "test5")
   allResults     <- runAll mgr [moduleCmd, executePactCmd, noYieldStepCmd,
                            resumeErrCmd, checkStateCmd]
 
@@ -381,9 +381,9 @@ testResetYield mgr = do
 
   moduleCmd        <- makeExecCmdWith (T.unpack (pactWithSameNameYield moduleName))
   executePactCmd   <- makeExecCmdWith ("(" ++ moduleName ++ ".tester)")
-  yieldSameKeyCmd  <- mkCont (TxId 1) 1 False Null def [adminKeys] (Just "test3")
-  resumeStepCmd    <- mkCont (TxId 1) 2 False Null def [adminKeys] (Just "test4")
-  checkStateCmd    <- mkCont (TxId 1) 3 False Null def [adminKeys] (Just "test5")
+  yieldSameKeyCmd  <- mkCont (PactId 1) 1 False Null def [adminKeys] (Just "test3")
+  resumeStepCmd    <- mkCont (PactId 1) 2 False Null def [adminKeys] (Just "test4")
+  checkStateCmd    <- mkCont (PactId 1) 3 False Null def [adminKeys] (Just "test5")
   allResults       <- runAll mgr [moduleCmd, executePactCmd, yieldSameKeyCmd,
                               resumeStepCmd, checkStateCmd]
 
@@ -392,7 +392,7 @@ testResetYield mgr = do
       yieldSameKeyCheck = makeCheck yieldSameKeyCmd False $ Just "step 1"
       resumeStepCheck   = makeCheck resumeStepCmd False $ Just "step 1"
       checkStateCheck   = makeCheck checkStateCmd True
-                           (Just "applyContinuation: txid not found: 1")
+                           (Just "applyContinuation: pact ID not found: 1")
       allChecks         = [moduleCheck, executePactCheck, yieldSameKeyCheck,
                            resumeStepCheck, checkStateCheck]
 

--- a/tests/cont-scripts/fail-both-price-up-01-cont.yaml
+++ b/tests/cont-scripts/fail-both-price-up-01-cont.yaml
@@ -1,6 +1,6 @@
 # Both debtor and creditor can finish together, but cannot negotiate price up
 type: "cont"
-txId: 5
+pactId: 5
 step: 1
 rollback: False
 data: {final-price: 12.0}

--- a/tests/cont-scripts/fail-cred-finish-01-cont.yaml
+++ b/tests/cont-scripts/fail-cred-finish-01-cont.yaml
@@ -1,6 +1,6 @@
 # Creditor (Bob) cannot finish alone
 type: "cont"
-txId: 5
+pactId: 5
 step: 1
 rollback: False
 keyPairs:

--- a/tests/cont-scripts/fail-deb-cancel-01-rollback.yaml
+++ b/tests/cont-scripts/fail-deb-cancel-01-rollback.yaml
@@ -1,6 +1,6 @@
 # Debtor (Alice) cannot cancel pre-timeout
 type: "cont"
-txId: 5
+pactId: 5
 step: 0
 rollback: True
 keyPairs:

--- a/tests/cont-scripts/fail-deb-finish-01-cont.yaml
+++ b/tests/cont-scripts/fail-deb-finish-01-cont.yaml
@@ -1,6 +1,6 @@
 # Debtor (Alice) cannot finish alone
 type: "cont"
-txId: 5
+pactId: 5
 step: 1
 rollback: False
 keyPairs:

--- a/tests/cont-scripts/pass-both-price-down-01-cont.yaml
+++ b/tests/cont-scripts/pass-both-price-down-01-cont.yaml
@@ -1,7 +1,7 @@
 # Both debtor and creditor can finish together if price remains the same
 # or negotiated down.
 type: "cont"
-txId: 5
+pactId: 5
 step: 1
 rollback: False
 data: {final-price: 1.75}

--- a/tests/cont-scripts/pass-cred-cancel-02-rollback.yaml
+++ b/tests/cont-scripts/pass-cred-cancel-02-rollback.yaml
@@ -1,6 +1,6 @@
 # Creditor (Bob) can cancel anytime
 type: "cont"
-txId: 5
+pactId: 5
 step: 0
 rollback: True
 keyPairs:

--- a/tests/cont-scripts/pass-deb-cancel-02-rollback.yaml
+++ b/tests/cont-scripts/pass-deb-cancel-02-rollback.yaml
@@ -1,6 +1,6 @@
 # Debtor (Alice) can cancel after timeout
 type: "cont"
-txId: 5
+pactId: 5
 step: 0
 rollback: True
 keyPairs:

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -41,7 +41,7 @@
 
   (defpact test-pact-guards (id:string)
     (step (step1 id))
-    (step (step2 id)))
+    (step (step2 (read-msg "id"))))
 
   (defun step1 (id:string)
     (insert guard-table id { "g": (create-pact-guard "test")}))
@@ -146,16 +146,17 @@
 
 (test-pact-guards "a")
 
-(env-step 1) ;;clears pact state
+(pact-state true) ;;clears pact state
 (let ((g (get-guard "a"))) ;; doing let so db failure doesn't confuse below
   (expect-failure "enforcing pact guard outside of pact" (enforce-guard g)))
 
-(env-pactid "4")
-(test-pact-guards "a")
+(env-data { "id": "a"})
+(continue-pact 4 1)
 (expect "pact enforce succeeds" 1 (at 'result (at 'yield (pact-state))))
 
-(env-pactid "5")
-(expect-failure "pact enforce fails" (test-pact-guards "a"))
+(pact-state true)
+(test-pact-guards "b")
+(expect-failure "pact enforce fails in pact 5 for id 'a'" (continue-pact 5 1))
 
 (env-keys ["a" "b" "c"])
 (expect-failure "cannot compose caps at toplevel" (compose-capability (KALL-CAP)))

--- a/tests/pact/yield.repl
+++ b/tests/pact/yield.repl
@@ -17,23 +17,22 @@
 
 (env-entity "B")
 (tester "stu")
-(expect "step 0 skips B" false (at "executed" (pact-state)))
+(expect "step 0 skips B" false (at "executed" (pact-state true)))
 
 (env-entity "A")
 (expect "step 0 executes" "stu->A" (tester "stu"))
 ;; set resume for step 1
-(env-step 1 false (at "yield" (pact-state)))
 (env-entity "B")
-(expect "step 1 executes" "stu->A->B" (tester "stu"))
+(expect "step 1 executes" "stu->A->B" (continue-pact 1 1))
+
 ;; test 1 skips A
 (env-entity "A")
-(tester "stu")
+(continue-pact 1 1)
 (expect "step 1 skips A" false (at "executed" (pact-state)))
 
 ;; test rollback
-(env-step 0 true)
-(expect "step 1 rollback executes" "rollback-a" (tester "stu"))
+(expect "step 1 rollback executes" "rollback-a" (continue-pact 1 0 true))
 ;; test no rollback for B
 (env-entity "B")
-(tester "stu")
+(continue-pact 1 0 true)
 (expect "step 0 rollback skips B" false (at "executed" (pact-state)))


### PR DESCRIPTION
PactId is no longer a string; pacts are as a result not executable in a local context. (They never were past step 0 anyway, and don't make sense outside of a transactional context).

Move to actual continuation-based "pact" continuations, away from the "just call the function again with the step in the environment" busted model before.

Lib functions `env-step` and `env-pactid` are gone, replaced with `continue-pact`; tests no longer re-invoke pact function. `pact-state` takes an boolean to clear out pact state.

Interpreter/PactService have breaking changes to properly handle invocation; `CommandPact` is gone and instead `PactExec` is to be used to track state.