### PR TITLE
Tweak order of docs for natives.

### DIFF
--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -886,10 +886,10 @@ instance Pretty n => Pretty (Term n) where
       <> nest 2 (
          line
       <> line <> fillSep (pretty <$> T.words _tNativeDocs)
-      <> examples
       <> line
       <> line <> annotate Header "Type:"
       <> line <> align (vsep (pretty <$> toList _tFunTypes))
+      <> examples
       ) where examples = case _tNativeExamples of
                 [] -> mempty
                 exs ->


### PR DESCRIPTION
Put type before examples.