### PR TITLE
PactOutput type for reliable Term output, yields

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -37,7 +37,7 @@ pact> (bind { "a": 1, "b": 2 } { "a" := a-value } a-value)
 Get transaction public metadata. Returns an object with 'chain-id', 'block-height', 'block-time', 'sender', 'gas-limit', 'gas-price', and 'gas-fee' fields.
 ```lisp
 pact> (chain-data)
-{"chain-id": 0,"block-height": 0,"block-time": 0,"sender": "","gas-limit": 0,"gas-price": 0}
+{"block-height": 0,"block-time": 0,"chain-id": 0,"gas-limit": 0,"gas-price": 0,"sender": ""}
 ```
 
 
@@ -1267,7 +1267,7 @@ Defines a guard predicate by NAME that captures the results of 'pact-id'. At enf
 *data*&nbsp;`<a>` *predfun*&nbsp;`string` *&rarr;*&nbsp;`guard`
 
 
-Defines a custom guard predicate, where DATA will be passed to PREDFUN at time of enforcement. PREDFUN is a valid name in the declaring environment. PREDFUN must refer to a pure function or enforcement will fail at runtime.
+Defines a custom guard predicate, where DATA will be passed to PREDFUN at time of enforcement. DATA must be an object. PREDFUN is a valid name in the declaring environment. PREDFUN must refer to a pure function or enforcement will fail at runtime.
 
 
 ### enforce-guard {#enforce-guard}

--- a/pact.cabal
+++ b/pact.cabal
@@ -174,6 +174,7 @@ library
                      , unordered-containers >= 0.2.7.2 && < 0.3
                      , utf8-string >= 1.0.1.1 && < 1.1
                      , vector >= 0.11.0.0 && < 0.13
+                     , vector-algorithms >= 0.7
                      , vector-space >= 0.10.4 && < 0.14
                      , mmorph >= 1.1 && < 1.2
                      , constraints
@@ -279,6 +280,7 @@ test-suite hspec
               , hedgehog == 0.6.*
               , hw-hspec-hedgehog == 0.1.*
               , intervals
+              , vector
   other-modules:
                 Blake2Spec
                 KeysetSpec

--- a/pact.cabal
+++ b/pact.cabal
@@ -56,6 +56,7 @@ library
                      , Pact.Types.Lang
                      , Pact.Types.Logger
                      , Pact.Types.Native
+                     , Pact.Types.PactOutput
                      , Pact.Types.Parser
                      , Pact.Types.Persistence
                      , Pact.Types.Pretty

--- a/src-ghc/Pact/Interpreter.hs
+++ b/src-ghc/Pact/Interpreter.hs
@@ -31,26 +31,27 @@ module Pact.Interpreter
   ) where
 
 import Control.Concurrent
-import qualified Data.Set as S
+import Control.Monad.Catch
+import Control.Monad.Except
 import Data.Aeson
 import Data.Default
-import Control.Monad.Except
-import Control.Monad.Catch
-import Data.Maybe
 import qualified Data.HashMap.Strict as HM
-
-import Pact.Types.Term
-import Pact.Types.Runtime
-import Pact.Compile
-import Pact.Eval hiding (evalContinuation)
-import qualified Pact.Eval as Eval (evalContinuation)
-import Pact.Types.Command
-import Pact.Native (nativeDefs)
-import Pact.PersistPactDb
-import qualified Pact.Persist.SQLite as PSL
+import Data.Maybe
+import qualified Data.Set as S
 import System.Directory
-import Pact.Types.Logger
+
+
+import Pact.Compile
+import qualified Pact.Eval as Eval (evalContinuation)
+import Pact.Eval hiding (evalContinuation)
+import Pact.Native (nativeDefs)
 import qualified Pact.Persist.Pure as Pure
+import qualified Pact.Persist.SQLite as PSL
+import Pact.PersistPactDb
+import Pact.Types.Command
+import Pact.Types.Logger
+import Pact.Types.PactOutput
+import Pact.Types.Runtime
 
 data PactDbEnv e = PactDbEnv {
   pdPactDb :: !(PactDb e),
@@ -69,7 +70,7 @@ initMsgData = MsgData def Null def
 
 data EvalResult = EvalResult
   { _erInput :: !(Either PactContinuation [Term Name])
-  , _erOutput :: ![Term Name]
+  , _erOutput :: ![PactOutput]
   , _erLogs :: ![TxLog Value]
   , _erRefStore :: !RefStore
   , _erExec :: !(Maybe PactExec)
@@ -156,7 +157,7 @@ interpret initState evalEnv terms = do
       pactExec = _evalPactExec state
       newRefs oldStore | isNothing tx = oldStore
                        | otherwise = updateRefStore (_evalRefs state) oldStore
-  return $! EvalResult terms rs logs refStore pactExec gas
+  return $! EvalResult terms (map toPactOutput' rs) logs refStore pactExec gas
 
 evalTerms :: Maybe TxId -> Either PactContinuation [Term Name] -> Eval e ([Term Name],[TxLog Value])
 evalTerms tx terms = do

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -19,10 +19,9 @@ import Control.Concurrent
 import Control.Exception.Safe
 import Control.Monad.Except
 import Control.Monad.Reader
-import qualified Data.Map.Strict as M
-
 import Data.Aeson as A
 import Data.Int (Int64)
+import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
 import Data.Word (Word32, Word64)
 
@@ -32,6 +31,7 @@ import Pact.Parse (ParsedDecimal(..))
 import Pact.Types.Command
 import Pact.Types.Gas
 import Pact.Types.Logger
+import Pact.Types.PactOutput
 import Pact.Types.Persistence
 import Pact.Types.RPC
 import Pact.Types.Runtime hiding (PublicKey)
@@ -145,7 +145,7 @@ applyContinuation rk msg@ContMsg{..} Command{..} = do
 
           -- Setup environment and get result
           let sigs = userSigsToPactKeySet _cmdSigs
-              pactStep = Just $ PactStep _cmStep _cmRollback _cmPactId _peYield
+              pactStep = Just $ PactStep _cmStep _cmRollback _cmPactId (fmap (fmap fromPactOutput) _peYield)
               evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode
                         (MsgData sigs _cmData pactStep _cmdHash) _csRefStore
                         _ceGasEnv permissiveNamespacePolicy noSPVSupport _cePublicData

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -250,7 +250,7 @@ pattern AST_Take node num list <- App node (NativeFunc SListTake) [num, list]
 pattern AST_MakeList :: a -> AST a -> AST a -> AST a
 pattern AST_MakeList node num val <- App node (NativeFunc SMakeList) [num, val]
 
-pattern AST_Obj :: forall a. a -> [(Lang.FieldKey, AST a)] -> AST a
+pattern AST_Obj :: forall a. a -> Lang.ObjectMap (AST a) -> AST a
 pattern AST_Obj objNode kvs <- Object objNode kvs
 
 pattern AST_List :: forall a. a -> [AST a] -> AST a

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -1215,8 +1215,8 @@ translateNode astNode = withAstContext astNode $ case astNode of
         pure $ Some listOfTy $ CoreTerm $ ListAt listOfTy index' list
       _ -> throwError' $ TypeError node
 
-  AST_Obj _node kvs -> do
-    kvs' <- for kvs $ \(Pact.FieldKey k, v) -> do
+  AST_Obj _node (Pact.ObjectMap kvs) -> do
+    kvs' <- for (Map.toList kvs) $ \(Pact.FieldKey k, v) -> do
       v' <- translateNode v
       pure (k, v')
     Some objTy litObj

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -306,7 +306,7 @@ objectLiteral = withList Braces $ \ListExp{..} -> do
         val <- sep Colon *> valueLevel
         return (key,val)
   ps <- (pair `sepBy` sep Comma) <* eof
-  return $ TObject (Object (ObjectMap $ M.fromList ps) TyAny _listInfo) _listInfo
+  return $ TObject (Object (ObjectMap $ M.fromList ps) TyAny (Just (map fst ps)) _listInfo) _listInfo
 
 literal :: Compile (Term Name)
 literal = lit >>= \LiteralExp{..} ->

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -545,8 +545,8 @@ reduce t@TNative {} = return $ toTerm $ pack $ show t
 reduce TConst {..} = case _tConstVal of
   CVEval _ t -> reduce t
   CVRaw a -> evalError _tInfo $ "internal error: reduce: unevaluated const: " <> pretty a
-reduce (TObject (Object ps t oi) i) =
-  TObject <$> (Object <$> traverse reduce ps <*> traverse reduce t <*> pure oi) <*> pure i
+reduce (TObject (Object ps t ko oi) i) =
+  TObject <$> (Object <$> traverse reduce ps <*> traverse reduce t <*> pure ko <*> pure oi) <*> pure i
 reduce (TBinding ps bod c i) = case c of
   BindLet -> reduceLet ps bod i
   BindSchema _ -> evalError i "Unexpected schema binding"

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -196,12 +196,12 @@ createUserGuard =
   (funType (tTyGuard (Just GTyUser)) [("data",tvA),("predfun",tTyString)])
   []
   "Defines a custom guard predicate, where DATA will be passed to PREDFUN at time \
-  \of enforcement. PREDFUN is a valid name in the declaring environment. \
+  \of enforcement. DATA must be an object. PREDFUN is a valid name in the declaring environment. \
   \PREDFUN must refer to a pure function or enforcement will fail at runtime."
   where
     createUserGuard' :: RNativeFun e
-    createUserGuard' i [udata,TLitString predfun] = case typeof udata of
-      Right {} -> case parseName (_faInfo i) predfun of
+    createUserGuard' i [TObject udata _,TLitString predfun] =
+      case parseName (_faInfo i) predfun of
         Right n -> do
           rn <- resolveRef n >>= \nm -> case nm of
             Just (Direct {}) -> return n
@@ -212,5 +212,4 @@ createUserGuard =
           return $ (`TGuard` (_faInfo i)) $ GUser (UserGuard udata rn)
         Left s -> evalError' i $
           "Invalid name " <> pretty predfun <> ": " <> prettyString s
-      Left {} -> evalError' i "Data must be value"
     createUserGuard' i as = argsError i as

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -216,7 +216,7 @@ gasPostReads i g0 postProcess action = do
   (,postProcess rs) <$> foldM (gasPostRead i) g0 rs
 
 columnsToObject :: ToTerm a => Type (Term n) -> Columns a -> Term n
-columnsToObject ty = (\ps -> TObject (Object (ObjectMap (M.fromList ps)) ty def) def) .
+columnsToObject ty = (\ps -> TObject (Object (ObjectMap (M.fromList ps)) ty def def) def) .
   map ((FieldKey . asString) *** toTerm) . M.toList . _columns
 
 columnsToObject' :: ToTerm a => Type (Term n) -> [(Info,ColumnId)] -> Columns a -> Eval m (Term n)
@@ -225,7 +225,7 @@ columnsToObject' ty cols (Columns m) = do
                 case M.lookup col m of
                   Nothing -> evalError ci $ "read: invalid column: " <> pretty col
                   Just v -> return (FieldKey $ asString col,toTerm v)
-  return $ TObject (Object (ObjectMap (M.fromList ps)) ty def) def
+  return $ TObject (Object (ObjectMap (M.fromList ps)) ty def def) def
 
 
 
@@ -268,7 +268,7 @@ withDefaultRead :: NativeFun e
 withDefaultRead fi as@[table',key',defaultRow',b@(TBinding ps bd (BindSchema _) _)] = do
   (!g0,!tkd) <- preGas fi [table',key',defaultRow']
   case tkd of
-    [table@TTable {..}, TLitString key, TObject (Object defaultRow _ _) _] -> do
+    [table@TTable {..}, TLitString key, TObject (Object defaultRow _ _ _) _] -> do
       guardTable fi table
       mrow <- readRow (_faInfo fi) (userTable table) (RowKey key)
       case mrow of
@@ -337,7 +337,7 @@ write :: WriteType -> SchemaPartial -> NativeFun e
 write wt partial i as = do
   ts <- mapM reduce as
   case ts of
-    [table@TTable {..},TLitString key,obj@(TObject (Object ps _ _) _)] -> do
+    [table@TTable {..},TLitString key,obj@(TObject (Object ps _ _ _) _)] -> do
       cost <- computeGas (Right i) (GWrite wt table obj)
       guardTable i table
       case _tTableType of

--- a/src/Pact/Native/Ops.hs
+++ b/src/Pact/Native/Ops.hs
@@ -60,11 +60,9 @@ addDef = defRNative "+" plus plusTy
       (a <> b)
       (if aty == bty then aty else TyAny)
       def
-    plus _ [TObject (Object as aty _) _,TObject (Object bs bty _) _] =
-      let reps (a,b) = (renderCompactText a,(a,b))
-          mapit = M.fromList . map reps
-      in return $ (`TObject` def) $ Object
-           (M.elems $ M.union (mapit as) (mapit bs))
+    plus _ [TObject (Object (ObjectMap as) aty _) _,TObject (Object (ObjectMap bs) bty _) _] =
+      return $ (`TObject` def) $ Object
+           (ObjectMap $ M.union as bs)
            (if aty == bty then aty else TyAny)
            def
     plus i as = binop' (+) (+) i as

--- a/src/Pact/Native/Ops.hs
+++ b/src/Pact/Native/Ops.hs
@@ -60,10 +60,11 @@ addDef = defRNative "+" plus plusTy
       (a <> b)
       (if aty == bty then aty else TyAny)
       def
-    plus _ [TObject (Object (ObjectMap as) aty _) _,TObject (Object (ObjectMap bs) bty _) _] =
+    plus _ [TObject (Object (ObjectMap as) aty _ _) _,TObject (Object (ObjectMap bs) bty _ _) _] =
       return $ (`TObject` def) $ Object
            (ObjectMap $ M.union as bs)
            (if aty == bty then aty else TyAny)
+           def
            def
     plus i as = binop' (+) (+) i as
     {-# INLINE plus #-}

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -39,6 +39,7 @@ import qualified Data.Vector as V
 
 #if defined(ghcjs_HOST_OS)
 import qualified Pact.Analyze.Remote.Client as RemoteClient
+import Data.Maybe
 #else
 
 import Criterion

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -533,7 +533,7 @@ envChainDataDef = defZRNative "env-chain-data" envChainData
   where
     envChainData :: RNativeFun LibState
     envChainData i as = case as of
-      [TObject (Object (ObjectMap ks) _ _) _] -> do
+      [TObject (Object (ObjectMap ks) _ _ _) _] -> do
         pd <- view eePublicData
 
         ud <- foldM (go (_faInfo i)) pd (M.toList ks)

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -32,33 +32,34 @@
 
 module Pact.Typechecker where
 
-import Data.Set (Set, isSubsetOf)
-import qualified Data.Set as Set
-import Data.Bitraversable (bimapM)
-import Control.Monad.Catch
-import Control.Lens hiding (List,Fold)
 import Bound.Scope
-import Safe hiding (at)
-import Data.Default
-import qualified Data.Map.Strict as M
-import qualified Data.HashMap.Strict as HM
-import qualified Data.Set as S
+import Control.Arrow hiding ((<+>))
+import Control.Lens hiding (List,Fold)
 import Control.Monad
+import Control.Monad.Catch
 import Control.Monad.State
+import Data.Bitraversable (bimapM)
+import Data.Default
+import Data.Foldable
+import qualified Data.HashMap.Strict as HM
+import Data.List
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
-import Control.Arrow hiding ((<+>))
-import Data.Foldable
-import Data.String
-import Data.List
+import qualified Data.Map.Strict as M
 import Data.Maybe (isJust)
+import Data.Set (Set, isSubsetOf)
+import qualified Data.Set as S
+import qualified Data.Set as Set
+import Data.String
+import qualified Data.Vector as V
+import Safe hiding (at)
 
 
-import Pact.Types.Pretty
-import Pact.Types.Typecheck
-import Pact.Types.Runtime hiding (App,appInfo,Object)
-import qualified Pact.Types.Runtime as Term
 import Pact.Types.Native
+import Pact.Types.Pretty
+import qualified Pact.Types.Runtime as Term
+import Pact.Types.Runtime hiding (App,appInfo,Object)
+import Pact.Types.Typecheck
 
 die :: MonadThrow m => Info -> String -> m a
 die i s = throwM $ CheckerException i s
@@ -91,7 +92,7 @@ walkAST f t@Table {} = f Pre t >>= f Post
 walkAST f t@Object {} = do
   Object {..} <- f Pre t
   t' <- Object _aNode <$>
-         forM _aObject (\(k,v) -> (k,) <$> walkAST f v)
+         mapM (walkAST f) _aObject
   f Post t'
 walkAST f t@List {} = do
   List {..} <- f Pre t
@@ -271,12 +272,12 @@ asPrimString t = die (_tiInfo (_aId (_aNode t))) $ "Expected literal string: " +
 applySchemas :: Visitor TC Node
 applySchemas Pre ast = case ast of
 
-  (Object n ps) -> findSchema n $ \sch partial -> do
+  (Object n (ObjectMap ps)) -> findSchema n $ \sch partial -> do
     debug $ "applySchemas [object]: " ++ show (n,sch,partial)
-    pmap <- forM ps $ \(FieldKey kstr,v) -> do
+    pmap <- forM ps $ \v -> do
       vt' <- lookupAndResolveTy (_aNode v)
-      return (kstr,(v,_aId (_aNode v),vt'))
-    validateSchema sch partial (M.fromList pmap) >>= \pm -> forM_ pm $ \pkeys -> case partial of
+      return (v,_aId (_aNode v),vt')
+    validateSchema sch partial pmap >>= \pm -> forM_ pm $ \pkeys -> case partial of
       FullSchema -> addFailure (_aId n) "Invalid partial schema found"
       _ -> do
         debug $ "Specializing schema ty for sublist: " ++ show pkeys
@@ -288,7 +289,7 @@ applySchemas Pre ast = case ast of
     pmapM <- forM bs $ \(Named _ node ni,bv) -> case bv of
       Prim _ (PrimLit (LString bn)) -> do
         vt' <- lookupAndResolveTy node
-        return $ Just (bn,(Var node,ni,vt'))
+        return $ Just (FieldKey bn,(Var node,ni,vt'))
       _ -> addFailure ni ("Found non-string key in schema binding: " ++ show bv) >> return Nothing
     case sequence pmapM of
       Just pmap -> validateSchema sch partial (M.fromList pmap) >>= \pm ->
@@ -316,7 +317,7 @@ applySchemas Pre ast = case ast of
     -- Given map of object text key to (value,key id,value ty) ...
     -- (returns partial keys list if subset of specified)
     validateSchema :: UserType -> SchemaPartial
-                   -> M.Map Text (AST Node, TcId, Type UserType) -> TC (Maybe (Set Text))
+                   -> M.Map FieldKey (AST Node, TcId, Type UserType) -> TC (Maybe (Set Text))
     validateSchema sch partial pmap = do
       -- smap: lookup from field name to ty
       let smap = filterPartial partial $ M.fromList $ (`map` _utFields sch) $ \(Arg an aty _) -> (an,aty)
@@ -324,7 +325,7 @@ applySchemas Pre ast = case ast of
           filterPartial AnySubschema = id
           filterPartial (PartialSchema ks) = (`M.restrictKeys` ks)
       -- over each object field ...
-      pks <- fmap (Set.fromList . concat) $ forM (M.toList pmap) $ \(k,(v,ki,vty)) -> case M.lookup k smap of
+      pks <- fmap (Set.fromList . concat) $ forM (M.toList pmap) $ \(FieldKey k,(v,ki,vty)) -> case M.lookup k smap of
         -- validate field exists ...
         Nothing -> do
           addFailure ki $ "Invalid field in schema object: " ++ show k ++ ", expected " ++ show (M.keys smap)
@@ -711,7 +712,7 @@ scopeToBody :: Info -> [AST Node] -> Scope Int Term (Either Ref (AST Node)) -> T
 scopeToBody i args bod = do
   bt <- instantiate (return . Right) <$> traverseScope (bindArgs i args) return bod
   case bt of
-    (TList ts@(_:_) _ _) -> mapM toAST ts -- verifies non-empty body.
+    (TList ts _ _) | not (V.null ts) -> mapM toAST (V.toList ts) -- verifies non-empty body.
     _ -> die i "Malformed def body"
 
 pfx :: Text -> Text -> Text
@@ -925,12 +926,12 @@ toAST TBinding {..} = do
 
 toAST TList {..} = do
   ty <- TyList <$> traverse toUserType _tListType
-  List <$> (trackNode ty =<< freshId _tInfo "list") <*> mapM toAST _tList
+  List <$> (trackNode ty =<< freshId _tInfo "list") <*> mapM toAST (V.toList _tList)
 toAST (TObject Term.Object {..} _) = do
   debug $ "TObject: " ++ show _oObjectType
   ty <- TySchema TyObject <$> traverse toUserType _oObjectType <*> pure FullSchema
   Object <$> (trackNode ty =<< freshId _oInfo "object")
-    <*> mapM (\(k,v) -> (k,) <$> toAST v) _oObject
+    <*> mapM toAST _oObject
 toAST TConst {..} = toAST (_cvRaw _tConstVal) -- TODO typecheck here
 toAST TGuard {..} = trackPrim _tInfo (TyGuard $ Just $ guardTypeOf _tGuard) (PrimGuard _tGuard)
 toAST TValue {..} = trackPrim _tInfo TyValue (PrimValue _tValue)

--- a/src/Pact/Types/PactOutput.hs
+++ b/src/Pact/Types/PactOutput.hs
@@ -8,17 +8,17 @@
 -- License     :  BSD-style (see the file LICENSE)
 -- Maintainer  :  Stuart Popejoy <stuart@kadena.io>
 --
--- 'PactTerm' is a type for marshalling term values in Pact's
+-- 'PactOutput' is a type for marshalling term values in Pact's
 -- "front end", to address the issue where 'Term Name' cannot
 -- be safely or meaningfully represented outside of the interpreter.
--- 'PactTerm' is intended to be used in execution results that need
--- to be serialized to and from JSON.
+-- 'PactOutput' is needed for reliable reproduction of receipt
+-- results and continuation arguments in the SPV process.
 --
 
-module Pact.Types.PactTerm
-  ( PactTerm(..),
-    toPactTerm,
-    fromPactTerm
+module Pact.Types.PactOutput
+  ( PactOutput(..),
+    toPactOutput,
+    fromPactOutput
   ) where
 
 import Data.Aeson hiding (Value(..))
@@ -39,7 +39,7 @@ import Pact.Types.Util (AsString(..))
 import Pact.Types.Pretty (renderCompactText)
 import Pact.Types.Type (Type(TyAny))
 
-data UserGuard' = UserGuard' (ObjectMap PactTerm) Text
+data UserGuard' = UserGuard' (ObjectMap PactOutput) Text
    deriving (Eq,Show,Ord)
 
 instance ToJSON UserGuard' where
@@ -94,10 +94,10 @@ instance FromJSON ObjType where
 
 
 
-data PactTerm
+data PactOutput
   = PLiteral Literal
-  | PList (Vector PactTerm)
-  | PObject (ObjectMap PactTerm)
+  | PList (Vector PactOutput)
+  | PObject (ObjectMap PactOutput)
   | PGuard Guard'
   deriving (Eq,Ord,Show)
 
@@ -105,7 +105,7 @@ data PactTerm
 pToJSON :: ToJSON v => ObjType -> v -> A.Value
 pToJSON t v = object [ "t" .= t, "v" .= v ]
 
-instance ToJSON PactTerm where
+instance ToJSON PactOutput where
   toJSON (PLiteral l) = case l of
     LInteger i -> A.Number (scientific i 0)
     LDecimal (Decimal p m) -> pToJSON ODecimal $ object [ "p" .= p, "m" .= m ]
@@ -121,13 +121,13 @@ instance ToJSON PactTerm where
     GModule' g -> pToJSON OGModule g
     GUser' g -> pToJSON OGUser g
 
-instance FromJSON PactTerm where
+instance FromJSON PactOutput where
   parseJSON (A.Number s)
-    | base10Exponent s /= 0 = fail "PactTerm: Only integer numbers supported"
+    | base10Exponent s /= 0 = fail "PactOutput: Only integer numbers supported"
     | otherwise = pure (PLiteral (LInteger (coefficient s)))
   parseJSON (A.String s) = pure (PLiteral (LString s))
   parseJSON (A.Bool b) = pure (PLiteral (LBool b))
-  parseJSON A.Null = fail "PactTerm: illegal NULL"
+  parseJSON A.Null = fail "PactOutput: illegal NULL"
   parseJSON (A.Array v) = PList <$> V.mapM parseJSON v
   parseJSON (A.Object o) = o .: "t" >>= \t -> case t of
     OObject -> PObject <$> pj o
@@ -142,28 +142,28 @@ instance FromJSON PactTerm where
     where pj o' = o' .: "v"
 
 
-toPactTerm :: Term Name -> Either Text PactTerm
-toPactTerm (TLiteral l _) = pure $ PLiteral l
-toPactTerm (TObject (Object o _ _) _) = PObject <$> traverse toPactTerm o
-toPactTerm (TList l _ _) = PList <$> V.mapM toPactTerm l
-toPactTerm (TGuard x _) = fmap PGuard $ case x of
+toPactOutput :: Term Name -> Either Text PactOutput
+toPactOutput (TLiteral l _) = pure $ PLiteral l
+toPactOutput (TObject (Object o _ _) _) = PObject <$> traverse toPactOutput o
+toPactOutput (TList l _ _) = PList <$> V.mapM toPactOutput l
+toPactOutput (TGuard x _) = fmap PGuard $ case x of
   GPact g -> pure $ GPact' g
   GKeySet g -> pure $ GKeySet' g
   GKeySetRef g -> pure $ GKeySetRef' g
   GModule g -> pure $ GModule' g
-  GUser (UserGuard (Object o _ _) n) -> GUser' <$> (UserGuard' <$> traverse toPactTerm o <*> pure (asString n))
-toPactTerm t = Left $ "Unable to convert Term: " <> renderCompactText t
+  GUser (UserGuard (Object o _ _) n) -> GUser' <$> (UserGuard' <$> traverse toPactOutput o <*> pure (asString n))
+toPactOutput t = Left $ "Unable to convert Term: " <> renderCompactText t
 
-fromPactTerm :: PactTerm -> Term Name
-fromPactTerm (PLiteral l) = TLiteral l def
-fromPactTerm (PObject o) = TObject (Object (fmap fromPactTerm o) TyAny def) def
-fromPactTerm (PList l) = TList (fmap fromPactTerm l) TyAny def
-fromPactTerm (PGuard x) = (`TGuard` def) $ case x of
+fromPactOutput :: PactOutput -> Term Name
+fromPactOutput (PLiteral l) = TLiteral l def
+fromPactOutput (PObject o) = TObject (Object (fmap fromPactOutput o) TyAny def) def
+fromPactOutput (PList l) = TList (fmap fromPactOutput l) TyAny def
+fromPactOutput (PGuard x) = (`TGuard` def) $ case x of
   GPact' g -> GPact g
   GKeySet' g -> GKeySet g
   GKeySetRef' g -> GKeySetRef g
   GModule' g -> GModule g
-  GUser' (UserGuard' d p) -> GUser $ UserGuard (Object (fmap fromPactTerm d) TyAny def) unsafeParseName
+  GUser' (UserGuard' d p) -> GUser $ UserGuard (Object (fmap fromPactOutput d) TyAny def) unsafeParseName
     where unsafeParseName = case parseName def p of
             Left t -> Name ("unsafe parse failed: " <> fromString t) def
             Right n -> n

--- a/src/Pact/Types/PactTerm.hs
+++ b/src/Pact/Types/PactTerm.hs
@@ -1,0 +1,169 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module      :  Pact.Types.Term
+-- Copyright   :  (C) 2019 Stuart Popejoy
+-- License     :  BSD-style (see the file LICENSE)
+-- Maintainer  :  Stuart Popejoy <stuart@kadena.io>
+--
+-- 'PactTerm' is a type for marshalling term values in Pact's
+-- "front end", to address the issue where 'Term Name' cannot
+-- be safely or meaningfully represented outside of the interpreter.
+-- 'PactTerm' is intended to be used in execution results that need
+-- to be serialized to and from JSON.
+--
+
+module Pact.Types.PactTerm
+  ( PactTerm(..),
+    toPactTerm,
+    fromPactTerm
+  ) where
+
+import Data.Aeson hiding (Value(..))
+import qualified Data.Aeson as A
+import Data.Decimal
+import Data.Default (def)
+import Data.Scientific
+import Data.Vector (Vector)
+import qualified Data.Vector as V
+import Data.Text (Text)
+import Data.String (IsString(..))
+
+import Pact.Types.Exp (Literal(..))
+import Pact.Types.Term (ObjectMap(..),PactGuard(..),KeySet(..),KeySetName(..),
+                        ModuleGuard(..),Term(..),Name(..),Object(..),Guard(..),
+                        UserGuard(..),parseName)
+import Pact.Types.Util (AsString(..))
+import Pact.Types.Pretty (renderCompactText)
+import Pact.Types.Type (Type(TyAny))
+
+data UserGuard' = UserGuard' (ObjectMap PactTerm) Text
+   deriving (Eq,Show,Ord)
+
+instance ToJSON UserGuard' where
+  toJSON (UserGuard' o n) = object [ "data" .= o, "pred" .= n ]
+instance FromJSON UserGuard' where
+  parseJSON = withObject "UserGuard'" $ \o ->
+    UserGuard' <$> o .: "data" <*> o .: "pred"
+
+
+
+
+data Guard'
+  = GPact' !PactGuard
+  | GKeySet' !KeySet
+  | GKeySetRef' !KeySetName
+  | GModule' !ModuleGuard
+  | GUser' !UserGuard'
+  deriving (Eq,Ord,Show)
+
+data ObjType
+  = OObject
+  | ODecimal
+  | OTime
+  | OGPact
+  | OGKeySet
+  | OGKeySetRef
+  | OGModule
+  | OGUser
+
+instance ToJSON ObjType where
+  toJSON o = A.String $ case o of
+    OObject -> "o"
+    ODecimal -> "d"
+    OTime -> "t"
+    OGPact -> "gpact"
+    OGKeySet -> "ks"
+    OGKeySetRef -> "ksref"
+    OGModule -> "gmodule"
+    OGUser -> "guser"
+instance FromJSON ObjType where
+  parseJSON = withText "ObjType" $ \s -> case s of
+     "o" -> pure OObject
+     "d" -> pure ODecimal
+     "t" -> pure OTime
+     "gpact" -> pure OGPact
+     "ks" -> pure OGKeySet
+     "ksref" -> pure OGKeySetRef
+     "gmodule" -> pure OGModule
+     "guser" -> pure OGUser
+     _ -> fail "unrecognized ObjType"
+
+
+
+
+data PactTerm
+  = PLiteral Literal
+  | PList (Vector PactTerm)
+  | PObject (ObjectMap PactTerm)
+  | PGuard Guard'
+  deriving (Eq,Ord,Show)
+
+
+pToJSON :: ToJSON v => ObjType -> v -> A.Value
+pToJSON t v = object [ "t" .= t, "v" .= v ]
+
+instance ToJSON PactTerm where
+  toJSON (PLiteral l) = case l of
+    LInteger i -> A.Number (scientific i 0)
+    LDecimal (Decimal p m) -> pToJSON ODecimal $ object [ "p" .= p, "m" .= m ]
+    LString s -> toJSON s
+    LBool b -> toJSON b
+    LTime t -> pToJSON OTime t
+  toJSON (PObject o) = pToJSON OObject o
+  toJSON (PList v) = toJSON v
+  toJSON (PGuard x) = case x of
+    GPact' g -> pToJSON OGPact g
+    GKeySet' g -> pToJSON OGKeySet g
+    GKeySetRef' g -> pToJSON OGKeySetRef g
+    GModule' g -> pToJSON OGModule g
+    GUser' g -> pToJSON OGUser g
+
+instance FromJSON PactTerm where
+  parseJSON (A.Number s)
+    | base10Exponent s /= 0 = fail "PactTerm: Only integer numbers supported"
+    | otherwise = pure (PLiteral (LInteger (coefficient s)))
+  parseJSON (A.String s) = pure (PLiteral (LString s))
+  parseJSON (A.Bool b) = pure (PLiteral (LBool b))
+  parseJSON A.Null = fail "PactTerm: illegal NULL"
+  parseJSON (A.Array v) = PList <$> V.mapM parseJSON v
+  parseJSON (A.Object o) = o .: "t" >>= \t -> case t of
+    OObject -> PObject <$> pj o
+    ODecimal -> pj o >>= fmap (PLiteral . LDecimal) . withObject "PDecimal"
+      (\d -> Decimal <$> d .: "p" <*> d .: "m")
+    OTime -> PLiteral . LTime <$> pj o
+    OGPact -> PGuard . GPact' <$> pj o
+    OGKeySet -> PGuard . GKeySet' <$> pj o
+    OGKeySetRef -> PGuard . GKeySetRef' <$> pj o
+    OGModule -> PGuard . GModule' <$> pj o
+    OGUser -> PGuard . GUser' <$> pj o
+    where pj o' = o' .: "v"
+
+
+toPactTerm :: Term Name -> Either Text PactTerm
+toPactTerm (TLiteral l _) = pure $ PLiteral l
+toPactTerm (TObject (Object o _ _) _) = PObject <$> traverse toPactTerm o
+toPactTerm (TList l _ _) = PList <$> V.mapM toPactTerm l
+toPactTerm (TGuard x _) = fmap PGuard $ case x of
+  GPact g -> pure $ GPact' g
+  GKeySet g -> pure $ GKeySet' g
+  GKeySetRef g -> pure $ GKeySetRef' g
+  GModule g -> pure $ GModule' g
+  GUser (UserGuard (Object o _ _) n) -> GUser' <$> (UserGuard' <$> traverse toPactTerm o <*> pure (asString n))
+toPactTerm t = Left $ "Unable to convert Term: " <> renderCompactText t
+
+fromPactTerm :: PactTerm -> Term Name
+fromPactTerm (PLiteral l) = TLiteral l def
+fromPactTerm (PObject o) = TObject (Object (fmap fromPactTerm o) TyAny def) def
+fromPactTerm (PList l) = TList (fmap fromPactTerm l) TyAny def
+fromPactTerm (PGuard x) = (`TGuard` def) $ case x of
+  GPact' g -> GPact g
+  GKeySet' g -> GKeySet g
+  GKeySetRef' g -> GKeySetRef g
+  GModule' g -> GModule g
+  GUser' (UserGuard' d p) -> GUser $ UserGuard (Object (fmap fromPactTerm d) TyAny def) unsafeParseName
+    where unsafeParseName = case parseName def p of
+            Left t -> Name ("unsafe parse failed: " <> fromString t) def
+            Right n -> n

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -48,24 +48,24 @@ module Pact.Types.Runtime
 
 
 import Control.Arrow ((&&&))
-import Control.Lens hiding ((.=),DefName)
-import Control.Monad.Except
-import Control.Monad.State.Strict
-import Control.Monad.Reader
-
-import qualified Data.Map.Strict as M
-import qualified Data.HashMap.Strict as HM
-import Data.Aeson hiding (Object)
-import Data.String
-import Data.Default
-import Control.Monad.Catch
 import Control.Concurrent.MVar
+import Control.Lens hiding ((.=),DefName)
+import Control.Monad.Catch
+import Control.Monad.Except
+import Control.Monad.Reader
+import Control.Monad.State.Strict
+import Data.Aeson hiding (Object)
+import Data.Default
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
+import Data.String
 
 import Pact.Types.ChainMeta
 import Pact.Types.Gas
 import Pact.Types.Lang
 import Pact.Types.Orphans ()
+import Pact.Types.PactOutput
 import Pact.Types.Persistence
 import Pact.Types.Pretty
 import Pact.Types.Util
@@ -144,7 +144,7 @@ data PactStep = PactStep {
       _psStep :: !Int
     , _psRollback :: !Bool
     , _psPactId :: !PactId
-    , _psResume :: !(Maybe (Term Name))
+    , _psResume :: !(Maybe (ObjectMap (Term Name)))
 } deriving (Eq,Show)
 makeLenses ''PactStep
 
@@ -163,15 +163,17 @@ data RefStore = RefStore {
 makeLenses ''RefStore
 instance Default RefStore where def = RefStore HM.empty HM.empty
 
-newtype PactContinuation = PactContinuation (App (Term Ref))
-  deriving (Eq,Show)
+data PactContinuation = PactContinuation
+  { _pcDef :: Def Ref
+  , _pcArgs :: [PactOutput]
+  } deriving (Eq,Show)
 
 -- | Result of evaluation of a 'defpact'.
 data PactExec = PactExec
   { -- | Count of steps in pact (discovered when code is executed)
     _peStepCount :: Int
     -- | Yield value if invoked
-  , _peYield :: !(Maybe (Term Name))
+  , _peYield :: !(Maybe (ObjectMap PactOutput))
     -- | Whether step was executed (in private cases, it can be skipped)
   , _peExecuted :: Bool
     -- | Step that was executed or skipped

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -67,7 +67,7 @@ module Pact.Types.Term
    tNativeDocs,tNativeFun,tNativeName,tNativeExamples,tNativeTopLevelOnly,tObject,tSchemaName,
    tStepEntity,tStepExec,tStepRollback,tTableName,tTableType,tValue,tVar,
    ToTerm(..),
-   toTermList,toTObject,toTList,
+   toTermList,toTObject,toTObjectMap,toTList,toTListV,
    typeof,typeof',guardTypeOf,
    pattern TLitString,pattern TLitInteger,pattern TLitBool,
    tLit,tStr,termEq,
@@ -1071,10 +1071,16 @@ instance ToTerm Int64 where toTerm = tLit . LInteger . fromIntegral
 
 
 toTObject :: Type (Term n) -> Info -> [(FieldKey,Term n)] -> Term n
-toTObject ty i ps = TObject (Object (ObjectMap (M.fromList ps)) ty i) i
+toTObject ty i = toTObjectMap ty i . ObjectMap . M.fromList
+
+toTObjectMap :: Type (Term n) -> Info -> ObjectMap (Term n) -> Term n
+toTObjectMap ty i m = TObject (Object m ty i) i
 
 toTList :: Type (Term n) -> Info -> [Term n] -> Term n
-toTList ty i vs = TList (V.fromList vs) ty i
+toTList ty i = toTListV ty i . V.fromList
+
+toTListV :: Type (Term n) -> Info -> V.Vector (Term n) -> Term n
+toTListV ty i vs = TList vs ty i
 
 toTermList :: (ToTerm a,Foldable f) => Type (Term b) -> f a -> Term b
 toTermList ty l = TList (V.map toTerm (V.fromList (toList l))) ty def

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
@@ -56,6 +57,7 @@ module Pact.Types.Term
    Def(..),dDefBody,dDefName,dDefType,dMeta,dFunType,dInfo,dModule,
    Example(..),
    derefDef,
+   ObjectMap(..),objectMapToListWith,
    Object(..),oObject,oObjectType,oInfo,
    FieldKey(..),
    Term(..),
@@ -89,7 +91,7 @@ import qualified Data.Aeson as A
 import qualified Data.ByteString.UTF8 as BS
 import Data.String
 import Data.Default
-import Data.Thyme
+import Data.Thyme (UTCTime)
 import GHC.Generics (Generic)
 import Data.Decimal
 import Data.Hashable
@@ -100,11 +102,14 @@ import Control.DeepSeq
 import Data.Maybe
 import qualified Data.HashSet as HS
 import qualified Data.HashMap.Strict as HM
+import qualified Data.Map.Strict as M
 import Data.Int (Int64)
 import Data.Serialize (Serialize)
 import Data.Eq.Deriving
 import Text.Show.Deriving
 import Data.Word (Word64, Word32)
+import Data.Vector (Vector)
+import qualified Data.Vector as V
 
 import Pact.Types.Parser
 import Pact.Types.Pretty hiding (dot)
@@ -155,7 +160,7 @@ instance Pretty PublicKey where
 data KeySet = KeySet {
       _ksKeys :: ![PublicKey]
     , _ksPredFun :: !Name
-    } deriving (Eq,Generic,Show)
+    } deriving (Eq,Generic,Show,Ord)
 
 instance Pretty KeySet where
   pretty (KeySet ks f) = "KeySet" <+> commaBraces
@@ -189,7 +194,7 @@ instance NFData PactId
 data PactGuard = PactGuard
   { _pgPactId :: !PactId
   , _pgName :: !Text
-  } deriving (Eq,Generic,Show)
+  } deriving (Eq,Generic,Show,Ord)
 
 instance Pretty PactGuard where
   pretty PactGuard{..} = "PactGuard" <+> commaBraces
@@ -203,7 +208,7 @@ instance FromJSON PactGuard where parseJSON = lensyParseJSON 3
 data ModuleGuard = ModuleGuard
   { _mgModuleName :: !ModuleName
   , _mgName :: !Text
-  } deriving (Eq,Generic,Show)
+  } deriving (Eq,Generic,Show,Ord)
 
 instance Pretty ModuleGuard where
   pretty ModuleGuard{..} = "ModuleGuard" <+> commaBraces
@@ -215,7 +220,7 @@ instance ToJSON ModuleGuard where toJSON = lensyToJSON 3
 instance FromJSON ModuleGuard where parseJSON = lensyParseJSON 3
 
 data UserGuard = UserGuard
-  { _ugData :: !(Term Name) -- TODO when Term is safe, use "object" type
+  { _ugData :: !(Object Name) -- TODO when Term is safe, use "object" type
   , _ugPredFun :: !Name
   } deriving (Eq,Generic,Show)
 
@@ -229,11 +234,11 @@ instance ToJSON UserGuard where toJSON = lensyToJSON 3
 instance FromJSON UserGuard where parseJSON = lensyParseJSON 3
 
 data Guard
-  = GPact PactGuard
-  | GKeySet KeySet
-  | GKeySetRef KeySetName
-  | GModule ModuleGuard
-  | GUser UserGuard
+  = GPact !PactGuard
+  | GKeySet !KeySet
+  | GKeySetRef !KeySetName
+  | GModule !ModuleGuard
+  | GUser !UserGuard
   deriving (Eq,Show)
 
 instance Pretty Guard where
@@ -390,6 +395,8 @@ instance Pretty Name where
   pretty = \case
     QName modName nName _ -> pretty modName <> "." <> pretty nName
     Name nName _          -> pretty nName
+
+instance AsString Name where asString = renderCompactText
 
 instance ToJSON Name where
   toJSON = toJSON . renderCompactString
@@ -638,7 +645,7 @@ instance Show1 Term where
       . showsPrec 11 _tInfo
     TList{..} ->
         showString "TList "
-      . showList1 _tList
+      . showList1 (V.toList _tList)
       . showChar ' '
       . shows2 11 _tListType
       . showChar ' '
@@ -775,19 +782,48 @@ instance Pretty Example where
 instance IsString Example where
   fromString = ExecExample . fromString
 
+-- | Label type for objects.
 newtype FieldKey = FieldKey Text
   deriving (Eq,Ord,IsString,AsString,ToJSON,FromJSON,Show)
 instance Pretty FieldKey where
   pretty (FieldKey k) = dquotes $ pretty k
 
+-- | Simple dictionary for object values.
+newtype ObjectMap v = ObjectMap (M.Map FieldKey v)
+  deriving (Eq,Ord,Show,Functor,Foldable,Traversable)
+
+-- | O(n) conversion to list. Adapted from 'M.toAscList'
+objectMapToListWith :: (FieldKey -> v -> r) -> ObjectMap v -> [r]
+objectMapToListWith f (ObjectMap m) = M.foldrWithKey (\k x xs -> (f k x):xs) [] m
+
+instance Pretty v => Pretty (ObjectMap v) where
+  pretty om = annotate Val $ commaBraces $
+    objectMapToListWith (\k v -> pretty k <> ": " <> pretty v) om
+
+instance ToJSON v => ToJSON (ObjectMap v)
+  where toJSON om =
+          object $ objectMapToListWith (\k v -> (asString k,toJSON v)) om
+
+instance FromJSON v => FromJSON (ObjectMap v)
+  where parseJSON = withObject "ObjectMap" $ \o ->
+          ObjectMap . M.fromList <$>
+            traverse (\(k,v) -> (FieldKey k,) <$> parseJSON v) (HM.toList o)
+
+-- | Full Term object.
 data Object n = Object
-  { _oObject :: ![(FieldKey,Term n)]
+  { _oObject :: !(ObjectMap (Term n))
   , _oObjectType :: !(Type (Term n))
   , _oInfo :: !Info
   } deriving (Functor,Foldable,Traversable,Eq,Show)
 instance Pretty n => Pretty (Object n) where
-  pretty (Object bs _ _) = annotate Val $ commaBraces $
-      fmap (\(a, b) -> pretty a <> ": " <> pretty b) bs
+  pretty (Object bs _ _) = pretty bs
+
+-- JSON instances are just for Guard above
+instance (Pretty n, ToJSON n) => ToJSON (Object n) where
+  toJSON = toJSON . _oObject
+
+instance FromJSON n => FromJSON (Object n) where
+  parseJSON v = Object <$> parseJSON v <*> pure TyAny <*> pure def
 
 -- | Pact evaluable term.
 data Term n =
@@ -797,7 +833,7 @@ data Term n =
     , _tInfo :: !Info
     } |
     TList {
-      _tList :: ![Term n]
+      _tList :: !(Vector (Term n))
     , _tListType :: Type (Term n)
     , _tInfo :: !Info
     } |
@@ -881,7 +917,7 @@ data Term n =
 instance Pretty n => Pretty (Term n) where
   pretty = \case
     TModule{..} -> pretty _tModuleDef
-    TList{..} -> bracketsSep $ pretty <$> _tList
+    TList{..} -> bracketsSep $ pretty <$> V.toList _tList
     TDef{..} -> pretty _tDef
     TNative{..} -> annotate Header ("native `" <> pretty _tNativeName <> "`")
       <> nest 2 (
@@ -956,7 +992,7 @@ instance Eq1 Term where
     liftEq (\(w,x) (y,z) -> liftEq (liftEq eq) w y && liftEq eq x z) a m &&
     liftEq eq b n && liftEq (liftEq (liftEq eq)) c o && d == p
   liftEq eq (TObject (Object a b c) d) (TObject (Object m n o) p) =
-    liftEq (\(w,x) (y,z) -> w == y && liftEq eq x z) a m && liftEq (liftEq eq) b n && c == o && d == p
+    liftEq (liftEq eq) a m && liftEq (liftEq eq) b n && c == o && d == p
   liftEq _ (TLiteral a b) (TLiteral m n) =
     a == m && b == n
   liftEq _ (TGuard a b) (TGuard m n) =
@@ -981,14 +1017,14 @@ instance Applicative Term where
 instance Monad Term where
     return a = TVar a def
     TModule m b i >>= f = TModule (fmap (>>= f) m) (b >>>= f) i
-    TList bs t i >>= f = TList (map (>>= f) bs) (fmap (>>= f) t) i
+    TList bs t i >>= f = TList (V.map (>>= f) bs) (fmap (>>= f) t) i
     TDef (Def n m dt ft b d i) i' >>= f = TDef (Def n m dt (fmap (>>= f) ft) (b >>>= f) d i) i'
     TNative n fn t exs d tl i >>= f = TNative n fn (fmap (fmap (>>= f)) t) exs d tl i
     TConst d m c t i >>= f = TConst (fmap (>>= f) d) m (fmap (>>= f) c) t i
     TApp a i >>= f = TApp (fmap (>>= f) a) i
     TVar n i >>= f = (f n) { _tInfo = i }
     TBinding bs b c i >>= f = TBinding (map (fmap (>>= f) *** (>>= f)) bs) (b >>>= f) (fmap (fmap (>>= f)) c) i
-    TObject (Object bs t oi) i >>= f = TObject (Object (map (id *** (>>= f)) bs) (fmap (>>= f) t) oi) i
+    TObject (Object bs t oi) i >>= f = TObject (Object (fmap (>>= f) bs) (fmap (>>= f) t) oi) i
     TLiteral l i >>= _ = TLiteral l i
     TGuard k i >>= _ = TGuard k i
     TUse u i >>= _ = TUse u i
@@ -1011,8 +1047,7 @@ instance Pretty n => ToJSON (Term n) where
     toJSON (TLiteral l _) = toJSON l
     toJSON (TValue v _) = v
     toJSON (TGuard k _) = toJSON k
-    toJSON (TObject (Object kvs _ _) _) =
-        object $ map (asString *** toJSON) kvs
+    toJSON (TObject (Object kvs _ _) _) = toJSON kvs
     toJSON (TList ts _ _) = toJSON ts
     toJSON t = toJSON (renderCompactText t)
     {-# INLINE toJSON #-}
@@ -1036,13 +1071,13 @@ instance ToTerm Int64 where toTerm = tLit . LInteger . fromIntegral
 
 
 toTObject :: Type (Term n) -> Info -> [(FieldKey,Term n)] -> Term n
-toTObject ty i ps = TObject (Object ps ty i) i
+toTObject ty i ps = TObject (Object (ObjectMap (M.fromList ps)) ty i) i
 
 toTList :: Type (Term n) -> Info -> [Term n] -> Term n
-toTList ty i vs = TList vs ty i
+toTList ty i vs = TList (V.fromList vs) ty i
 
 toTermList :: (ToTerm a,Foldable f) => Type (Term b) -> f a -> Term b
-toTermList ty l = TList (map toTerm (toList l)) ty def
+toTermList ty l = TList (V.map toTerm (V.fromList (toList l))) ty def
 
 guardTypeOf :: Guard -> GuardType
 guardTypeOf g = case g of
@@ -1098,11 +1133,14 @@ tStr = toTerm
 
 -- | Support pact `=` for value-level terms
 termEq :: Eq n => Term n -> Term n -> Bool
-termEq (TList a _ _) (TList b _ _) = length a == length b && and (zipWith termEq a b)
-termEq (TObject (Object a _ _) _) (TObject (Object b _ _) _) = length a == length b && all (lkpEq b) a
-    where lkpEq [] _ = False
-          lkpEq ((k',v'):ts) p@(k,v) | k == k' && termEq v v' = True
-                                     | otherwise = lkpEq ts p
+termEq (TList a _ _) (TList b _ _) = length a == length b && and (V.zipWith termEq a b)
+termEq (TObject (Object (ObjectMap a) _ _) _) (TObject (Object (ObjectMap b) _ _) _) =
+  -- O(3n), 2x M.toList + short circuiting walk
+  M.size a == M.size b && go (M.toList a) (M.toList b) True
+    where go _ _ False = False
+          go ((k1,v1):r1) ((k2,v2):r2) _ = go r1 r2 $ k1 == k2 && v1 `termEq` v2
+          go [] [] _ = True
+          go _ _ _ = False
 termEq (TLiteral a _) (TLiteral b _) = a == b
 termEq (TGuard a _) (TGuard b _) = a == b
 termEq (TValue a _) (TValue b _) = a == b
@@ -1132,9 +1170,11 @@ deriveEq1 ''Def
 deriveEq1 ''ModuleDef
 deriveEq1 ''Module
 deriveEq1 ''Governance
+deriveEq1 ''ObjectMap
 deriveEq1 ''Object
 
 deriveShow1 ''App
+deriveShow1 ''ObjectMap
 deriveShow1 ''Object
 deriveShow1 ''BindType
 deriveShow1 ''ConstVal

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -321,7 +321,7 @@ data AST n =
   } |
   Object {
   _aNode :: n,
-  _aObject :: [(FieldKey,AST n)]
+  _aObject :: ObjectMap (AST n)
   } |
   Prim {
   _aNode :: n,
@@ -350,10 +350,7 @@ instance Pretty t => Pretty (AST t) where
      Var {..} -> pn
      Object {..} -> sep
        [ pn
-       , bracesSep
-         [ indent 2 $ vsep $ _aObject <&> \(k,v) ->
-           pretty k <> sep [ ":", indent 4 (pretty v) ]
-         ]
+       , pretty _aObject
        ]
      List {..} -> sep
        [ pn

--- a/tests/Analyze/Translate.hs
+++ b/tests/Analyze/Translate.hs
@@ -11,6 +11,7 @@ import           Control.Monad.Reader      (ReaderT (runReaderT))
 import           Control.Monad.Trans.Class (MonadTrans (lift))
 import           Control.Monad.Trans.Maybe (MaybeT (MaybeT, runMaybeT),
                                             exceptToMaybeT)
+import qualified Data.Vector               as V
 
 import           Pact.Analyze.Translate    (translateNodeNoGraph)
 import           Pact.Analyze.Types        hiding (Object, Term)
@@ -202,7 +203,7 @@ toPactTm = \case
       arg'     <- toPactTm arg
       argList' <- traverse toPactTm argList
       pure $ (`TApp` dummyInfo) $ App (liftTerm defTm)
-        [arg', Pact.TList argList' (Pact.TyList Pact.TyAny) dummyInfo]
+        [arg', Pact.TList (V.fromList argList') (Pact.TyList Pact.TyAny) dummyInfo]
         dummyInfo
 
     arithOpToDef :: ArithOp -> NativeDef

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -14,6 +14,8 @@
 
   (defschema yieldschema result:integer)
 
+  (defschema guardschema key:string)
+
   (defcap GRANTED () true)
 
   (defcap KALL-CAP () (enforce-keyset 'kall))
@@ -34,10 +36,10 @@
     (create-module-guard "test"))
 
   (defun msg-keyset-user-guard (key:string)
-    (create-user-guard key "enforce-msg-keyset"))
+    (create-user-guard {'key: key} "enforce-msg-keyset"))
 
-  (defun enforce-msg-keyset (key:string)
-    (enforce-keyset (read-keyset key)))
+  (defun enforce-msg-keyset (key:object{guardschema})
+    (enforce-keyset (read-keyset (at 'key key))))
 
   (defpact test-pact-guards (id:string)
     (step (step1 id))


### PR DESCRIPTION
Fixes #459 

Implemented in `EvalResult` output, yields, and continuations for stable recovery of these values in SPV.

Notable features:

- `TObject` now based on a `Map` finally. Absurdly better code and asymptotics on things like key lookup.
- `TList` now based on `Vector`. Better code, maybe slightly better asymptotics, but waaaay better sort (via mutable vector use)