### PR TITLE
Typecheck yield/resume

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -382,7 +382,7 @@ pact> (remove "bar" { "foo": 1, "bar": 2 })
 
 ### resume {#resume}
 
-*binding*&nbsp;`binding:[]<{y}>` *body*&nbsp;`*` *&rarr;*&nbsp;`<a>`
+*binding*&nbsp;`binding:[]<{r}>` *&rarr;*&nbsp;`<a>`
 
 
 Special form binds to a yielded object value from the prior step execution in a pact.

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -830,7 +830,7 @@ verifyModule modules moduleData = runExceptT $ do
     (\name (ref, cType) accum -> do
       maybeFun <- lift $ runTC 0 False $ typecheckTopLevel ref
       pure $ case maybeFun of
-        (TopFun (FDefun _info _mod _name funType _args _body) _meta, _tcState)
+        (TopFun (FDefun _info _mod _name _defType funType _args _body) _meta, _tcState)
           -> case cType of
             CheckDefconst -> error "invariant violation: this cannot be a constant"
             _             -> accum & _1 . at name ?~ (ref, funType, cType)

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -43,7 +43,7 @@ pattern NativeFunc f <- FNative _ f _ _
 
 pattern AST_InlinedApp :: Lang.ModuleName -> Text -> [(Named a, AST a)] -> [AST a] -> AST a
 pattern AST_InlinedApp modName funName bindings body <-
-  App _ (FDefun _ modName funName _ _ [Binding _ bindings body AstBindInlinedCallArgs]) _args
+  App _ (FDefun _ modName funName _ _ _ [Binding _ bindings body AstBindInlinedCallArgs]) _args
 
 pattern AST_Let :: forall a. [(Named a, AST a)] -> [AST a] -> AST a
 pattern AST_Let bindings body <- Binding _ bindings body AstBindLet

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -16,7 +16,7 @@ import           Pact.Types.Runtime   (Literal (LString))
 import           Pact.Types.Typecheck (AST (App, Binding, List, Object, Prim, Step, Table),
                                        AstBindType (..), Fun (FDefun, FNative),
                                        Named, Node, PrimValue (PrimLit),
-                                       Special (SBinding), aNode, aTy)
+                                       Special (SBinding), aNode, aTy, YieldResume)
 import qualified Pact.Types.Typecheck as TC
 
 import           Pact.Analyze.Feature
@@ -256,5 +256,5 @@ pattern AST_Obj objNode kvs <- Object objNode kvs
 pattern AST_List :: forall a. a -> [AST a] -> AST a
 pattern AST_List node elems <- List node elems
 
-pattern AST_Step :: a -> Maybe (AST a) -> AST a -> Maybe (AST a) -> AST a
-pattern AST_Step node entity exec rollback <- Step node entity exec rollback
+pattern AST_Step :: a -> Maybe (AST a) -> AST a -> Maybe (AST a) -> Maybe (YieldResume a) -> AST a
+pattern AST_Step node entity exec rollback yr <- Step node entity exec rollback yr

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -662,7 +662,7 @@ translatePact nodes = do
 translateStep
   :: Bool -> AST Node -> TranslateM (PactStep, Vertex, Maybe (AST Node))
 translateStep firstStep = \case
-  AST_Step _node entity exec rollback -> do
+  AST_Step _node entity exec rollback _yr -> do
     p <- if firstStep then use tsCurrentPath else startNewSubpath
     mEntity <- for entity $ \tm -> do
       Some SStr entity' <- translateNode tm

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -434,12 +434,12 @@ langDefs =
      ["(typeof \"hello\")"] "Returns type of X as string."
     ,setTopLevelOnly $ defRNative "list-modules" listModules
      (funType (TyList tTyString) []) [] "List modules available for loading."
-    ,defRNative "yield" yield (funType yieldv [("OBJECT",yieldv)])
+    ,defRNative (specialForm Yield) yield (funType yieldv [("OBJECT",yieldv)])
      [LitExample "(yield { \"amount\": 100.0 })"]
      "Yield OBJECT for use with 'resume' in following pact step. The object is similar to database row objects, in that \
      \only the top level can be bound to in 'resume'; nested objects are converted to opaque JSON values."
-    ,defNative "resume" resume
-     (funType a [("binding",TySchema TyBinding (mkSchemaVar "y") def),("body",TyAny)]) []
+    ,defNative (specialForm Resume) resume
+     (funType a [("binding",TySchema TyBinding (mkSchemaVar "r") def)]) []
      "Special form binds to a yielded object value from the prior step execution in a pact."
 
     ,pactVersionDef

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -425,7 +425,7 @@ tc i as = case as of
           r :: Either TC.CheckerException ([TC.TopLevel TC.Node],[TC.Failure]) <-
             try $ liftIO $ typecheckModule dbg md
           case r of
-            Left (TC.CheckerException ei e) -> evalError ei ("Typechecker Internal Error: " <> pretty e)
+            Left (TC.CheckerException ei e) -> evalError ei ("Typechecker Internal Error: " <> prettyString e)
             Right (_,fails) -> case fails of
               [] -> return $ tStr $ "Typecheck " <> modname <> ": success"
               _ -> do

--- a/src/Pact/Types/Native.hs
+++ b/src/Pact/Types/Native.hs
@@ -14,7 +14,9 @@ data SpecialForm =
   Bind |
   Select |
   Where |
-  WithCapability
+  WithCapability |
+  Yield |
+  Resume
   deriving (Eq,Enum,Ord,Bounded)
 
 instance AsString SpecialForm where
@@ -24,6 +26,8 @@ instance AsString SpecialForm where
   asString Select = "select"
   asString Where = "where"
   asString WithCapability = asString RWithCapability
+  asString Yield = "yield"
+  asString Resume = "resume"
 
 instance Show SpecialForm where show = show . asString
 

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -269,7 +269,7 @@ defTypeRep Defpact = "defpact"
 defTypeRep Defcap = "defcap"
 
 instance Pretty DefType where
-  pretty = pretty . defTypeRep
+  pretty = prettyString . defTypeRep
 
 newtype NativeDefName = NativeDefName Text
     deriving (Eq,Ord,IsString,ToJSON,AsString,Show)
@@ -582,7 +582,7 @@ data Def n = Def
 
 instance Pretty n => Pretty (Def n) where
   pretty Def{..} = parensSep $
-    [ pretty $ defTypeRep _dDefType
+    [ pretty _dDefType
     , pretty _dModule <> "." <> pretty _dDefName <> ":" <> pretty (_ftReturn _dFunType)
     , parensSep $ pretty <$> _ftArgs _dFunType
     ] ++ maybe [] (\docs -> [pretty docs]) (_mDocs _dMeta)

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -33,14 +33,14 @@ module Pact.Types.Typecheck
     PrimValue (..),
     TopLevel (..),tlFun,tlInfo,tlName,tlType,tlConstVal,tlUserType,tlMeta,tlDoc,toplevelInfo,
     Special (..),
-    Fun (..),fInfo,fModule,fName,fTypes,fSpecial,fType,fArgs,fBody,
+    Fun (..),fInfo,fModule,fName,fTypes,fSpecial,fType,fArgs,fBody,fDefType,
     Node (..),aId,aTy,
     Named (..),
     AstBindType (..),
     AST (..),aNode,aAppFun,aAppArgs,aBindings,aBody,aBindType,aList,aObject,
     aPrimValue,aEntity,aExec,aRollback,aTableName,aYieldResume,
     Visit(..),Visitor,
-    YieldResume(..)
+    YieldResume(..),yrYield,yrResume
   ) where
 
 import Control.Monad.Catch
@@ -238,6 +238,7 @@ data Fun t =
     _fInfo   :: Info,
     _fModule :: ModuleName,
     _fName   :: Text,
+    _fDefType :: DefType,
     _fType   :: FunType UserType,
     _fArgs   :: [Named t],
     _fBody   :: [AST t]
@@ -254,7 +255,7 @@ instance Pretty t => Pretty (Fun t) where
            _ -> mempty)
     ]
   pretty FDefun {..} = parensSep
-    [ "defun " <> pretty _fName
+    [ pretty _fDefType <> " " <> pretty _fName
     , indent 2 $ "::" <+> pretty _fType
     , indent 2 $ sep [ "(", indent 2 (sep (map pretty _fArgs)), ")" ]
     , indent 2 $ vsep (map pretty _fBody)
@@ -392,6 +393,7 @@ makeLenses ''Fun
 makeLenses ''TopLevel
 makeLenses ''Node
 makeLenses ''TcId
+makeLenses ''YieldResume
 
 makeLenses ''TcState
 makeLenses ''Overload

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -48,7 +48,7 @@
 
   (defun step2:object{yieldschema} (id:string)
     (enforce-guard (get-guard id))
-    (yield { "result": 1 }))
+    { "result": 1 })
 
   (defun get-guard (id:string)
     (at 'g (read guard-table id)))
@@ -151,8 +151,8 @@
   (expect-failure "enforcing pact guard outside of pact" (enforce-guard g)))
 
 (env-data { "id": "a"})
-(continue-pact 4 1)
-(expect "pact enforce succeeds" 1 (at 'result (at 'yield (pact-state))))
+
+(expect "pact enforce succeeds" 1 (at 'result (continue-pact 4 1)))
 
 (pact-state true)
 (test-pact-guards "b")

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -149,12 +149,18 @@
       (update persons "foo" partial)
       partial))
 
+  (defschema schema-a a:integer)
+  (defschema schema-b b:integer)
+
   (defpact tc-yield-resume-1 (foo bar x:integer)
     (step (if foo
-              (yield {'a: x})
+              (let ((y:object{schema-a} {'a: x}))
+                (yield y))
             (yield {'a: (+ x 1)})))
     (step (if bar
-              (resume {'a := z} (yield {'b: (+ z 1)}))
+              (resume {'a := z}
+                (let ((y:object{schema-b} {'b: (+ z 1)}))
+                  (yield y)))
             (resume {'a:= z} (yield {'b: z}))))
     (step (resume {'b:= q} q))
   )

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -148,6 +148,17 @@
     (let ((partial { "name": "dave" }))
       (update persons "foo" partial)
       partial))
+
+  (defpact tc-yield-resume-1 (foo bar x:integer)
+    (step (if foo
+              (yield {'a: x})
+            (yield {'a: (+ x 1)})))
+    (step (if bar
+              (resume {'a := z} (yield {'b: (+ z 1)}))
+            (resume {'a:= z} (yield {'b: z}))))
+    (step (resume {'b:= q} q))
+  )
+
 )
 
 (create-table persons)


### PR DESCRIPTION
Fixes #442 

Caveats: 

- Types must be specified somewhere in order to typecheck. I briefly investigated being able to specialize object literals on the fly a la `{ 'foo: 1 }:object{bar}` (which would be ugly anyway) but Compile didn't like it. The example in the test shows the upshot: https://github.com/kadena-io/pact/blob/2a49f372ef6ecdd9b2b7664d0c74a4a414b42433/tests/pact/tc.repl#L155

- Return types on `defpact`s are weird/pathological. They associate to the return value of the last step, which itself is associated to the step app (ie, ignoring the rollback). Thus in the example we have steps returning different types.

- Resume/yield in rollback is currently permitted, as the environment simply gathers `yield`/`resume` invocations within a `step` and associates them (respectively).

NB: `Defun{}` Funs now indicates def type, which was ignored before; resume/yield nodes are stored in `Step{}` ASTs.