### PR TITLE
public data in api req

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -29,6 +29,18 @@ pact> (bind { "a": 1, "b": 2 } { "a" := a-value } a-value)
 ```
 
 
+### chain-data {#chain-data}
+
+ *&rarr;*&nbsp;`object:[]<{o}>`
+
+
+Get transaction public metadata. Returns an object with 'chain-id', 'block-height', 'block-time', 'sender', 'gas-limit', 'gas-price', and 'gas-fee' fields.
+```lisp
+pact> (chain-data)
+{"chain-id": 0,"block-height": 0,"block-time": 0,"sender": "","gas-limit": 0,"gas-price": 0}
+```
+
+
 ### compose {#compose}
 
 *x*&nbsp;`x:<a> -> <b>` *y*&nbsp;`x:<b> -> <c>` *value*&nbsp;`<a>` *&rarr;*&nbsp;`<c>`
@@ -1367,6 +1379,18 @@ Continue previously-initiated pact identified by PACT-ID at STEP, optionally spe
 (continue-pact 2 1)
 (continue-pact 2 1 true)
 (continue-pact 2 1 false { "rate": 0.9 })
+```
+
+
+### env-chain-data {#env-chain-data}
+
+*new-data*&nbsp;`object:[]*` *&rarr;*&nbsp;`string`
+
+
+Update existing entries 'chain-data' with NEW-DATA, replacing those items only.
+```lisp
+pact> (env-chain-data { "chain-id": 2, "block-height": 20 })
+"Updated public metadata"
 ```
 
 

--- a/src-ghc/Pact/ApiReq.hs
+++ b/src-ghc/Pact/ApiReq.hs
@@ -72,7 +72,7 @@ data ApiReq = ApiReq {
   _ylCodeFile :: Maybe FilePath,
   _ylKeyPairs :: [ApiKeyPair],
   _ylNonce :: Maybe String,
-  _ylPublicData :: Maybe PublicMeta
+  _ylPublicMeta :: Maybe PublicMeta
   } deriving (Eq,Show,Generic)
 instance ToJSON ApiReq where toJSON = lensyToJSON 3
 instance FromJSON ApiReq where parseJSON = lensyParseJSON 3
@@ -114,7 +114,7 @@ mkApiReqExec ar@ApiReq{..} kps fp = do
       (Nothing,Nothing) -> return Null
       _ -> dieAR "Expected either a 'data' or 'dataFile' entry, or neither"
     return (code,cdata)
-  let pubMeta = fromMaybe def _ylPublicData
+  let pubMeta = fromMaybe def _ylPublicMeta
   ((ar,code,cdata,pubMeta),) <$> mkExec code cdata pubMeta kps _ylNonce
 
 mkExec :: String -> Value -> PublicMeta -> [SomeKeyPair] -> Maybe String -> IO (Command Text)
@@ -150,7 +150,7 @@ mkApiReqCont ar@ApiReq{..} kps fp = do
                           eitherDecode
       (Nothing,Nothing) -> return Null
       _ -> dieAR "Expected either a 'data' or 'dataFile' entry, or neither"
-  let pubMeta = fromMaybe def _ylPublicData
+  let pubMeta = fromMaybe def _ylPublicMeta
   ((ar,"",cdata,pubMeta),) <$> mkCont txId step rollback cdata pubMeta kps _ylNonce
 
 mkCont :: PactId -> Int -> Bool  -> Value -> PublicMeta -> [SomeKeyPair]

--- a/tests/chainweb-example.yaml
+++ b/tests/chainweb-example.yaml
@@ -1,0 +1,9 @@
+code: (+ 1 2)
+publicMeta:
+  chainId : "0"
+  sender: "sender00"
+  gasLimit: 1000
+  gasPrice: 0.01
+keyPairs:
+  - public: 368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca
+    secret: 251a920c403ae8c8f65f59142316af3c82b631fba46ddea92ee8c95035bd2898


### PR DESCRIPTION
Add public data to ApiReq so we can author Chainweb transactions with the `pact -a`