### PR TITLE
Fix pretty-printing of strings

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -29,6 +29,18 @@ pact> (bind { "a": 1, "b": 2 } { "a" := a-value } a-value)
 ```
 
 
+### chain-data {#chain-data}
+
+ *&rarr;*&nbsp;`object:[]<{o}>`
+
+
+Get transaction public metadata. Returns an object with 'chain-id', 'block-height', 'block-time', 'sender', 'gas-limit', 'gas-price', and 'gas-fee' fields.
+```lisp
+pact> (chain-data)
+{"chain-id": 0,"block-height": 0,"block-time": 0,"sender": "","gas-limit": 0,"gas-price": 0}
+```
+
+
 ### compose {#compose}
 
 *x*&nbsp;`x:<a> -> <b>` *y*&nbsp;`x:<b> -> <c>` *value*&nbsp;`<a>` *&rarr;*&nbsp;`<c>`
@@ -1367,6 +1379,18 @@ Continue previously-initiated pact identified by PACT-ID at STEP, optionally spe
 (continue-pact 2 1)
 (continue-pact 2 1 true)
 (continue-pact 2 1 false { "rate": 0.9 })
+```
+
+
+### env-chain-data {#env-chain-data}
+
+*new-data*&nbsp;`object:[]*` *&rarr;*&nbsp;`string`
+
+
+Update existing entries 'chain-data' with NEW-DATA, replacing those items only.
+```lisp
+pact> (env-chain-data { "chain-id": 2, "block-height": 20 })
+"Updated public metadata"
 ```
 
 

--- a/src-ghc/Pact/Persist/SQLite.hs
+++ b/src-ghc/Pact/Persist/SQLite.hs
@@ -111,11 +111,11 @@ encodeBlob a = SText $ Utf8 $ BSL.toStrict $ encode a
 
 expectSing :: Show a => String -> [a] -> IO a
 expectSing _ [s] = return s
-expectSing desc v = throwDbError $ "Expected single-" <> pretty desc <> " result, got: " <> viaShow v
+expectSing desc v = throwDbError $ "Expected single-" <> prettyString desc <> " result, got: " <> viaShow v
 
 expectTwo :: Show a => String -> [a] -> IO (a,a)
 expectTwo _ [a,b] = return (a,b)
-expectTwo desc v = throwDbError $ "Expected two-" <> pretty desc <> " result, got: " <> viaShow v
+expectTwo desc v = throwDbError $ "Expected two-" <> prettyString desc <> " result, got: " <> viaShow v
 
 kTextTys :: KeyTys DataKey
 kTextTys = KeyTys "text" (SText . toUtf8 . asString) RText decodeText

--- a/src/Pact/Analyze/Parse/Prop.hs
+++ b/src/Pact/Analyze/Parse/Prop.hs
@@ -191,7 +191,7 @@ parseBindings mkBinding = \case
     (nameTy:) <$> parseBindings mkBinding exps
   exp@(EAtom _):_exps -> throwErrorIn exp
     "type annotation required for all property bindings."
-  exp -> throwErrorD $ "in " <> pretty exp <> ", unexpected binding form"
+  exp -> throwErrorD $ "in " <> prettyList exp <> ", unexpected binding form"
 
 parseType :: Exp Info -> Maybe QType
 parseType = \case
@@ -288,7 +288,7 @@ inferPreProp preProp = case preProp of
     as' <- traverse inferPreProp as
     Some listTy litList <- maybe
       (throwErrorD
-        ("unable to make list of a single type from " <> pretty as'))
+        ("unable to make list of a single type from " <> prettyList as'))
       pure
       $ mkLiteralList as'
 
@@ -337,7 +337,7 @@ inferPreProp preProp = case preProp of
       (Some SStr (StrLit ix''), Some objty@(SObject schema) objProp)
         -> case lookupKeyInType ix'' schema of
           Nothing -> throwErrorIn preProp $
-            "could not find expected key " <> pretty ix''
+            "could not find expected key " <> prettyString ix''
           Just (EType ty) -> pure $
             Some ty $ PObjAt objty (StrLit ix'') objProp
 
@@ -642,7 +642,7 @@ checkPreProp ty preProp
 typeError :: (HasCallStack, Pretty a, Pretty b) => PreProp -> a -> b -> PropCheck c
 typeError preProp a b = throwErrorIn preProp $
   "type error: " <> pretty a <> " vs " <> pretty b <> "(" <>
-  pretty (prettyCallStack callStack) <> ")"
+  prettyString (prettyCallStack callStack) <> ")"
 
 expectColumnType
   :: Prop TyTableName -> Prop TyColumnName -> SingTy a -> PropCheck ()

--- a/src/Pact/Analyze/Types/Capability.hs
+++ b/src/Pact/Analyze/Types/Capability.hs
@@ -31,7 +31,7 @@ instance Show Capability where
     . showsPrec 11 capName
 
 instance Pretty Capability where
-  pretty (Capability _ (CapName cn)) = pretty cn
+  pretty (Capability _ (CapName cn)) = prettyString cn
 
 -- | The index into the family that is a 'Capability'. Think of this of the
 -- arguments to a particular call of a capability.

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -87,7 +87,7 @@ import           Text.Show                     (showListWith)
 import           Pact.Types.Pretty             (commaBraces, commaBrackets,
                                                 parens, parensSep,
                                                 Pretty(pretty), Doc, viaShow,
-                                                vsep)
+                                                vsep, prettyString, prettyList)
 import           Pact.Types.Persistence        (WriteType)
 
 import           Pact.Analyze.Feature          hiding (Doc, Sym, Var, col, str,
@@ -401,7 +401,7 @@ singPrettyObject SObjectNil (Object SNil) = [""]
 singPrettyObject
   (SObjectUnsafe (SingList (SCons _ _ objty)))
   (Object (SCons k (Column vTy v) obj))
-    = (pretty (symbolVal k) <> ": " <> singPrettyTm vTy v)
+    = (prettyString (symbolVal k) <> ": " <> singPrettyTm vTy v)
       : singPrettyObject (SObjectUnsafe (SingList objty)) (Object obj)
 singPrettyObject _ _ = error "malformed object"
 
@@ -1502,12 +1502,12 @@ prettyTerm ty = \case
   EnforceOne (Left _)        -> parensSep
     [ "enforce-one"
     , "\"(generated enforce-one)\""
-    , pretty ([] :: [Integer])
+    , prettyList ([] :: [Integer])
     ]
   EnforceOne (Right x)       -> parensSep
     [ "enforce-one"
     , "\"(generated enforce-one)\""
-    , pretty $ fmap snd x
+    , prettyList $ fmap snd x
     ]
 
   Enforce _ (GuardPasses _ x) -> parensSep ["enforce-guard", pretty x]
@@ -1522,7 +1522,7 @@ prettyTerm ty = \case
   Read _ _ tab x       -> parensSep ["read", pretty tab, pretty x]
   Write ty' _ _ tab x y -> parensSep ["write", pretty tab, pretty x, singPrettyTm ty' y]
   PactVersion          -> parensSep ["pact-version"]
-  Format x y           -> parensSep ["format", pretty x, pretty y]
+  Format x y           -> parensSep ["format", pretty x, prettyList y]
   FormatTime x y       -> parensSep ["format", pretty x, pretty y]
   ParseTime Nothing y  -> parensSep ["parse-time", pretty y]
   ParseTime (Just x) y -> parensSep ["parse-time", pretty x, pretty y]

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -921,7 +921,7 @@ withPretty = withDict . singMkPretty
       SDecimal     -> Dict
       SGuard       -> Dict
       SAny         -> Dict
-      SList _ty'    -> undefined -- withPretty ty' Dict
+      SList ty'    -> withPretty ty' Dict
       SObjectUnsafe SNil'   -> Dict
       SObjectUnsafe (SCons' _ ty' tys)
         -> withPretty ty' $

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -484,7 +484,7 @@ data EObject tm where
 instance Pretty (tm ('TyObject m)) => Pretty (Object tm m) where
   pretty (Object vals) = commaBraces (prettyVals vals) where
     prettyVals = foldHList $ \k (Column ty v) ->
-      [pretty (symbolVal k) <> " := " <> singPrettyTm ty v]
+      [prettyString (symbolVal k) <> " := " <> singPrettyTm ty v]
 
 instance Show (tm ('TyObject m)) => Show (Object tm m) where
   showsPrec p (Object vals) = showParen (p > 10) $
@@ -921,7 +921,7 @@ withPretty = withDict . singMkPretty
       SDecimal     -> Dict
       SGuard       -> Dict
       SAny         -> Dict
-      SList ty'    -> withPretty ty' Dict
+      SList _ty'    -> undefined -- withPretty ty' Dict
       SObjectUnsafe SNil'   -> Dict
       SObjectUnsafe (SCons' _ ty' tys)
         -> withPretty ty' $

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -403,12 +403,6 @@ evaluateDefs info defs = do
       unifiedDefs = foldl dresolve HM.empty sortedDefs
   traverse (runPure . evalConsts) unifiedDefs
 
--- | Helper to use 'pretty' on an 'Either'
-newtype SomeDoc = SomeDoc Doc
-
-instance Pretty SomeDoc where
-  pretty (SomeDoc doc) = doc
-
 mkSomeDoc :: (Pretty a, Pretty b) => Either a b -> SomeDoc
 mkSomeDoc = either (SomeDoc . pretty) (SomeDoc . pretty)
 

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -211,6 +211,6 @@ createUserGuard =
             _ -> evalError' i $ "Could not resolve predfun: " <> pretty n
           return $ (`TGuard` (_faInfo i)) $ GUser (UserGuard udata rn)
         Left s -> evalError' i $
-          "Invalid name " <> pretty predfun <> ": " <> pretty s
+          "Invalid name " <> pretty predfun <> ": " <> prettyString s
       Left {} -> evalError' i "Data must be value"
     createUserGuard' i as = argsError i as

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -70,7 +70,7 @@ parseMsgKey i msg key = do
     Nothing -> evalError' i $ "No such key in message: " <> pretty key
     Just v -> case fromJSON v of
                 Success t -> return t
-                Error e -> evalError' i $ pretty msg <> ": parse failed: " <> pretty e <> ": " <> pretty v
+                Error e -> evalError' i $ prettyString msg <> ": parse failed: " <> prettyString e <> ": " <> pretty v
 
 
 bindReduce :: [(Arg (Term Ref),Term Ref)] -> Scope Int Term Ref -> Info -> (Text -> Maybe (Term Ref)) -> Eval e (Term Name)

--- a/src/Pact/Native/Ops.hs
+++ b/src/Pact/Native/Ops.hs
@@ -322,7 +322,7 @@ binop :: (Decimal -> Decimal -> Either String Decimal) ->
        (Integer -> Integer -> Either String Integer) -> RNativeFun e
 binop dop iop fi as@[TLiteral a _,TLiteral b _] = do
   let hdl (Right v) = return $ toTerm v
-      hdl (Left err) = evalError' fi $ pretty err <> ": " <> pretty (a,b)
+      hdl (Left err) = evalError' fi $ prettyString err <> ": " <> pretty (a,b)
   case (a,b) of
     (LInteger i,LInteger j) -> hdl (i `iop` j)
     (LDecimal i,LDecimal j) -> hdl (i `dop` j)

--- a/src/Pact/Native/Time.hs
+++ b/src/Pact/Native/Time.hs
@@ -92,7 +92,7 @@ timeDef = defRNative "time" time
     time i [TLitString s] =
       case parseTime defaultTimeLocale simpleISO8601 (unpack s) of
         Nothing -> evalError' i $
-          "Invalid time, expecting '" <> pretty simpleISO8601 <> "': " <> pretty s
+          "Invalid time, expecting '" <> prettyString simpleISO8601 <> "': " <> pretty s
         Just t -> return (tLit (LTime t))
     time i as = argsError i as
 

--- a/src/Pact/Persist.hs
+++ b/src/Pact/Persist.hs
@@ -117,7 +117,7 @@ class (Ord k,Show k,Eq k,Hashable k,Pretty k) => PactKey k
 instance PactKey TxKey
 instance PactKey DataKey
 
-class (Eq v,Show v,ToJSON v,FromJSON v,Typeable v,Pretty v) => PactValue v
+class (Eq v,Show v,ToJSON v,FromJSON v,Typeable v, Pretty v) => PactValue v
 instance PactValue v => PactValue (TxLog v)
 instance PactValue (Columns Persistable)
 instance PactValue a => PactValue [a]

--- a/src/Pact/Persist.hs
+++ b/src/Pact/Persist.hs
@@ -9,7 +9,7 @@ module Pact.Persist
   (Persist,
    Table(..),DataTable,TxTable,
    TableId(..),tableId,
-   PactKey,PactValue,
+   PactKey,PactValue(..),
    DataKey(..),TxKey(..),
    KeyCmp(..),cmpToOp,
    KeyConj(..),conjToOp,
@@ -117,14 +117,18 @@ class (Ord k,Show k,Eq k,Hashable k,Pretty k) => PactKey k
 instance PactKey TxKey
 instance PactKey DataKey
 
-class (Eq v,Show v,ToJSON v,FromJSON v,Typeable v, Pretty v) => PactValue v
-instance PactValue v => PactValue (TxLog v)
-instance PactValue (Columns Persistable)
-instance PactValue a => PactValue [a]
-instance PactValue (ModuleDef Name)
-instance PactValue KeySet
-instance PactValue Value
-instance PactValue Namespace
+class (Eq v,Show v,ToJSON v,FromJSON v,Typeable v) => PactValue v where
+  prettyPactValue :: v -> Doc
+
+instance PactValue v => PactValue (TxLog v) where
+  prettyPactValue = pretty . fmap (SomeDoc . prettyPactValue)
+instance PactValue (Columns Persistable)    where prettyPactValue = pretty
+instance PactValue a => PactValue [a]       where
+  prettyPactValue = prettyList . fmap (SomeDoc . prettyPactValue)
+instance PactValue (ModuleDef Name)         where prettyPactValue = pretty
+instance PactValue KeySet                   where prettyPactValue = pretty
+instance PactValue Value                    where prettyPactValue = pretty
+instance PactValue Namespace                where prettyPactValue = pretty
 
 data Persister s = Persister {
   createTable :: forall k . PactKey k => Table k -> Persist s ()

--- a/src/Pact/Persist/Pure.hs
+++ b/src/Pact/Persist/Pure.hs
@@ -29,7 +29,7 @@ import Data.Typeable
 import Pact.Persist hiding (compileQuery)
 import Pact.Types.Pretty
 
-data PValue = forall a . (PactValue a, Pretty a) => PValue a
+data PValue = forall a . (PactValue a) => PValue a
 instance Show PValue where show (PValue a) = show a
 
 

--- a/src/Pact/Persist/Pure.hs
+++ b/src/Pact/Persist/Pure.hs
@@ -125,7 +125,7 @@ qry t kq s = case firstOf (temp . tblType t . tbls . ix t . tbl) s of
 
 conv :: (PactValue v) => PValue -> IO v
 conv (PValue v) = case cast v of
-  Nothing -> throwDbError $ "Failed to reify DB value: " <> pretty v
+  Nothing -> throwDbError $ "Failed to reify DB value: " <> prettyPactValue v
   Just s -> return s
 {-# INLINE conv #-}
 

--- a/src/Pact/PersistPactDb.hs
+++ b/src/Pact/PersistPactDb.hs
@@ -190,7 +190,7 @@ getLogs d tid = mapM convLog . fromMaybe [] =<< doPersist (\p -> readValue p (tn
     tn Namespaces = TxTable namespacesTable
     tn (UserTables t) = userTxRecord t
     convLog tl = case fromJSON (_txValue tl) of
-      Error s -> throwDbError $ "Unexpected value, unable to deserialize log: " <> pretty s
+      Error s -> throwDbError $ "Unexpected value, unable to deserialize log: " <> prettyString s
       Success v -> return $ set txValue v tl
 {-# INLINE getLogs #-}
 

--- a/src/Pact/PersistPactDb.hs
+++ b/src/Pact/PersistPactDb.hs
@@ -75,7 +75,7 @@ instance Pretty UserTableInfo where
     [ "module: " <> pretty mod'
     ]
 
-instance PactValue UserTableInfo
+instance PactValue UserTableInfo where prettyPactValue = pretty
 instance FromJSON UserTableInfo
 instance ToJSON UserTableInfo
 

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -188,7 +188,7 @@ pureEval ei e = do
   (ReplState evalE evalS _ _ _ _) <- get
   er <- try (liftIO $ runEval' evalS evalE e)
   let (r,es) = case er of
-                 Left (SomeException ex) -> (Left (PactError EvalError def def (pretty (show ex))),evalS)
+                 Left (SomeException ex) -> (Left (PactError EvalError def def (prettyString (show ex))),evalS)
                  Right v -> v
   mode <- use rMode
   case r of

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -250,7 +250,7 @@ formatAddr i [TLitString scheme, TLitString cryptoPubKey] = do
   let eitherEvalErr :: Either String a -> String -> (a -> b) -> Eval LibState b
       eitherEvalErr res effectStr transformFunc =
         case res of
-          Left e  -> evalError' i $ pretty effectStr <> ": " <> pretty e
+          Left e  -> evalError' i $ prettyString effectStr <> ": " <> prettyString e
           Right v -> return (transformFunc v)
   sppk  <- eitherEvalErr (fromText' scheme)
            "Invalid PPKScheme"
@@ -280,7 +280,7 @@ setsigs i as = argsError i as
 setmsg :: RNativeFun LibState
 setmsg i [TLitString j] =
   case eitherDecode (BSL.fromStrict $ encodeUtf8 j) of
-    Left f -> evalError' i ("Invalid JSON: " <> pretty f)
+    Left f -> evalError' i ("Invalid JSON: " <> prettyString f)
     Right v -> setenv eeMsgBody v >> return (tStr "Setting transaction data")
 setmsg _ [a] = setenv eeMsgBody (toJSON a) >> return (tStr "Setting transaction data")
 setmsg i as = argsError i as
@@ -425,7 +425,7 @@ tc i as = case as of
           r :: Either TC.CheckerException ([TC.TopLevel TC.Node],[TC.Failure]) <-
             try $ liftIO $ typecheckModule dbg md
           case r of
-            Left (TC.CheckerException ei e) -> evalError ei ("Typechecker Internal Error: " <> pretty e)
+            Left (TC.CheckerException ei e) -> evalError ei ("Typechecker Internal Error: " <> prettyString e)
             Right (_,fails) -> case fails of
               [] -> return $ tStr $ "Typecheck " <> modname <> ": success"
               _ -> do
@@ -466,7 +466,7 @@ print' i as = argsError i as
 
 envHash :: RNativeFun LibState
 envHash i [TLitString s] = case fromText' s of
-  Left err -> evalError' i $ "Bad hash value: " <> pretty s <> ": " <> pretty err
+  Left err -> evalError' i $ "Bad hash value: " <> pretty s <> ": " <> prettyString err
   Right h -> do
     setenv eeHash h
     return $ tStr $ "Set tx hash to " <> s
@@ -541,7 +541,7 @@ envChainDataDef = defZRNative "env-chain-data" envChainData
             info = _faInfo i
 
         unless (length ts == length ts') $ evalError info $
-          "envChainData: cannot update duplicate keys: " <> pretty (ts \\ (S.toList ts'))
+          "envChainData: cannot update duplicate keys: " <> prettyList (ts \\ (S.toList ts'))
 
         ud <- foldM (go info) pd ks
         setenv eePublicData ud
@@ -553,13 +553,13 @@ envChainDataDef = defZRNative "env-chain-data" envChainData
       "gas-limit"    -> pure $ set (pdPublicMeta . pmGasLimit) (ParsedInteger . fromIntegral $ l) pd
       "block-height" -> pure $ set pdBlockHeight (fromIntegral l) pd
       "block-time"   -> pure $ set pdBlockTime (fromIntegral l) pd
-      t              -> evalError i $ "envChainData: bad public metadata key: " <> pretty t
+      t              -> evalError i $ "envChainData: bad public metadata key: " <> prettyString t
 
     go i pd ((FieldKey k), (TLiteral (LDecimal l) _)) = case Text.unpack k of
       "gas-price" -> pure $ set (pdPublicMeta . pmGasPrice) (ParsedDecimal l) pd
-      t           -> evalError i $ "envChainData: bad public metadata key: " <> pretty t
+      t           -> evalError i $ "envChainData: bad public metadata key: " <> prettyString t
 
     go i pd ((FieldKey k), (TLiteral (LString l) _)) = case Text.unpack k of
       "sender" -> pure $ set (pdPublicMeta . pmSender) l pd
-      t        -> evalError i $ "envChainData: bad public metadata key: " <> pretty t
+      t        -> evalError i $ "envChainData: bad public metadata key: " <> prettyString t
     go i _ as = evalError i $ "envChainData: bad public metadata values: " <> pretty as

--- a/src/Pact/Types/ExpParser.hs
+++ b/src/Pact/Types/ExpParser.hs
@@ -137,9 +137,9 @@ runCompile act cs a =
     (Left (TrivialError _ (Just err) expect)) -> case err of
       EndOfInput -> case S.toList expect of
         (Tokens (x :| _):_) -> doErr (getInfo x) "unexpected end of input"
-        (Label s:_) -> doErr def (pretty (toList s))
+        (Label s:_) -> doErr def (prettyString (toList s))
         er -> doErr def (viaShow er)
-      Label ne -> doErr def (pretty (toList ne))
+      Label ne -> doErr def (prettyString (toList ne))
       Tokens (x :| _) -> doErr (getInfo x) $ prettyString $ showExpect expect
     (Left e) -> doErr def (viaShow e)
     where doErr :: Info -> Doc -> Either PactError a

--- a/src/Pact/Types/Persistence.hs
+++ b/src/Pact/Types/Persistence.hs
@@ -165,7 +165,7 @@ data Persistable =
 instance Pretty Persistable where
     pretty (PLiteral l) = pretty l
     pretty (PGuard k) = pretty k
-    pretty (PValue v) = pretty $ BSL.toString $ encode v
+    pretty (PValue v) = prettyString $ BSL.toString $ encode v
 instance ToTerm Persistable where
     toTerm (PLiteral l) = toTerm l
     toTerm (PGuard k) = toTerm k

--- a/src/Pact/Types/Pretty.hs
+++ b/src/Pact/Types/Pretty.hs
@@ -9,6 +9,7 @@ module Pact.Types.Pretty
   , Doc
   , Pretty(..)
   , RenderColor(..)
+  , SomeDoc(..)
   , abbrev
   , abbrevStr
   , align
@@ -35,7 +36,6 @@ module Pact.Types.Pretty
   , nest
   , parens
   , parensSep
-  , prettyList
   , prettyString
   , punctuate
   , putDoc
@@ -92,30 +92,25 @@ type Doc = PP.Doc Annot
 
 -- | Pact's version of 'Pretty', with 'Annot' annotations.
 class Pretty a where
-  pretty     :: a   -> Doc
+  pretty :: a -> Doc
 
-prettyList :: Pretty a => [a] -> Doc
-prettyList = list . map pretty
+  prettyList :: [a] -> Doc
+  prettyList = list . map pretty
 
--- prettyList :: Pretty a => [a] -> Doc
-
-instance Pretty a => Pretty [a] where
-  pretty = list . map pretty
-
-instance Pretty Text where pretty = PP.pretty
 instance Pretty Char where
   pretty     = PP.pretty
-  -- prettyList = prettyString
-instance Pretty Bool where pretty = PP.pretty
-instance Pretty Integer where pretty = PP.pretty
-instance Pretty Int where pretty = PP.pretty
-instance Pretty Int64 where pretty = viaShow
-instance Pretty () where pretty = PP.pretty
+  prettyList = prettyString
+instance Pretty Text                  where pretty = PP.pretty
+instance Pretty Bool                  where pretty = PP.pretty
+instance Pretty Integer               where pretty = PP.pretty
+instance Pretty Int                   where pretty = PP.pretty
+instance Pretty Int64                 where pretty = viaShow
+instance Pretty ()                    where pretty = PP.pretty
+instance Pretty a => Pretty (Maybe a) where pretty = maybe mempty pretty
 instance (Pretty a, Pretty b) => Pretty (a, b) where
   pretty (a, b) = tupled [pretty a, pretty b]
 instance (Pretty a, Pretty b, Pretty c) => Pretty (a, b, c) where
   pretty (a, b, c) = tupled [pretty a, pretty b, pretty c]
-instance Pretty a => Pretty (Maybe a) where pretty = maybe mempty pretty
 
 prettyString :: String -> Doc
 prettyString = PP.pretty . pack
@@ -228,3 +223,9 @@ abbrev a =
 
 abbrevStr :: Pretty a => a -> String
 abbrevStr = unpack . abbrev
+
+-- | Helper to use 'pretty' on functors
+newtype SomeDoc = SomeDoc Doc
+
+instance Pretty SomeDoc where
+  pretty (SomeDoc doc) = doc

--- a/src/Pact/Types/Pretty.hs
+++ b/src/Pact/Types/Pretty.hs
@@ -97,6 +97,11 @@ class Pretty a where
   prettyList :: [a] -> Doc
   prettyList = list . map pretty
 
+-- Warning: you should avoid this instance since it does the wrong thing for
+-- strings.
+instance Pretty a => Pretty [a] where
+  pretty = prettyList
+
 instance Pretty Char where
   pretty     = PP.pretty
   prettyList = prettyString

--- a/src/Pact/Types/Pretty.hs
+++ b/src/Pact/Types/Pretty.hs
@@ -35,6 +35,7 @@ module Pact.Types.Pretty
   , nest
   , parens
   , parensSep
+  , prettyList
   , prettyString
   , punctuate
   , putDoc
@@ -91,13 +92,20 @@ type Doc = PP.Doc Annot
 
 -- | Pact's version of 'Pretty', with 'Annot' annotations.
 class Pretty a where
-  pretty :: a -> Doc
+  pretty     :: a   -> Doc
+
+prettyList :: Pretty a => [a] -> Doc
+prettyList = list . map pretty
+
+-- prettyList :: Pretty a => [a] -> Doc
 
 instance Pretty a => Pretty [a] where
   pretty = list . map pretty
 
 instance Pretty Text where pretty = PP.pretty
-instance Pretty Char where pretty = PP.pretty
+instance Pretty Char where
+  pretty     = PP.pretty
+  -- prettyList = prettyString
 instance Pretty Bool where pretty = PP.pretty
 instance Pretty Integer where pretty = PP.pretty
 instance Pretty Int where pretty = PP.pretty

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -148,7 +148,8 @@ instance FromJSON PublicKey where
 instance ToJSON PublicKey where
   toJSON = toJSON . decodeUtf8 . _pubKey
 
-instance Pretty PublicKey where pretty (PublicKey s) = pretty (BS.toString s)
+instance Pretty PublicKey where
+  pretty (PublicKey s) = prettyString (BS.toString s)
 
 -- | KeySet pairs keys with a predicate function name.
 data KeySet = KeySet {
@@ -158,7 +159,7 @@ data KeySet = KeySet {
 
 instance Pretty KeySet where
   pretty (KeySet ks f) = "KeySet" <+> commaBraces
-    [ "keys: " <> pretty ks
+    [ "keys: " <> prettyList ks
     , "pred: " <> pretty f
     ]
 
@@ -269,7 +270,7 @@ defTypeRep Defpact = "defpact"
 defTypeRep Defcap = "defcap"
 
 instance Pretty DefType where
-  pretty = pretty . defTypeRep
+  pretty = prettyString . defTypeRep
 
 newtype NativeDefName = NativeDefName Text
     deriving (Eq,Ord,IsString,ToJSON,AsString,Show)
@@ -582,7 +583,7 @@ data Def n = Def
 
 instance Pretty n => Pretty (Def n) where
   pretty Def{..} = parensSep $
-    [ pretty $ defTypeRep _dDefType
+    [ prettyString $ defTypeRep _dDefType
     , pretty _dModule <> "." <> pretty _dDefName <> ":" <> pretty (_ftReturn _dFunType)
     , parensSep $ pretty <$> _ftArgs _dFunType
     ] ++ maybe [] (\docs -> [pretty docs]) (_mDocs _dMeta)
@@ -601,7 +602,7 @@ data Namespace = Namespace
   } deriving (Eq, Show)
 
 instance Pretty Namespace where
-  pretty Namespace{..} = "(namespace " <> pretty (asString' _nsName) <> ")"
+  pretty Namespace{..} = "(namespace " <> prettyString (asString' _nsName) <> ")"
 
 instance FromJSON Namespace where
   parseJSON = withObject "Namespace" $ \o -> Namespace
@@ -928,7 +929,7 @@ instance Pretty n => Pretty (Term n) where
       [ "defschema"
       , pretty _tSchemaName
       , pretty _tMeta
-      , pretty _tFields
+      , prettyList _tFields
       ]
     TTable{..} -> parensSep
       [ "deftable"

--- a/src/Pact/Types/Type.hs
+++ b/src/Pact/Types/Type.hs
@@ -91,7 +91,7 @@ funTypes ft = ft :| []
 
 prettyFunTypes :: Pretty o => FunTypes o -> Doc
 prettyFunTypes (t :| []) = pretty t
-prettyFunTypes ts = pretty (toList ts)
+prettyFunTypes ts = prettyList (toList ts)
 
 data GuardType
   = GTyKeySet
@@ -218,7 +218,7 @@ instance (Pretty o) => Pretty (Type o) where
     TyVar n        -> pretty n
     TyUser v       -> pretty v
     TyFun f        -> pretty f
-    TySchema s t p -> pretty s <> colon <> pretty (showPartial p) <> pretty t
+    TySchema s t p -> pretty s <> colon <> prettyList (showPartial p) <> pretty t
     TyList t       -> brackets $ pretty t
     TyPrim t       -> pretty t
     TyAny          -> "*"


### PR DESCRIPTION
Due to a longstanding bug in the [Haskell report](https://www.haskell.org/onlinereport/haskell2010/haskellch2.html#x7-200002.6), lists (`[a]`) should be pretty-printed as `[a, b, ...]` _except_ in the case where the type variable `a` is `Char` (`[Char]`), in which case the alternate format `"ab..."` is preferred.

Previously, in Pact we had relied upon remembering to use `prettyString` (rather than `pretty`) in cases where the second behavior was preferred. Unfortunately, this was not enforced by the typechecker, so we misused `pretty` in several places.

In this PR we adopt the workaround used by the [`Show` typeclass](http://hackage.haskell.org/package/base-4.12.0.0/docs/Text-Show.html#t:Show), namely adding `prettyList` (analogous to `showList`) to `Pretty` (with the special case for `Char`) and removing the `Pretty` instance for lists.