### PR TITLE
Better compile errors

### DIFF
--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -358,7 +358,7 @@ data AtPair = DocPair Text | ModelPair [Exp Info] deriving (Eq,Ord)
 meta :: ModelAllowed -> Compile Meta
 meta modelAllowed =
   -- hiding labels/errors here because otherwise they hang around for all module errors
-  hidden (atPairs) <|> hidden (try docStr) <|> return def
+  hidden atPairs <|> hidden (try docStr) <|> return def
   where
     docStr = Meta <$> (Just <$> str) <*> pure []
     docPair = symbol "@doc" >> (DocPair <$> str)

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -596,7 +596,11 @@ bodyForm term = do
   return $ TList (V.fromList bs) TyAny i
 
 bodyForm' :: Compile a -> Compile ([a],Info)
-bodyForm' term = (,) <$> some term <*> contextInfo
+bodyForm' term = (,) <$> go <*> contextInfo
+  where go = getInput >>= \c -> case _cStream c of
+          [] -> pure <$> term -- will fail, similar to 'some'
+          es -> replicateM (length es) term
+
 
 _compileAccounts :: IO (Either PactError [Term Name])
 _compileAccounts = _compileF "examples/accounts/accounts.pact"

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -594,7 +594,7 @@ bodyForm term = do
   return $ TList (V.fromList bs) TyAny i
 
 bodyForm' :: Compile a -> Compile ([a],Info)
-bodyForm' term = (,) <$> some term <*> contextInfo
+bodyForm' term = (,) <$> (some term <?> "expected body") <*> contextInfo
 
 _compileAccounts :: IO (Either PactError [Term Name])
 _compileAccounts = _compileF "examples/accounts/accounts.pact"
@@ -602,38 +602,46 @@ _compileAccounts = _compileF "examples/accounts/accounts.pact"
 _compileF :: FilePath -> IO (Either PactError [Term Name])
 _compileF f = _parseF f >>= _compile id
 
+handleParseError :: TF.Result a -> IO a
+handleParseError (TF.Failure f) = putDoc (fromAnsiWlPprint (TF._errDoc f)) >> error "parseFailed"
+handleParseError (TF.Success a) = return a
+
+_compileWith :: Compile a -> (ParseState CompileState -> ParseState CompileState) ->
+            TF.Result ([Exp Parsed],MkInfo) -> IO (Either PactError [a])
+_compileWith parser sfun r = handleParseError r >>= \(a,mk) -> return $ forM a $ \e ->
+  let ei = mk <$> e
+  in runCompile parser (sfun (initParseState ei)) ei
+
 _compile :: (ParseState CompileState -> ParseState CompileState) ->
-            TF.Result ([Exp Parsed],String) -> IO (Either PactError [Term Name])
-_compile _ (TF.Failure f) = putDoc (fromAnsiWlPprint (TF._errDoc f)) >> error "Parse failed"
-_compile sfun (TF.Success (a,s)) = return $ forM a $ \e ->
-  let ei = mkStringInfo s <$> e
-  in runCompile topLevel (sfun (initParseState ei)) ei
+            TF.Result ([Exp Parsed],MkInfo) -> IO (Either PactError [Term Name])
+_compile = _compileWith topLevel
+
 
 -- | run a string as though you were in a module (test deftable, etc)
 _compileStrInModule :: String -> IO [Term Name]
-_compileStrInModule = _compileStr' (set (psUser . csModule) (Just (initModuleState "mymodule" (hash mempty))))
+_compileStrInModule = fmap concat . _compileStr' moduleLevel (set (psUser . csModule) (Just (initModuleState "mymodule" (hash mempty))))
 
 _compileStr :: String -> IO [Term Name]
-_compileStr = _compileStr' id
+_compileStr = _compileStr' topLevel id
 
-_compileStr' :: (ParseState CompileState -> ParseState CompileState) -> String -> IO [Term Name]
-_compileStr' sfun code = do
-    r <- _compile sfun ((,code) <$> _parseS code)
+_compileStr' :: Compile a -> (ParseState CompileState -> ParseState CompileState) -> String -> IO [a]
+_compileStr' parser sfun code = do
+    r <- _compileWith parser sfun $ _parseS code
     case r of Left e -> throwIO $ userError (show e)
               Right t -> return t
 
-_parseS :: String -> TF.Result [Exp Parsed]
-_parseS = TF.parseString exprsOnly mempty
+_parseS :: String -> TF.Result ([Exp Parsed],MkInfo)
+_parseS s = (,mkStringInfo s) <$> TF.parseString exprsOnly mempty s
 
-_parseF :: FilePath -> IO (TF.Result ([Exp Parsed],String))
-_parseF fp = readFile fp >>= \s -> fmap (,s) <$> TF.parseFromFileEx exprsOnly fp
+_parseF :: FilePath -> IO (TF.Result ([Exp Parsed],MkInfo))
+_parseF fp = readFile fp >>= \s -> fmap (,mkStringInfo s) <$> TF.parseFromFileEx exprsOnly fp
 
 _compileFile :: FilePath -> IO [Term Name]
 _compileFile f = do
     p <- _parseF f
     rs <- case p of
             (TF.Failure e) -> putDoc (fromAnsiWlPprint (TF._errDoc e)) >> error "Parse failed"
-            (TF.Success (es,s)) -> return $ map (compile (mkStringInfo s)) es
+            (TF.Success (es,s)) -> return $ map (compile s) es
     case sequence rs of
       Left e -> throwIO $ userError (show e)
       Right ts -> return ts

--- a/src/Pact/Types/ExpParser.hs
+++ b/src/Pact/Types/ExpParser.hs
@@ -228,8 +228,8 @@ exp ty prism = do
   let test i = case firstOf prism i of
         Just a -> Right (a,i)
         Nothing -> err i ("Expected: " ++ ty)
-      err i s = Left (pure (Tokens (i:|[])),
-                      S.singleton (strErr s))
+      err i s = Left (pure (strErr s),
+                      S.singleton (Tokens (i:|[])))
   r <- context >>= (lift . pTokenEpsilon test)
   psCurrent .= snd r
   return r

--- a/src/Pact/Types/ExpParser.hs
+++ b/src/Pact/Types/ExpParser.hs
@@ -134,23 +134,17 @@ runCompile :: ExpParse s a -> ParseState s -> Exp Info -> Either PactError a
 runCompile act cs a =
   case runParser (runStateT act cs) "" (Cursor Nothing [a]) of
     (Right (r,_)) -> Right r
-    (Left (TrivialError _ (Just err) expect)) -> case err of
-      EndOfInput -> case S.toList expect of
-        (Tokens (x :| _):_) -> doErr (getInfo x) "unexpected end of input"
-        (Label s:_) -> doErr def (prettyString (toList s))
-        er -> doErr def (viaShow er)
-      Label ne -> doErr def (prettyString (toList ne))
-      Tokens (x :| _) -> doErr (getInfo x) $ prettyString $ showExpect expect
-    (Left e) -> doErr def (viaShow e)
-    where doErr :: Info -> Doc -> Either PactError a
-          doErr i s = Left $ PactError SyntaxError i def s
-          showExpect e = case labelText $ S.toList e of
-            [] -> show (S.toList e)
-            ss -> intercalate "," ss
-          labelText [] = []
-          labelText (Label s:r) = toList s:labelText r
-          labelText (EndOfInput:r) = "Expected: end of expression or input":labelText r
-          labelText (_:r) = labelText r
+    -- Left e -> Left $ PactError SyntaxError def def $ prettyString $ show e
+    (Left (TrivialError _ itemMay expect)) -> Left $ PactError SyntaxError inf [] (prettyString msg)
+      where expectList = S.toList expect
+            items = maybe expectList (:expectList) itemMay
+            msg = intercalate ", " msgs
+            (inf,msgs) = foldr go (def,[]) items
+            go item (ri,rmsgs) = case item of
+              Label s -> (ri,toList s:rmsgs)
+              EndOfInput -> (ri,"Unexpected end of input":rmsgs)
+              Tokens (x :| _) -> (getInfo x,rmsgs)
+    (Left (FancyError _ errs)) -> Left $ PactError SyntaxError def [] (prettyString $ show errs)
 
 
 {-# INLINE strErr #-}

--- a/src/Pact/Types/ExpParser.hs
+++ b/src/Pact/Types/ExpParser.hs
@@ -134,7 +134,6 @@ runCompile :: ExpParse s a -> ParseState s -> Exp Info -> Either PactError a
 runCompile act cs a =
   case runParser (runStateT act cs) "" (Cursor Nothing [a]) of
     (Right (r,_)) -> Right r
-    -- Left e -> Left $ PactError SyntaxError def def $ prettyString $ show e
     (Left (TrivialError _ itemMay expect)) -> Left $ PactError SyntaxError inf [] (prettyString msg)
       where expectList = S.toList expect
             items = maybe expectList (:expectList) itemMay
@@ -157,9 +156,8 @@ tokenErr s = tokenErr' s . Just
 
 {-# INLINE tokenErr' #-}
 tokenErr' :: String -> Maybe (Exp Info) -> ExpParse s a
-tokenErr' ty i = failure
-  (fmap (\e -> Tokens (e:|[])) i)
-  (S.singleton (strErr ty))
+tokenErr' ty i = failure (Just $ strErr ty) $
+  maybe S.empty (\e -> S.singleton (Tokens (e:|[]))) i
 
 {-# INLINE context #-}
 context :: ExpParse s (Maybe (Exp Info))


### PR DESCRIPTION
- Non-insane handling of error results in `runCompile`
- `tokenErr'` is main change, to insert label as main error item instead of token
- suppression of `meta` errors (not finding a meta resulted in "Expected: literal, Expected: atom" that wouldn't get cleared out)
- possibly extraneous `commit` add in `reservedAtom` that does no harm
- better interactive test functions in Compile (ie, `_compileStrWith` allows running an individual Compile parser)