### PR TITLE
Remove duplicate definition of `read-cp-master`.

### DIFF
--- a/examples/cp/cp.pact
+++ b/examples/cp/cp.pact
@@ -206,8 +206,6 @@
 
   )
 
-  (defun read-cp-master (ticker) (read cp-master ticker))
-
   (defun read-cp-inventory (inv-key) (read cp-inventory inv-key))
 
 )


### PR DESCRIPTION
(see earlier in file)