### PR TITLE
Add "chain-data", "env-chain-data" functions and Public Data type

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -45,6 +45,7 @@ library
                      , Pact.Server.API
                      , Pact.Server.Client
                      , Pact.Types.API
+                     , Pact.Types.ChainMeta
                      , Pact.Types.Command
                      , Pact.Types.Scheme
                      , Pact.Types.Exp

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -76,7 +76,7 @@ loadBenchModule db = do
            Nothing
            (initialHashTx H.Blake2b_512)
   let e = setupEvalEnv db entity (Transactional 1) md initRefStore
-          freeGasEnv permissiveNamespacePolicy noSPVSupport
+          freeGasEnv permissiveNamespacePolicy noSPVSupport def
   _erRefStore <$> evalExec e pc
 
 parseCode :: Text -> IO ParsedCode
@@ -89,7 +89,7 @@ runPactExec :: PactDbEnv e -> RefStore -> ParsedCode -> IO Value
 runPactExec dbEnv refStore pc = do
   t <- Transactional . fromIntegral <$> getCPUTime
   let e = setupEvalEnv dbEnv entity t (initMsgData (initialHashTx H.Blake2b_512))
-          refStore freeGasEnv permissiveNamespacePolicy noSPVSupport
+          refStore freeGasEnv permissiveNamespacePolicy noSPVSupport def
   toJSON . _erOutput <$> evalExec e pc
 
 benchKeySet :: KeySet

--- a/src-ghc/Pact/Interpreter.hs
+++ b/src-ghc/Pact/Interpreter.hs
@@ -101,8 +101,9 @@ setupEvalEnv
   -> GasEnv
   -> NamespacePolicy
   -> SPVSupport
+  -> PublicData
   -> EvalEnv e
-setupEvalEnv dbEnv ent mode msgData refStore gasEnv np spv =
+setupEvalEnv dbEnv ent mode msgData refStore gasEnv np spv pd =
   EvalEnv {
     _eeRefStore = refStore
   , _eeMsgSigs = mdSigs msgData
@@ -117,6 +118,7 @@ setupEvalEnv dbEnv ent mode msgData refStore gasEnv np spv =
   , _eeGasEnv = gasEnv
   , _eeNamespacePolicy = np
   , _eeSPVSupport = spv
+  , _eePublicData = pd
   }
   where modeToTx (Transactional t) = Just t
         modeToTx Local = Nothing

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -22,17 +22,21 @@ import Control.Monad.Reader
 import qualified Data.Map.Strict as M
 
 import Data.Aeson as A
+import Data.Int (Int64)
 import Data.Maybe (fromMaybe)
+import Data.Word (Word32, Word64)
 
+import Pact.Gas
+import Pact.Interpreter
+import Pact.Parse (ParsedDecimal(..))
 import Pact.Types.Command
+import Pact.Types.Gas
+import Pact.Types.Logger
+import Pact.Types.Persistence
 import Pact.Types.RPC
 import Pact.Types.Runtime hiding (PublicKey)
 import Pact.Types.Server
-import Pact.Types.Logger
-import Pact.Gas
-import Pact.Parse (ParsedDecimal(..))
 
-import Pact.Interpreter
 
 initPactService :: CommandConfig -> Loggers -> IO (CommandExecInterface PublicMeta ParsedCode)
 initPactService CommandConfig {..} loggers = do
@@ -40,13 +44,19 @@ initPactService CommandConfig {..} loggers = do
       klog s = logLog logger "INIT" s
       gasRate = fromMaybe 0 _ccGasRate
       gasModel = constGasModel (fromIntegral gasRate)
-      mkCEI p@PactDbEnv {..} = do
+      chainId = fromMaybe 0 _ccChainId
+      blockHeight = fromMaybe 0 _ccBlockHeight
+      blockTime = fromMaybe 0 _ccBlockTime
+
+  let mkCEI p@PactDbEnv {..} = do
         cmdVar <- newMVar (CommandState initRefStore M.empty)
         klog "Creating Pact Schema"
         initSchema p
         return CommandExecInterface
-          { _ceiApplyCmd = \eMode cmd -> applyCmd logger _ccEntity p cmdVar gasModel eMode cmd (verifyCommand cmd)
-          , _ceiApplyPPCmd = applyCmd logger _ccEntity p cmdVar gasModel }
+          { _ceiApplyCmd = \eMode cmd ->
+              applyCmd logger _ccEntity p cmdVar gasModel chainId
+                blockHeight blockTime eMode cmd (verifyCommand cmd)
+          , _ceiApplyPPCmd = applyCmd logger _ccEntity p cmdVar gasModel chainId blockHeight blockTime }
   case _ccSqlite of
     Nothing -> do
       klog "Initializing pure pact"
@@ -57,14 +67,17 @@ initPactService CommandConfig {..} loggers = do
 
 
 applyCmd :: Logger -> Maybe EntityName -> PactDbEnv p -> MVar CommandState ->
-            GasModel -> ExecutionMode -> Command a ->
+            GasModel -> Word32 -> Word64 -> Int64 -> ExecutionMode -> Command a ->
             ProcessedCommand PublicMeta ParsedCode -> IO CommandResult
-applyCmd _ _ _ _ _ ex cmd (ProcFail s) = return $ jsonResult ex (cmdToRequestKey cmd) (Gas 0) s
-applyCmd logger conf dbv cv gasModel exMode _ (ProcSucc cmd) = do
+applyCmd _ _ _ _ _ _ _ _ ex cmd (ProcFail s) = return $ jsonResult ex (cmdToRequestKey cmd) (Gas 0) s
+applyCmd logger conf dbv cv gasModel cid bh bt exMode _ (ProcSucc cmd) = do
   let pubMeta = _pMeta $ _cmdPayload cmd
       (ParsedDecimal gasPrice) = _pmGasPrice pubMeta
       gasEnv = GasEnv (fromIntegral $ _pmGasLimit pubMeta) (GasPrice gasPrice) gasModel
-  r <- tryAny $ runCommand (CommandEnv conf exMode dbv cv logger gasEnv) $ runPayload cmd
+
+  let pd = PublicData pubMeta cid bh bt
+
+  r <- tryAny $ runCommand (CommandEnv conf exMode dbv cv logger gasEnv pd) $ runPayload cmd
   case r of
     Right cr -> do
       logLog logger "DEBUG" $ "success for requestKey: " ++ show (cmdToRequestKey cmd)
@@ -93,8 +106,8 @@ applyExec rk (ExecMsg parsedCode edata) Command{..} = do
   when (null (_pcExps parsedCode)) $ throwCmdEx "No expressions found"
   (CommandState refStore pacts) <- liftIO $ readMVar _ceState
   let sigs = userSigsToPactKeySet _cmdSigs
-      evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode
-                (MsgData sigs edata Nothing _cmdHash) refStore _ceGasEnv permissiveNamespacePolicy noSPVSupport
+      evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode (MsgData sigs edata Nothing _cmdHash)
+        refStore _ceGasEnv permissiveNamespacePolicy noSPVSupport _cePublicData
   EvalResult{..} <- liftIO $ evalExec evalEnv parsedCode
   newCmdPact <- join <$> mapM (handlePactExec _erInput) _erExec
   let newPacts = case newCmdPact of
@@ -135,7 +148,7 @@ applyContinuation rk msg@ContMsg{..} Command{..} = do
               pactStep = Just $ PactStep _cmStep _cmRollback _cmPactId _peYield
               evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode
                         (MsgData sigs _cmData pactStep _cmdHash) _csRefStore
-                        _ceGasEnv permissiveNamespacePolicy noSPVSupport
+                        _ceGasEnv permissiveNamespacePolicy noSPVSupport _cePublicData
           res <- tryAny (liftIO  $ evalContinuation evalEnv _peContinuation)
 
           -- Update pacts state

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -44,9 +44,9 @@ initPactService CommandConfig {..} loggers = do
       klog s = logLog logger "INIT" s
       gasRate = fromMaybe 0 _ccGasRate
       gasModel = constGasModel (fromIntegral gasRate)
-      chainId = fromMaybe 0 _ccChainId
-      blockHeight = fromMaybe 0 _ccBlockHeight
-      blockTime = fromMaybe 0 _ccBlockTime
+      chainId = 0
+      blockHeight = 0
+      blockTime = 0
 
   let mkCEI p@PactDbEnv {..} = do
         cmdVar <- newMVar (CommandState initRefStore M.empty)

--- a/src-ghc/Pact/Server/Server.hs
+++ b/src-ghc/Pact/Server/Server.hs
@@ -53,9 +53,6 @@ data Config = Config {
   _entity :: Maybe EntityName,
   _gasLimit :: Maybe Int,
   _gasRate :: Maybe Int,
-  _chainId :: Maybe Word32,
-  _blockHeight :: Maybe Word64,
-  _blockTime :: Maybe Int64
   } deriving (Eq,Show,Generic)
 instance ToJSON Config where toJSON = lensyToJSON 1
 instance FromJSON Config where parseJSON = lensyParseJSON 1

--- a/src-ghc/Pact/Server/Server.hs
+++ b/src-ghc/Pact/Server/Server.hs
@@ -29,7 +29,6 @@ import qualified Data.ByteString.Char8 as B8
 
 import qualified Data.HashMap.Strict as HashMap
 
-import Data.Int
 import Data.Word
 import GHC.Generics
 import System.Log.FastLogger
@@ -52,7 +51,7 @@ data Config = Config {
   _verbose :: Bool,
   _entity :: Maybe EntityName,
   _gasLimit :: Maybe Int,
-  _gasRate :: Maybe Int,
+  _gasRate :: Maybe Int
   } deriving (Eq,Show,Generic)
 instance ToJSON Config where toJSON = lensyToJSON 1
 instance FromJSON Config where parseJSON = lensyParseJSON 1
@@ -92,9 +91,7 @@ setupServer configFile = do
           _entity
           _gasLimit
           _gasRate
-          _chainId
-          _blockHeight
-          _blockTime
+
   let histConf = initHistoryEnv histC inC _persistDir debugFn replayFromDisk'
   asyncCmd <- async (startCmdThread cmdConfig inC histC replayFromDisk' debugFn)
   asyncHist <- async (runHistoryService histConf Nothing)

--- a/src-ghc/Pact/Server/Server.hs
+++ b/src-ghc/Pact/Server/Server.hs
@@ -29,7 +29,8 @@ import qualified Data.ByteString.Char8 as B8
 
 import qualified Data.HashMap.Strict as HashMap
 
-import Data.Word (Word16)
+import Data.Int
+import Data.Word
 import GHC.Generics
 import System.Log.FastLogger
 import Data.Default
@@ -51,7 +52,10 @@ data Config = Config {
   _verbose :: Bool,
   _entity :: Maybe EntityName,
   _gasLimit :: Maybe Int,
-  _gasRate :: Maybe Int
+  _gasRate :: Maybe Int,
+  _chainId :: Maybe Word32,
+  _blockHeight :: Maybe Word64,
+  _blockTime :: Maybe Int64
   } deriving (Eq,Show,Generic)
 instance ToJSON Config where toJSON = lensyToJSON 1
 instance FromJSON Config where parseJSON = lensyParseJSON 1
@@ -91,6 +95,9 @@ setupServer configFile = do
           _entity
           _gasLimit
           _gasRate
+          _chainId
+          _blockHeight
+          _blockTime
   let histConf = initHistoryEnv histC inC _persistDir debugFn replayFromDisk'
   asyncCmd <- async (startCmdThread cmdConfig inC histC replayFromDisk' debugFn)
   asyncHist <- async (runHistoryService histConf Nothing)

--- a/src-ghc/Pact/Types/Server.hs
+++ b/src-ghc/Pact/Types/Server.hs
@@ -53,7 +53,6 @@ import Data.Text.Encoding
 import Data.Aeson
 import Data.HashSet (HashSet)
 import Data.HashMap.Strict (HashMap)
-import Data.Word
 import Data.Int
 
 import Prelude

--- a/src-ghc/Pact/Types/Server.hs
+++ b/src-ghc/Pact/Types/Server.hs
@@ -23,9 +23,9 @@
 --
 module Pact.Types.Server
   ( userSigToPactPubKey, userSigsToPactKeySet
-  , CommandConfig(..), ccSqlite, ccEntity, ccGasLimit, ccGasRate
+  , CommandConfig(..), ccSqlite, ccEntity, ccGasLimit, ccGasRate, ccChainId, ccBlockHeight, ccBlockTime
   , CommandState(..), csRefStore, csPacts
-  , CommandEnv(..), ceEntity, ceMode, ceDbEnv, ceState, ceLogger, ceGasEnv
+  , CommandEnv(..), ceEntity, ceMode, ceDbEnv, ceState, ceLogger, cePublicData, ceGasEnv
   , CommandM, runCommand, throwCmdEx
   , History(..)
   , ExistenceResult(..)
@@ -51,9 +51,10 @@ import qualified Data.Map.Strict         as M
 import qualified Data.Set                as S
 import Data.Text.Encoding
 import Data.Aeson
-
 import Data.HashSet (HashSet)
 import Data.HashMap.Strict (HashMap)
+import Data.Word
+import Data.Int
 
 import Prelude
 
@@ -78,6 +79,9 @@ data CommandConfig = CommandConfig {
     , _ccEntity :: Maybe EntityName
     , _ccGasLimit :: Maybe Int
     , _ccGasRate :: Maybe Int
+    , _ccChainId :: Maybe Word32
+    , _ccBlockHeight :: Maybe Word64
+    , _ccBlockTime :: Maybe Int64
     }
 $(makeLenses ''CommandConfig)
 
@@ -96,6 +100,7 @@ data CommandEnv p = CommandEnv {
     , _ceState :: MVar CommandState
     , _ceLogger :: Logger
     , _ceGasEnv :: GasEnv
+    , _cePublicData :: PublicData
     }
 $(makeLenses ''CommandEnv)
 

--- a/src-ghc/Pact/Types/Server.hs
+++ b/src-ghc/Pact/Types/Server.hs
@@ -23,7 +23,7 @@
 --
 module Pact.Types.Server
   ( userSigToPactPubKey, userSigsToPactKeySet
-  , CommandConfig(..), ccSqlite, ccEntity, ccGasLimit, ccGasRate, ccChainId, ccBlockHeight, ccBlockTime
+  , CommandConfig(..), ccSqlite, ccEntity, ccGasLimit, ccGasRate
   , CommandState(..), csRefStore, csPacts
   , CommandEnv(..), ceEntity, ceMode, ceDbEnv, ceState, ceLogger, cePublicData, ceGasEnv
   , CommandM, runCommand, throwCmdEx
@@ -79,9 +79,6 @@ data CommandConfig = CommandConfig {
     , _ccEntity :: Maybe EntityName
     , _ccGasLimit :: Maybe Int
     , _ccGasRate :: Maybe Int
-    , _ccChainId :: Maybe Word32
-    , _ccBlockHeight :: Maybe Word64
-    , _ccBlockTime :: Maybe Int64
     }
 $(makeLenses ''CommandConfig)
 

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -289,7 +289,8 @@ namespaceDef = setTopLevelOnly $ defRNative "namespace" namespace
 chainDataDef :: NativeDef
 chainDataDef = defRNative "chain-data" chainData (funType (tTyObject a) [])
     ["(chain-data)"]
-    "Read transaction public metadata."
+    "Get transaction public metadata. Returns an object with 'chain-id', 'block-height', \
+    \'block-time', 'sender', 'gas-limit', 'gas-price', and 'gas-fee' fields."
   where
     chainData :: RNativeFun e
     chainData i as = case as of

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -313,15 +313,6 @@ chainDataDef = defRNative "chain-data" chainData (funType obj [])
         ]
     chainData i as = argsError i as
 
-envChainDataDef :: NativeDef
-envChainDataDef = defRNative "env-chain-data" envChainData
-    (funType tTyString [("new-data", obj)])
-    ["(env-chain-data { \"chain-id\": 2, \"block-height\": 20 })"]
-    "Update existing entries 'chain-data' with new values, replacing those items only."
-  where
-    envChainData :: RNativeFun e
-    envChainData = undefined
-
 mapDef :: NativeDef
 mapDef = defNative "map" map'
   (funType (TyList a) [("app",lam b a),("list",TyList b)])
@@ -485,7 +476,6 @@ langDefs =
     ,defineNamespaceDef
     ,namespaceDef
     ,chainDataDef
-    ,envChainDataDef
     ])
     where
           d = mkTyVar "d" []

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -294,11 +294,13 @@ chainDataDef = defRNative "chain-data" chainData (funType obj [])
   where
     chainData :: RNativeFun e
     chainData _ [] = do
-      pd <- view eePublicData
+      PublicData{..} <- view eePublicData
 
-      let (ParsedInteger gl) = _pmGasLimit _pdPublicMeta $ pd
-          (ParsedDecimal gp) = _pmGasPrice _pdPublicMeta $ pd
-          (ParsedDecimal gf) = _pmFee _pdPublicMeta $ pd
+      let PublicMeta{..} = _pdPublicMeta
+
+      let (ParsedInteger gl) = _pmGasLimit
+          (ParsedDecimal gp) = _pmGasPrice
+          (ParsedDecimal gf) = _pmFee
 
       pure $ toTObject TyAny def
         [ ("chain-id"    , toTerm _pdChainId    )

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -294,13 +294,11 @@ chainDataDef = defRNative "chain-data" chainData (funType obj [])
   where
     chainData :: RNativeFun e
     chainData _ [] = do
-      PublicData{..} <- view eePublicData
+      pd <- view eePublicData
 
-      let PublicMeta{..} = _pdPublicMeta
-
-      let (ParsedInteger gl) = _pmGasLimit
-          (ParsedDecimal gp) = _pmGasPrice
-          (ParsedDecimal gf) = _pmFee
+      let (ParsedInteger gl) = _pmGasLimit _pdPublicMeta $ pd
+          (ParsedDecimal gp) = _pmGasPrice _pdPublicMeta $ pd
+          (ParsedDecimal gf) = _pmFee _pdPublicMeta $ pd
 
       pure $ toTObject TyAny def
         [ ("chain-id"    , toTerm _pdChainId    )

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -300,7 +300,6 @@ chainDataDef = defRNative "chain-data" chainData (funType obj [])
 
       let (ParsedInteger gl) = _pmGasLimit
           (ParsedDecimal gp) = _pmGasPrice
-          (ParsedDecimal gf) = _pmFee
 
       pure $ toTObject TyAny def
         [ ("chain-id"    , toTerm _pdChainId    )
@@ -309,7 +308,6 @@ chainDataDef = defRNative "chain-data" chainData (funType obj [])
         , ("sender"      , toTerm _pmSender     )
         , ("gas-limit"   , toTerm gl            )
         , ("gas-price"   , toTerm gp            )
-        , ("gas-fee"     , toTerm gf            )
         ]
     chainData i as = argsError i as
 

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -105,7 +105,7 @@ initPureEvalEnv :: Maybe String -> IO (EvalEnv LibState)
 initPureEvalEnv verifyUri = do
   mv <- initLibState neverLog verifyUri >>= newMVar
   return $ EvalEnv (RefStore nativeDefs mempty) def Null (Just 0)
-    def def mv repldb def initialHash freeGasEnv permissiveNamespacePolicy (SPVSupport $ spv mv)
+    def def mv repldb def initialHash freeGasEnv permissiveNamespacePolicy (SPVSupport $ spv mv) def
 
 
 spv :: MVar (LibState) -> Text -> Object Name -> IO (Either Text (Object Name))

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -26,9 +26,6 @@ import Control.Lens
 import Control.Monad.Reader
 import Control.Monad.Catch
 
-import Criterion
-import Criterion.Types
-
 import Data.Aeson (eitherDecode,toJSON)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Default
@@ -43,6 +40,10 @@ import Data.Text.Encoding
 #if defined(ghcjs_HOST_OS)
 import qualified Pact.Analyze.Remote.Client as RemoteClient
 #else
+
+import Criterion
+import Criterion.Types
+
 import Control.Monad.State.Strict (get)
 
 import Statistics.Types (Estimate(..))

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -538,11 +538,12 @@ envChainDataDef = defZRNative "env-chain-data" envChainData
 
         let ts = fmap fst ks
             ts' = S.fromList ts
+            info = _faInfo i
 
-        unless (length ts == length ts') $ evalError (_faInfo i) $
+        unless (length ts == length ts') $ evalError info $
           "envChainData: cannot update duplicate keys: " <> pretty (ts \\ (S.toList ts'))
 
-        ud <- foldM (go . _faInfo $ i) pd ks
+        ud <- foldM (go info) pd ks
         setenv eePublicData ud
         return $ tStr $ "Updated public metadata"
       _ -> argsError i as
@@ -552,7 +553,7 @@ envChainDataDef = defZRNative "env-chain-data" envChainData
       "gas-limit"    -> pure $ set (pdPublicMeta . pmGasLimit) (ParsedInteger . fromIntegral $ l) pd
       "block-height" -> pure $ set pdBlockHeight (fromIntegral l) pd
       "block-time"   -> pure $ set pdBlockTime (fromIntegral l) pd
-      t              -> evalError i $ "envChainData: found bad public metadata key: " <> pretty t
+      t              -> evalError i $ "envChainData: bad public metadata key: " <> pretty t
 
     go i pd ((FieldKey k), (TLiteral (LDecimal l) _)) = case Text.unpack k of
       "gas-price" -> pure $ set (pdPublicMeta . pmGasPrice) (ParsedDecimal l) pd

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -19,34 +19,42 @@
 
 module Pact.Repl.Lib where
 
+
 import Control.Arrow ((&&&))
-import Data.Default
-import Data.Semigroup (Endo(..))
-import qualified Data.HashMap.Strict as HM
+import Control.Concurrent.MVar
+import Control.Lens
 import Control.Monad.Reader
 import Control.Monad.Catch
-import Control.Lens
-import qualified Data.Set as S
-import qualified Data.ByteString.Lazy as BSL
-import Control.Concurrent.MVar
+
+import Criterion
+import Criterion.Types
+
 import Data.Aeson (eitherDecode,toJSON)
-import qualified Data.Text as Text
-import Data.Text.Encoding
+import qualified Data.ByteString.Lazy as BSL
+import Data.Default
+import qualified Data.HashMap.Strict as HM
 import Data.Maybe
 import qualified Data.Map as M
+import Data.Semigroup (Endo(..))
+import qualified Data.Set as S
+import qualified Data.Text as Text
+import Data.Text.Encoding
+
 #if defined(ghcjs_HOST_OS)
 import qualified Pact.Analyze.Remote.Client as RemoteClient
 #else
 import Control.Monad.State.Strict (get)
-import Criterion
-import Criterion.Types
-import qualified Pact.Analyze.Check as Check
+
 import Statistics.Types (Estimate(..))
+
+import qualified Pact.Analyze.Check as Check
 import qualified Pact.Types.Crypto as Crypto
 import Pact.Types.Util (fromText')
 #endif
+
+import Pact.Parse
 import Pact.Typechecker
-import Pact.Types.Typecheck
+import qualified Pact.Types.Typecheck as TC
 -- intentionally hidden unused functions to prevent lib functions from consuming gas
 import Pact.Native.Internal hiding (defRNative,defGasRNative,defNative)
 import qualified Pact.Native.Internal as Native
@@ -180,6 +188,7 @@ replDefs = ("Repl",
       (funType tTyString [("type",tTyString),("payload",tTyObject TyAny),("output",tTyObject TyAny)])
       [LitExample "(mock-spv \"TXOUT\" { 'proof: \"a54f54de54c54d89e7f\" } { 'amount: 10.0, 'account: \"Dave\", 'chainId: 1 })"]
       "Mock a successful call to 'spv-verify' with TYPE and PAYLOAD to return OUTPUT."
+     , envChainDataDef
      ])
      where
        json = mkTyVar "a" [tTyInteger,tTyString,tTyTime,tTyDecimal,tTyBool,
@@ -411,14 +420,14 @@ tc i as = case as of
       case mdm of
         Nothing -> evalError' i $ "No such module: " <> pretty modname
         Just md -> do
-          r :: Either CheckerException ([TopLevel Node],[Failure]) <-
+          r :: Either TC.CheckerException ([TC.TopLevel TC.Node],[TC.Failure]) <-
             try $ liftIO $ typecheckModule dbg md
           case r of
-            Left (CheckerException ei e) -> evalError ei ("Typechecker Internal Error: " <> pretty e)
+            Left (TC.CheckerException ei e) -> evalError ei ("Typechecker Internal Error: " <> pretty e)
             Right (_,fails) -> case fails of
               [] -> return $ tStr $ "Typecheck " <> modname <> ": success"
               _ -> do
-                setop $ TcErrors $ map (\(Failure ti s) -> renderInfo (_tiInfo ti) ++ ":Warning: " ++ s) fails
+                setop $ TcErrors $ map (\(TC.Failure ti s) -> renderInfo (TC._tiInfo ti) ++ ":Warning: " ++ s) fails
                 return $ tStr $ "Typecheck " <> modname <> ": Unable to resolve all types"
 
 verify :: RNativeFun LibState
@@ -511,3 +520,37 @@ testCapability _ [ c@TApp{} ] = do
     Nothing -> "Capability granted"
     Just cap' -> "Capability granted: " <> tShow cap'
 testCapability i as = argsError' i as
+
+-- | Modify existing env chain data with new data, replacing just those
+-- environment items only.
+envChainDataDef :: NativeDef
+envChainDataDef = defZRNative "env-chain-data" envChainData
+    (funType tTyString [("new-data", tTyObject TyAny)])
+    ["(env-chain-data { \"chain-id\": 2, \"block-height\": 20 })"]
+    "Update existing entries 'chain-data' with NEW-DATA, replacing those items only."
+  where
+    envChainData :: RNativeFun LibState
+    envChainData i as = case as of
+      [TObject (Object ks _ _) _] -> do
+        pd <- view eePublicData
+        ud <- foldM (go . _faInfo $ i) pd ks
+        setenv eePublicData ud
+        return $ tStr $ "Updated public metadata"
+      _ -> argsError i as
+
+    go i pd ((FieldKey k), (TLiteral (LInteger l) _)) = case Text.unpack k of
+      "chain-id"     -> pure $ set pdChainId (fromIntegral l) pd
+      "gas-limit"    -> pure $ set (pdPublicMeta . pmGasLimit) (ParsedInteger . fromIntegral $ l) pd
+      "block-height" -> pure $ set pdBlockHeight (fromIntegral l) pd
+      "block-time"   -> pure $ set pdBlockTime (fromIntegral l) pd
+      t              -> evalError i $ "Bad public metadata key: " <> pretty t
+
+    go i pd ((FieldKey k), (TLiteral (LDecimal l) _)) = case Text.unpack k of
+      "gas-price" -> pure $ set (pdPublicMeta . pmGasPrice) (ParsedDecimal l) pd
+      "gas-fee"   -> pure $ set (pdPublicMeta . pmFee) (ParsedDecimal l) pd
+      t           -> evalError i $ "Bad public metadata key: " <> pretty t
+
+    go i pd ((FieldKey k), (TLiteral (LString l) _)) = case Text.unpack k of
+      "sender" -> pure $ set (pdPublicMeta . pmSender) l pd
+      t        -> evalError i $ "Bad public metadata key: " <> pretty t
+    go i _ as = evalError i $ "Bad public metadata values: " <> pretty as

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -539,7 +539,7 @@ envChainDataDef = defZRNative "env-chain-data" envChainData
         let ts = fmap fst ks
             ts' = S.fromList ts
             info = _faInfo i
-        
+
         unless (length ts == length ts') $ evalError info $
           "envChainData: cannot update duplicate keys: " <> pretty (ts \\ (S.toList ts'))
 
@@ -557,7 +557,6 @@ envChainDataDef = defZRNative "env-chain-data" envChainData
 
     go i pd ((FieldKey k), (TLiteral (LDecimal l) _)) = case Text.unpack k of
       "gas-price" -> pure $ set (pdPublicMeta . pmGasPrice) (ParsedDecimal l) pd
-      "gas-fee"   -> pure $ set (pdPublicMeta . pmFee) (ParsedDecimal l) pd
       t           -> evalError i $ "envChainData: bad public metadata key: " <> pretty t
 
     go i pd ((FieldKey k), (TLiteral (LString l) _)) = case Text.unpack k of

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -539,13 +539,13 @@ envChainDataDef = defZRNative "env-chain-data" envChainData
         let ts = fmap fst ks
             ts' = S.fromList ts
             info = _faInfo i
-
+        
         unless (length ts == length ts') $ evalError info $
           "envChainData: cannot update duplicate keys: " <> pretty (ts \\ (S.toList ts'))
 
         ud <- foldM (go info) pd ks
         setenv eePublicData ud
-        return $ tStr $ "Updated public metadata"
+        return $ tStr "Updated public metadata"
       _ -> argsError i as
 
     go i pd ((FieldKey k), (TLiteral (LInteger l) _)) = case Text.unpack k of

--- a/src/Pact/Types/ChainMeta.hs
+++ b/src/Pact/Types/ChainMeta.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+-- |
+-- Module      :  Pact.Types.Runtime
+-- Copyright   :  (C) 2016 Stuart Popejoy
+-- License     :  BSD-style (see the file LICENSE)
+-- Maintainer  :  Stuart Popejoy <stuart@kadena.io>
+--
+-- Meta data and its types
+--
+module Pact.Types.ChainMeta
+  ( -- * data
+    Address(..)
+  , PrivateMeta(..)
+  , PublicMeta(..)
+  , HasPlafMeta(..)
+  , PublicData(..)
+    -- * optics
+  , aFrom, aTo
+  , pmAddress, pmChainId, pmSender, pmGasLimit, pmGasPrice, pmFee
+  , pdChainId, pdPublicMeta, pdBlockHeight, pdBlockTime
+  ) where
+
+
+import GHC.Generics
+
+import Control.DeepSeq (NFData)
+import Control.Lens (makeLenses)
+
+import Data.Aeson
+import Data.Default (Default, def)
+import Data.Hashable (Hashable)
+import Data.Int (Int64)
+import Data.Serialize (Serialize)
+import Data.Set (Set)
+import Data.String (IsString)
+import Data.Text
+import Data.Word (Word32, Word64)
+
+-- internal pact modules
+
+import Pact.Parse
+import Pact.Types.Util (AsString, lensyToJSON, lensyParseJSON)
+
+
+newtype EntityName = EntityName Text
+  deriving (Eq, Ord, NFData, ToJSON, FromJSON, Default, Generic, IsString, Serialize, Hashable, AsString)
+
+instance Show EntityName where show (EntityName t) = show t
+
+
+-- | Confidential/Encrypted addressing info, for use in metadata on privacy-supporting platforms.
+data Address = Address
+  { _aFrom :: EntityName
+  , _aTo :: Set EntityName
+  }
+  deriving (Eq,Show,Ord,Generic)
+
+instance NFData Address
+instance Serialize Address
+instance ToJSON Address where toJSON = lensyToJSON 2
+instance FromJSON Address where parseJSON = lensyParseJSON 2
+makeLenses ''Address
+
+newtype PrivateMeta = PrivateMeta { _pmAddress :: Maybe Address }
+  deriving (Eq,Show,Generic)
+makeLenses ''PrivateMeta
+
+instance Default PrivateMeta where def = PrivateMeta def
+instance ToJSON PrivateMeta where toJSON = lensyToJSON 3
+instance FromJSON PrivateMeta where parseJSON = lensyParseJSON 3
+instance NFData PrivateMeta
+instance Serialize PrivateMeta
+
+-- | Contains all necessary metadata for a Chainweb-style public chain.
+data PublicMeta = PublicMeta
+  { _pmChainId :: Text
+  , _pmSender :: Text
+  , _pmGasLimit :: ParsedInteger
+  , _pmGasPrice :: ParsedDecimal
+  , _pmFee :: ParsedDecimal
+  } deriving (Eq, Show, Generic)
+makeLenses ''PublicMeta
+
+instance Default PublicMeta where def = PublicMeta "" "" 0 0 0
+instance ToJSON PublicMeta where toJSON = lensyToJSON 3
+instance FromJSON PublicMeta where parseJSON = lensyParseJSON 3
+instance NFData PublicMeta
+instance Serialize PublicMeta
+
+class HasPlafMeta a where
+  getPrivateMeta :: a -> PrivateMeta
+  getPublicMeta :: a -> PublicMeta
+
+instance HasPlafMeta PrivateMeta where
+  getPrivateMeta = id
+  getPublicMeta = const def
+
+instance HasPlafMeta PublicMeta where
+  getPrivateMeta = const def
+  getPublicMeta = id
+
+instance HasPlafMeta () where
+  getPrivateMeta = const def
+  getPublicMeta = const def
+
+data PublicData = PublicData
+  { _pdPublicMeta :: PublicMeta
+  , _pdChainId :: Word32
+  , _pdBlockHeight :: Word64
+  , _pdBlockTime :: Int64
+  }
+  deriving (Show, Eq, Generic)
+makeLenses ''PublicData
+
+instance ToJSON PublicData where toJSON = lensyToJSON 3
+instance FromJSON PublicData where parseJSON = lensyParseJSON 3
+instance Default PublicData where def = PublicData def def def def

--- a/src/Pact/Types/ChainMeta.hs
+++ b/src/Pact/Types/ChainMeta.hs
@@ -20,7 +20,7 @@ module Pact.Types.ChainMeta
   , EntityName(..)
     -- * optics
   , aFrom, aTo
-  , pmAddress, pmChainId, pmSender, pmGasLimit, pmGasPrice, pmFee
+  , pmAddress, pmChainId, pmSender, pmGasLimit, pmGasPrice
   , pdChainId, pdPublicMeta, pdBlockHeight, pdBlockTime
   ) where
 
@@ -81,11 +81,10 @@ data PublicMeta = PublicMeta
   , _pmSender :: Text
   , _pmGasLimit :: ParsedInteger
   , _pmGasPrice :: ParsedDecimal
-  , _pmFee :: ParsedDecimal
   } deriving (Eq, Show, Generic)
 makeLenses ''PublicMeta
 
-instance Default PublicMeta where def = PublicMeta "" "" 0 0 0
+instance Default PublicMeta where def = PublicMeta "" "" 0 0
 instance ToJSON PublicMeta where toJSON = lensyToJSON 3
 instance FromJSON PublicMeta where parseJSON = lensyParseJSON 3
 instance NFData PublicMeta

--- a/src/Pact/Types/ChainMeta.hs
+++ b/src/Pact/Types/ChainMeta.hs
@@ -11,12 +11,13 @@
 -- Meta data and its types
 --
 module Pact.Types.ChainMeta
-  ( -- * data
+  ( -- * types
     Address(..)
   , PrivateMeta(..)
   , PublicMeta(..)
   , HasPlafMeta(..)
   , PublicData(..)
+  , EntityName(..)
     -- * optics
   , aFrom, aTo
   , pmAddress, pmChainId, pmSender, pmGasLimit, pmGasPrice, pmFee

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -61,10 +61,10 @@ import Data.Maybe  (fromMaybe)
 import GHC.Generics
 import Prelude
 
+import Pact.Parse (parseExprs)
 import Pact.Types.Runtime hiding (PublicKey)
 import Pact.Types.Orphans ()
 import Pact.Types.RPC
-import Pact.Parse
 
 
 #if !defined(ghcjs_HOST_OS)

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -31,10 +31,6 @@ module Pact.Types.Command
   , PPKScheme(..)
 #endif
   , ProcessedCommand(..),_ProcSucc,_ProcFail
-  , Address(..),aFrom,aTo
-  , PrivateMeta(..),pmAddress
-  , PublicMeta(..),pmChainId,pmSender,pmGasLimit,pmGasPrice,pmFee
-  , HasPlafMeta(..)
   , Payload(..),pMeta,pNonce,pPayload
   , ParsedCode(..),pcCode,pcExps
   , UserSig(..),usScheme,usPubKey,usAddress,usSig
@@ -59,8 +55,6 @@ import Data.String
 import Data.Hashable (Hashable)
 import Data.Aeson as A
 import Data.Text hiding (filter, all)
-import qualified Data.Set as S
-import Data.Default (Default,def)
 import Data.Maybe  (fromMaybe)
 
 
@@ -189,55 +183,6 @@ data ParsedCode = ParsedCode
 instance NFData ParsedCode
 
 
--- | Confidential/Encrypted addressing info, for use in metadata on privacy-supporting platforms.
-data Address = Address {
-    _aFrom :: EntityName
-  , _aTo :: S.Set EntityName
-  } deriving (Eq,Show,Ord,Generic)
-instance NFData Address
-instance Serialize Address
-instance ToJSON Address where toJSON = lensyToJSON 2
-instance FromJSON Address where parseJSON = lensyParseJSON 2
-
-data PrivateMeta = PrivateMeta
-  { _pmAddress :: Maybe Address
-  } deriving (Eq,Show,Generic)
-instance Default PrivateMeta where def = PrivateMeta def
-instance ToJSON PrivateMeta where toJSON = lensyToJSON 3
-instance FromJSON PrivateMeta where parseJSON = lensyParseJSON 3
-instance NFData PrivateMeta
-instance Serialize PrivateMeta
-
--- | Contains all necessary metadata for a Chainweb-style public chain.
-data PublicMeta = PublicMeta
-  { _pmChainId :: Text
-  , _pmSender :: Text
-  , _pmGasLimit :: ParsedInteger
-  , _pmGasPrice :: ParsedDecimal
-  , _pmFee :: ParsedDecimal
-  } deriving (Eq,Show,Generic)
-instance Default PublicMeta where def = PublicMeta "" "" 0 0 0
-instance ToJSON PublicMeta where toJSON = lensyToJSON 3
-instance FromJSON PublicMeta where parseJSON = lensyParseJSON 3
-instance NFData PublicMeta
-instance Serialize PublicMeta
-
-class HasPlafMeta a where
-  getPrivateMeta :: a -> PrivateMeta
-  getPublicMeta :: a -> PublicMeta
-
-instance HasPlafMeta PrivateMeta where
-  getPrivateMeta = id
-  getPublicMeta = const def
-
-instance HasPlafMeta PublicMeta where
-  getPrivateMeta = const def
-  getPublicMeta = id
-
-instance HasPlafMeta () where
-  getPrivateMeta = const def
-  getPublicMeta = const def
-
 -- | Payload combines a 'PactRPC' with a nonce and platform-specific metadata.
 data Payload m c = Payload
   { _pPayload :: !(PactRPC c)
@@ -352,9 +297,6 @@ initialRequestKey = RequestKey initialHash
 makeLenses ''UserSig
 makeLenses ''CommandExecInterface
 makeLenses ''ExecutionMode
-makeLenses ''Address
-makeLenses ''PrivateMeta
-makeLenses ''PublicMeta
 makeLenses ''Command
 makeLenses ''ParsedCode
 makeLenses ''Payload

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -61,7 +61,6 @@ import Data.Maybe  (fromMaybe)
 import GHC.Generics
 import Prelude
 
-import Pact.Parse (parseExprs)
 import Pact.Types.Runtime hiding (PublicKey)
 import Pact.Types.Orphans ()
 import Pact.Types.RPC
@@ -69,8 +68,10 @@ import Pact.Types.RPC
 
 #if !defined(ghcjs_HOST_OS)
 import qualified Data.ByteString.Lazy as BSL
-import Pact.Types.Crypto              as Base
 import qualified Crypto.Hash          as H
+
+import Pact.Parse (parseExprs)
+import Pact.Types.Crypto              as Base
 #else
 import Pact.Types.Hash
 import Pact.Types.Scheme (PPKScheme(..), defPPKScheme)

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE DeriveGeneric #-}
 -- |
 -- Module      :  Pact.Types.Runtime
 -- Copyright   :  (C) 2016 Stuart Popejoy
@@ -24,7 +25,7 @@ module Pact.Types.Runtime
    RefStore(..),rsNatives,rsModules,updateRefStore,
    EntityName(..),
    EvalEnv(..),eeRefStore,eeMsgSigs,eeMsgBody,eeTxId,eeEntity,eePactStep,eePactDbVar,
-   eePactDb,eePurity,eeHash,eeGasEnv,eeNamespacePolicy,eeSPVSupport,
+   eePactDb,eePurity,eeHash,eeGasEnv,eeNamespacePolicy,eeSPVSupport,eePublicData,
    Purity(..),PureNoDb,PureSysRead,EnvNoDb(..),EnvReadOnly(..),mkNoDbEnv,mkReadOnlyEnv,
    StackFrame(..),sfName,sfLoc,sfApp,
    PactExec(..),peStepCount,peYield,peExecuted,pePactId,peStep,peContinuation,
@@ -39,12 +40,19 @@ module Pact.Types.Runtime
    NamespacePolicy(..), nsPolicy,
    permissiveNamespacePolicy,
    SPVSupport(..),noSPVSupport,
+   Address(..),aFrom,aTo,
+   PrivateMeta(..),pmAddress,
+   PublicMeta(..),pmChainId,pmSender,pmGasLimit,pmGasPrice,pmFee,
+   HasPlafMeta(..),
    PactContinuation(..),
+   PublicData(..), pdChainId, pdPublicMeta, pdBlockHeight, pdBlockTime,
    module Pact.Types.Lang,
    module Pact.Types.Util,
    module Pact.Types.Persistence,
    module Pact.Types.Gas
    ) where
+
+import GHC.Generics
 
 import Control.Arrow ((&&&))
 import Control.Lens hiding ((.=),DefName)
@@ -52,17 +60,21 @@ import Control.DeepSeq
 import Control.Monad.Except
 import Control.Monad.State.Strict
 import Control.Monad.Reader
+
 import qualified Data.Map.Strict as M
 import qualified Data.HashMap.Strict as HM
 import Data.Aeson hiding (Object)
-import qualified Data.Set as S
 import Data.String
 import Data.Default
+import Data.Int
 import Control.Monad.Catch
 import Control.Concurrent.MVar
 import Data.Serialize (Serialize)
 import Data.Hashable
+import qualified Data.Set as S
+import Data.Word (Word32, Word64)
 
+import Pact.Parse
 import Pact.Types.Gas
 import Pact.Types.Lang
 import Pact.Types.Orphans ()
@@ -215,6 +227,72 @@ newtype SPVSupport = SPVSupport {
 noSPVSupport :: SPVSupport
 noSPVSupport = SPVSupport $ \_ _ -> return $ Left $ "SPV verify not supported"
 
+-- | Confidential/Encrypted addressing info, for use in metadata on privacy-supporting platforms.
+data Address = Address {
+    _aFrom :: EntityName
+  , _aTo :: S.Set EntityName
+  } deriving (Eq,Show,Ord,Generic)
+instance NFData Address
+instance Serialize Address
+instance ToJSON Address where toJSON = lensyToJSON 2
+instance FromJSON Address where parseJSON = lensyParseJSON 2
+makeLenses ''Address
+
+data PrivateMeta = PrivateMeta
+  { _pmAddress :: Maybe Address
+  } deriving (Eq,Show,Generic)
+$(makeLenses ''PrivateMeta)
+instance Default PrivateMeta where def = PrivateMeta def
+instance ToJSON PrivateMeta where toJSON = lensyToJSON 3
+instance FromJSON PrivateMeta where parseJSON = lensyParseJSON 3
+instance NFData PrivateMeta
+instance Serialize PrivateMeta
+
+-- | Contains all necessary metadata for a Chainweb-style public chain.
+data PublicMeta = PublicMeta
+  { _pmChainId :: Text
+  , _pmSender :: Text
+  , _pmGasLimit :: ParsedInteger
+  , _pmGasPrice :: ParsedDecimal
+  , _pmFee :: ParsedDecimal
+  } deriving (Eq,Show,Generic)
+makeLenses ''PublicMeta
+
+instance Default PublicMeta where def = PublicMeta "" "" 0 0 0
+instance ToJSON PublicMeta where toJSON = lensyToJSON 3
+instance FromJSON PublicMeta where parseJSON = lensyParseJSON 3
+instance NFData PublicMeta
+instance Serialize PublicMeta
+
+class HasPlafMeta a where
+  getPrivateMeta :: a -> PrivateMeta
+  getPublicMeta :: a -> PublicMeta
+
+instance HasPlafMeta PrivateMeta where
+  getPrivateMeta = id
+  getPublicMeta = const def
+
+instance HasPlafMeta PublicMeta where
+  getPrivateMeta = const def
+  getPublicMeta = id
+
+instance HasPlafMeta () where
+  getPrivateMeta = const def
+  getPublicMeta = const def
+
+data PublicData = PublicData
+  { _pdPublicMeta :: PublicMeta
+  , _pdChainId :: Word32
+  , _pdBlockHeight :: Word64
+  , _pdBlockTime :: Int64
+  }
+  deriving (Show, Eq, Generic)
+makeLenses ''PublicData
+
+instance ToJSON PublicData where toJSON = lensyToJSON 3
+instance FromJSON PublicData where parseJSON = lensyParseJSON 3
+instance Default PublicData where def = PublicData def def def def
+
 -- | Interpreter reader environment, parameterized over back-end MVar state type.
 data EvalEnv e = EvalEnv {
       -- | Environment references.
@@ -243,6 +321,8 @@ data EvalEnv e = EvalEnv {
     , _eeNamespacePolicy :: NamespacePolicy
       -- | SPV backend
     , _eeSPVSupport :: SPVSupport
+      -- | Env public data
+    , _eePublicData :: PublicData
     }
 makeLenses ''EvalEnv
 
@@ -468,6 +548,7 @@ mkPureEnv holder purity readRowImpl env@EvalEnv{..} = do
     _eeGasEnv
     permissiveNamespacePolicy
     _eeSPVSupport
+    _eePublicData
 
 
 mkNoDbEnv :: EvalEnv e -> Eval e (EvalEnv (EnvNoDb e))

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE DeriveGeneric #-}
 -- |
 -- Module      :  Pact.Types.Runtime
 -- Copyright   :  (C) 2016 Stuart Popejoy

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -23,7 +23,6 @@ module Pact.Types.Runtime
    PactStep(..),psStep,psRollback,psPactId,psResume,
    ModuleData(..), mdModule, mdRefMap,
    RefStore(..),rsNatives,rsModules,updateRefStore,
-   EntityName(..),
    EvalEnv(..),eeRefStore,eeMsgSigs,eeMsgBody,eeTxId,eeEntity,eePactStep,eePactDbVar,
    eePactDb,eePurity,eeHash,eeGasEnv,eeNamespacePolicy,eeSPVSupport,eePublicData,
    Purity(..),PureNoDb,PureSysRead,EnvNoDb(..),EnvReadOnly(..),mkNoDbEnv,mkReadOnlyEnv,

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -47,11 +47,9 @@ module Pact.Types.Runtime
    module Pact.Types.ChainMeta
    ) where
 
-import GHC.Generics
 
 import Control.Arrow ((&&&))
 import Control.Lens hiding ((.=),DefName)
-import Control.DeepSeq
 import Control.Monad.Except
 import Control.Monad.State.Strict
 import Control.Monad.Reader
@@ -61,15 +59,10 @@ import qualified Data.HashMap.Strict as HM
 import Data.Aeson hiding (Object)
 import Data.String
 import Data.Default
-import Data.Int
 import Control.Monad.Catch
 import Control.Concurrent.MVar
-import Data.Serialize (Serialize)
-import Data.Hashable
 import qualified Data.Set as S
-import Data.Word (Word32, Word64)
 
-import Pact.Parse
 import Pact.Types.ChainMeta
 import Pact.Types.Gas
 import Pact.Types.Lang

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -1123,6 +1123,7 @@ makeLenses ''Def
 makeLenses ''ModuleName
 makePrisms ''DefType
 makeLenses ''Object
+makeLenses ''FieldKey
 
 deriveEq1 ''App
 deriveEq1 ''BindType

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -104,8 +104,7 @@ import Data.Int (Int64)
 import Data.Serialize (Serialize)
 import Data.Eq.Deriving
 import Text.Show.Deriving
-import Data.Word (Word64)
-
+import Data.Word (Word64, Word32)
 
 import Pact.Types.Parser
 import Pact.Types.Pretty hiding (dot)
@@ -1030,6 +1029,9 @@ instance ToTerm Literal where toTerm = tLit
 instance ToTerm Value where toTerm = (`TValue` def)
 instance ToTerm UTCTime where toTerm = tLit . LTime
 instance ToTerm PactId where toTerm = tLit . LInteger . fromIntegral
+instance ToTerm Word32 where toTerm = tLit . LInteger . fromIntegral
+instance ToTerm Word64 where toTerm = tLit . LInteger . fromIntegral
+instance ToTerm Int64 where toTerm = tLit . LInteger . fromIntegral
 
 
 toTObject :: Type (Term n) -> Info -> [(FieldKey,Term n)] -> Term n

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -1123,7 +1123,6 @@ makeLenses ''Def
 makeLenses ''ModuleName
 makePrisms ''DefType
 makeLenses ''Object
-makeLenses ''FieldKey
 
 deriveEq1 ''App
 deriveEq1 ''BindType

--- a/tests/SchemeSpec.hs
+++ b/tests/SchemeSpec.hs
@@ -12,7 +12,7 @@ import qualified Crypto.Hash              as H
 
 import Pact.ApiReq
 import Pact.Types.Crypto
-import Pact.Types.Command hiding (Address)
+import Pact.Types.ChainMeta hiding (Address)
 import Pact.Types.Util (toB16Text, fromJSON')
 
 
@@ -65,7 +65,7 @@ testKeyPairImport = do
         apiKP = ApiKeyPair priv (Just pub) (Just addr) (Just scheme)
     kp <- mkKeyPairs [apiKP]
     (map getKeyPairComponents kp) `shouldBe` [someED25519Pair]
-    
+
   it "imports ETH Key Pair" $ do
     let (pub, priv, addr, scheme) = someETHPair
         apiKP = ApiKeyPair priv (Just pub) (Just addr) (Just scheme)

--- a/tests/SchemeSpec.hs
+++ b/tests/SchemeSpec.hs
@@ -12,7 +12,7 @@ import qualified Crypto.Hash              as H
 
 import Pact.ApiReq
 import Pact.Types.Crypto
-import Pact.Types.ChainMeta hiding (Address)
+import Pact.Types.Command
 import Pact.Types.Util (toB16Text, fromJSON')
 
 

--- a/tests/pact/pubdata.repl
+++ b/tests/pact/pubdata.repl
@@ -1,0 +1,27 @@
+;; Chain public metadata should initialize with defaults
+(expect "chain data chain id initializes with 0" (= (at "chain-id" (chain-data)) 0))
+(expect "chain data block height initializes with 0" (= (at "block-height" (chain-data)) 0))
+(expect "chain data block time id initializes with 0" (= (at "block-time" (chain-data)) 0))
+(expect "chain data sender initializes with \"\"" (= (at "sender" (chain-data)) ""))
+(expect "chain data gas limit initializes with 0" (= (at "gas-limit" (chain-data)) 0))
+(expect "chain data gas price initializes with 0.0" (= (at "gas-price" (chain-data)) 0.0))
+(expect "chain data gas fee initializes with 0.0" (= (at "gas-fee" (chain-data)) 0.0))
+
+;; Chain public metadata should reflect updates
+(env-chain-data { "chain-id": 2, "block-height": 20 })
+(expect "chain data chain id reflects updated value" (= (at "chain-id" (chain-data)) 2)
+(expect "chain data block height reflects updated value" (= (at "block-height" (chain-data)) 20))
+
+;; show that updates are granular
+(env-chain-data { "sender": "squawk" })
+(expect "chain data sender reflects updated value" (= (at "sender" (chain-data)) "squawk")
+
+;; show that updates are cumulative
+(expect "chain data chain id reflects updated value" (= (at "chain-id" (chain-data)) 2)
+(expect "chain data block height reflects updated value" (= (at "block-height" (chain-data)) 20))
+
+;; Show failure on improper keys
+(expect-failure "chain data should fail to update when wrong key is specified" (env-chain-data { "foo": 8 }))
+
+;; Show failure on wrongly-typed keys
+(expect-failure "chain data should fail for wrongly-typed keys" (env-chain-data { "chain-id": 0.0 }))

--- a/tests/pact/pubdata.repl
+++ b/tests/pact/pubdata.repl
@@ -5,7 +5,6 @@
 (expect "chain data sender initializes with \"\"" "" (at "sender" (chain-data)))
 (expect "chain data gas limit initializes with 0" 0 (at "gas-limit" (chain-data)))
 (expect "chain data gas price initializes with 0.0" 0.0 (at "gas-price" (chain-data)))
-(expect "chain data gas fee initializes with 0.0" 0.0 (at "gas-fee" (chain-data)))
 
 ;; Chain public metadata should reflect updates
 (env-chain-data { "chain-id": 2, "block-height": 20 })

--- a/tests/pact/pubdata.repl
+++ b/tests/pact/pubdata.repl
@@ -1,24 +1,24 @@
 ;; Chain public metadata should initialize with defaults
-(expect "chain data chain id initializes with 0" (= (at "chain-id" (chain-data)) 0))
-(expect "chain data block height initializes with 0" (= (at "block-height" (chain-data)) 0))
-(expect "chain data block time id initializes with 0" (= (at "block-time" (chain-data)) 0))
-(expect "chain data sender initializes with \"\"" (= (at "sender" (chain-data)) ""))
-(expect "chain data gas limit initializes with 0" (= (at "gas-limit" (chain-data)) 0))
-(expect "chain data gas price initializes with 0.0" (= (at "gas-price" (chain-data)) 0.0))
-(expect "chain data gas fee initializes with 0.0" (= (at "gas-fee" (chain-data)) 0.0))
+(expect "chain data chain id initializes with 0" 0 (at "chain-id" (chain-data)))
+(expect "chain data block height initializes with 0" 0 (at "block-height" (chain-data)))
+(expect "chain data block time id initializes with 0" 0 (at "block-time" (chain-data)))
+(expect "chain data sender initializes with \"\"" "" (at "sender" (chain-data)))
+(expect "chain data gas limit initializes with 0" 0 (at "gas-limit" (chain-data)))
+(expect "chain data gas price initializes with 0.0" 0.0 (at "gas-price" (chain-data)))
+(expect "chain data gas fee initializes with 0.0" 0.0 (at "gas-fee" (chain-data)))
 
 ;; Chain public metadata should reflect updates
 (env-chain-data { "chain-id": 2, "block-height": 20 })
-(expect "chain data chain id reflects updated value" (= (at "chain-id" (chain-data)) 2)
-(expect "chain data block height reflects updated value" (= (at "block-height" (chain-data)) 20))
+(expect "chain data chain id reflects updated value" 2 (at "chain-id" (chain-data)))
+(expect "chain data block height reflects updated value" 20 (at "block-height" (chain-data)))
 
 ;; show that updates are granular
 (env-chain-data { "sender": "squawk" })
-(expect "chain data sender reflects updated value" (= (at "sender" (chain-data)) "squawk")
+(expect "chain data sender reflects updated value" "squawk" (at "sender" (chain-data)))
 
 ;; show that updates are cumulative
-(expect "chain data chain id reflects updated value" (= (at "chain-id" (chain-data)) 2)
-(expect "chain data block height reflects updated value" (= (at "block-height" (chain-data)) 20))
+(expect "chain data chain id reflects updated value" 2 (at "chain-id" (chain-data)))
+(expect "chain data block height reflects updated value" 20 (at "block-height" (chain-data)))
 
 ;; Show failure on improper keys
 (expect-failure "chain data should fail to update when wrong key is specified" (env-chain-data { "foo": 8 }))

--- a/tests/pact/pubdata.repl
+++ b/tests/pact/pubdata.repl
@@ -25,3 +25,6 @@
 
 ;; Show failure on wrongly-typed keys
 (expect-failure "chain data should fail for wrongly-typed keys" (env-chain-data { "chain-id": 0.0 }))
+
+;; Show failure on duplicate keys
+(expect-failure "chain data should not accept duplicate updates" (env-chain-data { "chain-id": 1, "chain-id:": 2 }))


### PR DESCRIPTION
Adds two functions: `chain-data`, and `env-chain-data` which allows us to access public metadata from the pact repl. This is part of the ongoing pact testnet work. 

- [x] add `chain-data`
- [x] add `env-chain-data`
- [x] tests