### PR TITLE
Non-malleability: signatories and chain version in payload 

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -37,7 +37,7 @@ pact> (bind { "a": 1, "b": 2 } { "a" := a-value } a-value)
 Get transaction public metadata. Returns an object with 'chain-id', 'block-height', 'block-time', 'sender', 'gas-limit', 'gas-price', and 'gas-fee' fields.
 ```lisp
 pact> (chain-data)
-{"block-height": 0,"block-time": 0,"chain-id": 0,"gas-limit": 0,"gas-price": 0,"sender": ""}
+{"block-height": 0,"block-time": 0,"chain-id": "Testnet00/0","gas-limit": 0,"gas-price": 0,"sender": ""}
 ```
 
 
@@ -1389,7 +1389,7 @@ Continue previously-initiated pact identified by PACT-ID at STEP, optionally spe
 
 Update existing entries 'chain-data' with NEW-DATA, replacing those items only.
 ```lisp
-pact> (env-chain-data { "chain-id": 2, "block-height": 20 })
+pact> (env-chain-data { "chain-id": "TestNet00/2", "block-height": 20 })
 "Updated public metadata"
 ```
 

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -37,7 +37,7 @@ pact> (bind { "a": 1, "b": 2 } { "a" := a-value } a-value)
 Get transaction public metadata. Returns an object with 'chain-id', 'block-height', 'block-time', 'sender', 'gas-limit', 'gas-price', and 'gas-fee' fields.
 ```lisp
 pact> (chain-data)
-{"block-height": 0,"block-time": 0,"chain-id": "Testnet00/0","gas-limit": 0,"gas-price": 0,"sender": ""}
+{"block-height": 0,"block-time": 0,"chain-id": "","gas-limit": 0,"gas-price": 0,"sender": ""}
 ```
 
 

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -114,7 +114,8 @@ benchReadValue (TxTable _t) _k = rcp Nothing
 
 mkBenchCmd :: [SomeKeyPair] -> (String, Text) -> IO (String, Command ByteString)
 mkBenchCmd kps (str, t) = do
-  cmd <- mkCommand' kps (toStrict $ encode (Payload (Exec (ExecMsg t Null)) "nonce" () (toSigners kps)))
+  cmd <- mkCommand' kps (toStrict $ encode (Payload (Exec (ExecMsg t Null)) "nonce" ()
+                                            (keyPairsToSigners kps)))
   return (str, cmd)
 
 

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -114,7 +114,7 @@ benchReadValue (TxTable _t) _k = rcp Nothing
 
 mkBenchCmd :: [SomeKeyPair] -> (String, Text) -> IO (String, Command ByteString)
 mkBenchCmd kps (str, t) = do
-  cmd <- mkCommand' kps (toStrict $ encode (Payload (Exec (ExecMsg t Null)) "nonce" ()))
+  cmd <- mkCommand' kps (toStrict $ encode (Payload (Exec (ExecMsg t Null)) "nonce" () (toSigners kps)))
   return (str, cmd)
 
 

--- a/src-ghc/Pact/Types/Server.hs
+++ b/src-ghc/Pact/Types/Server.hs
@@ -65,11 +65,11 @@ import Pact.Types.Logger
 import Pact.Interpreter
 
 
-userSigToPactPubKey :: UserSig -> Pact.PublicKey
-userSigToPactPubKey UserSig{..} = Pact.PublicKey $ encodeUtf8 _usAddress
+userSigToPactPubKey :: Signer -> Pact.PublicKey
+userSigToPactPubKey Signer{..} = Pact.PublicKey $ encodeUtf8 _siAddress
 
 
-userSigsToPactKeySet :: [UserSig] -> S.Set Pact.PublicKey
+userSigsToPactKeySet :: [Signer] -> S.Set Pact.PublicKey
 userSigsToPactKeySet = S.fromList . fmap userSigToPactPubKey
 
 

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -305,7 +305,7 @@ chainDataDef = defRNative "chain-data" chainData (funType obj [])
           (ParsedDecimal gp) = _pmGasPrice
 
       pure $ toTObject TyAny def
-        [ ("chain-id"    , toTerm _pdChainId    )
+        [ ("chain-id"    , toTerm _pmChainId    )
         , ("block-height", toTerm _pdBlockHeight)
         , ("block-time"  , toTerm _pdBlockTime  )
         , ("sender"      , toTerm _pmSender     )

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -529,7 +529,7 @@ testCapability i as = argsError' i as
 envChainDataDef :: NativeDef
 envChainDataDef = defZRNative "env-chain-data" envChainData
     (funType tTyString [("new-data", tTyObject TyAny)])
-    ["(env-chain-data { \"chain-id\": 2, \"block-height\": 20 })"]
+    ["(env-chain-data { \"chain-id\": \"TestNet00/2\", \"block-height\": 20 })"]
     "Update existing entries 'chain-data' with NEW-DATA, replacing those items only."
   where
     envChainData :: RNativeFun LibState
@@ -543,7 +543,6 @@ envChainDataDef = defZRNative "env-chain-data" envChainData
       _ -> argsError i as
 
     go i pd ((FieldKey k), (TLiteral (LInteger l) _)) = case Text.unpack k of
-      "chain-id"     -> pure $ set pdChainId (fromIntegral l) pd
       "gas-limit"    -> pure $ set (pdPublicMeta . pmGasLimit) (ParsedInteger . fromIntegral $ l) pd
       "block-height" -> pure $ set pdBlockHeight (fromIntegral l) pd
       "block-time"   -> pure $ set pdBlockTime (fromIntegral l) pd
@@ -554,6 +553,7 @@ envChainDataDef = defZRNative "env-chain-data" envChainData
       t           -> evalError i $ "envChainData: bad public metadata key: " <> prettyString t
 
     go i pd ((FieldKey k), (TLiteral (LString l) _)) = case Text.unpack k of
-      "sender" -> pure $ set (pdPublicMeta . pmSender) l pd
-      t        -> evalError i $ "envChainData: bad public metadata key: " <> prettyString t
+      "chain-id" -> pure $ set (pdPublicMeta . pmChainId) (ChainId l) pd
+      "sender"   -> pure $ set (pdPublicMeta . pmSender) l pd
+      t          -> evalError i $ "envChainData: bad public metadata key: " <> prettyString t
     go i _ as = evalError i $ "envChainData: bad public metadata values: " <> pretty as

--- a/src/Pact/Types/ChainMeta.hs
+++ b/src/Pact/Types/ChainMeta.hs
@@ -14,6 +14,7 @@ module Pact.Types.ChainMeta
   ( -- * types
     Address(..)
   , PrivateMeta(..)
+  , ChainId(..)
   , PublicMeta(..)
   , HasPlafMeta(..)
   , PublicData(..)
@@ -21,6 +22,7 @@ module Pact.Types.ChainMeta
     -- * optics
   , aFrom, aTo
   , pmAddress, pmChainId, pmSender, pmGasLimit, pmGasPrice
+  , ciId, ciNetworkVersion
   , pdChainId, pdPublicMeta, pdBlockHeight, pdBlockTime
   ) where
 
@@ -75,16 +77,31 @@ instance FromJSON PrivateMeta where parseJSON = lensyParseJSON 3
 instance NFData PrivateMeta
 instance Serialize PrivateMeta
 
+
+-- | Contains ChainId and Chainweb network version, for preventing sending Testnet  to Mainet.
+data ChainId = ChainId
+  { _ciId :: Word32
+  , _ciNetworkVersion :: Text
+  } deriving (Eq, Show, Generic)
+makeLenses ''ChainId
+
+instance Default ChainId where def = ChainId 0 "Testnet00"
+instance ToJSON ChainId where toJSON = lensyToJSON 3
+instance FromJSON ChainId where parseJSON = lensyParseJSON 3
+instance NFData ChainId
+instance Serialize ChainId
+
+
 -- | Contains all necessary metadata for a Chainweb-style public chain.
 data PublicMeta = PublicMeta
-  { _pmChainId :: Text
+  { _pmChainId :: ChainId
   , _pmSender :: Text
   , _pmGasLimit :: ParsedInteger
   , _pmGasPrice :: ParsedDecimal
   } deriving (Eq, Show, Generic)
 makeLenses ''PublicMeta
 
-instance Default PublicMeta where def = PublicMeta "" "" 0 0
+instance Default PublicMeta where def = PublicMeta def "" 0 0
 instance ToJSON PublicMeta where toJSON = lensyToJSON 3
 instance FromJSON PublicMeta where parseJSON = lensyParseJSON 3
 instance NFData PublicMeta
@@ -108,7 +125,7 @@ instance HasPlafMeta () where
 
 data PublicData = PublicData
   { _pdPublicMeta :: PublicMeta
-  , _pdChainId :: Word32
+  , _pdChainId :: Word32  -- TODO: Replicate of PublicMeta's ChainId
   , _pdBlockHeight :: Word64
   , _pdBlockTime :: Int64
   }

--- a/src/Pact/Types/ChainMeta.hs
+++ b/src/Pact/Types/ChainMeta.hs
@@ -78,10 +78,10 @@ instance NFData PrivateMeta
 instance Serialize PrivateMeta
 
 
--- | Contains ChainId and Chainweb network version, for preventing sending Testnet  to Mainet.
+-- | Contains ChainId and Chainweb network version, for preventing sending Testnet txs to Mainet.
 data ChainId = ChainId
   { _ciId :: Word32
-  , _ciNetworkVersion :: Text
+  , _ciNetworkVersion :: Text  -- TODO Ensure that only textual representations of ChainwebVersion are permissable
   } deriving (Eq, Show, Generic)
 makeLenses ''ChainId
 

--- a/src/Pact/Types/ChainMeta.hs
+++ b/src/Pact/Types/ChainMeta.hs
@@ -22,8 +22,7 @@ module Pact.Types.ChainMeta
     -- * optics
   , aFrom, aTo
   , pmAddress, pmChainId, pmSender, pmGasLimit, pmGasPrice
-  , ciId, ciNetworkVersion
-  , pdChainId, pdPublicMeta, pdBlockHeight, pdBlockTime
+  , pdPublicMeta, pdBlockHeight, pdBlockTime
   ) where
 
 
@@ -40,12 +39,13 @@ import Data.Serialize (Serialize)
 import Data.Set (Set)
 import Data.String (IsString)
 import Data.Text
-import Data.Word (Word32, Word64)
+import Data.Word (Word64)
 
 -- internal pact modules
 
 import Pact.Parse
 import Pact.Types.Util (AsString, lensyToJSON, lensyParseJSON)
+import Pact.Types.Term (ToTerm(..))
 
 
 newtype EntityName = EntityName Text
@@ -78,18 +78,17 @@ instance NFData PrivateMeta
 instance Serialize PrivateMeta
 
 
--- | Contains ChainId and Chainweb network version, for preventing sending Testnet txs to Mainet.
-data ChainId = ChainId
-  { _ciId :: Word32
-  , _ciNetworkVersion :: Text  -- TODO Ensure that only textual representations of ChainwebVersion are permissable
-  } deriving (Eq, Show, Generic)
-makeLenses ''ChainId
+-- | Contains ChainId, Chainweb network version, ect.
+--   Meant to prevent sending Testnet txs to Mainet.
+newtype ChainId = ChainId Text
+  deriving (Eq, Show, Generic)
 
-instance Default ChainId where def = ChainId 0 "Testnet00"
-instance ToJSON ChainId where toJSON = lensyToJSON 3
-instance FromJSON ChainId where parseJSON = lensyParseJSON 3
+instance ToJSON ChainId
+instance FromJSON ChainId
 instance NFData ChainId
 instance Serialize ChainId
+instance Default ChainId where def = ChainId "Testnet00/0"
+instance ToTerm ChainId where toTerm (ChainId i) = toTerm i
 
 
 -- | Contains all necessary metadata for a Chainweb-style public chain.
@@ -125,7 +124,6 @@ instance HasPlafMeta () where
 
 data PublicData = PublicData
   { _pdPublicMeta :: PublicMeta
-  , _pdChainId :: Word32  -- TODO: Replicate of PublicMeta's ChainId
   , _pdBlockHeight :: Word64
   , _pdBlockTime :: Int64
   }
@@ -134,4 +132,4 @@ makeLenses ''PublicData
 
 instance ToJSON PublicData where toJSON = lensyToJSON 3
 instance FromJSON PublicData where parseJSON = lensyParseJSON 3
-instance Default PublicData where def = PublicData def def def def
+instance Default PublicData where def = PublicData def def def

--- a/src/Pact/Types/ChainMeta.hs
+++ b/src/Pact/Types/ChainMeta.hs
@@ -78,16 +78,9 @@ instance NFData PrivateMeta
 instance Serialize PrivateMeta
 
 
--- | Contains ChainId, Chainweb network version, ect.
---   Meant to prevent sending Testnet txs to Mainet.
+-- | Expresses unique platform-specific chain identifier.
 newtype ChainId = ChainId Text
-  deriving (Eq, Show, Generic)
-
-instance ToJSON ChainId
-instance FromJSON ChainId
-instance NFData ChainId
-instance Serialize ChainId
-instance Default ChainId where def = ChainId "Testnet00/0"
+  deriving (Eq, Show, Generic, IsString, ToJSON, FromJSON, Serialize, NFData)
 instance ToTerm ChainId where toTerm (ChainId i) = toTerm i
 
 
@@ -100,7 +93,7 @@ data PublicMeta = PublicMeta
   } deriving (Eq, Show, Generic)
 makeLenses ''PublicMeta
 
-instance Default PublicMeta where def = PublicMeta def "" 0 0
+instance Default PublicMeta where def = PublicMeta "" "" 0 0
 instance ToJSON PublicMeta where toJSON = lensyToJSON 3
 instance FromJSON PublicMeta where parseJSON = lensyParseJSON 3
 instance NFData PublicMeta

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -139,8 +139,7 @@ keyPairsToSigners creds = map toSigner creds
 mkCommand' :: [SomeKeyPair] -> ByteString -> IO (Command ByteString)
 mkCommand' creds env = do
   let hsh = hash env    -- hash associated with a Command, aka a Command's Request Key
-      toUserSig cred = UserSig <$>
-                       toB16Text <$>
+      toUserSig cred = UserSig . toB16Text <$>
                        sign cred (toUntypedHash hsh)
   sigs <- traverse toUserSig creds
   return $ Command env sigs hsh
@@ -248,7 +247,7 @@ instance (FromJSON a,FromJSON m) => FromJSON (Payload m a) where parseJSON = len
 
 
 
-data UserSig = UserSig { _usSig :: !Text }
+newtype UserSig = UserSig { _usSig :: Text }
   deriving (Eq, Ord, Show, Generic)
 
 instance NFData UserSig

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -177,11 +177,14 @@ verifyCommand orig@Command{..} =
 
 
 hasInvalidSigs :: Hash -> [UserSig] -> [Signer] -> Maybe String
-hasInvalidSigs hsh sigs signers = if (length sigsWithIssues == 0)
-                                  then Nothing else formatIssues
+hasInvalidSigs hsh sigs signers
+  | not (length sigs == length signers)  = Just "Number of sig(s) does not match number of signer(s)"
+  | otherwise                            = if (length sigsWithIssues == 0)
+                                           then Nothing else formatIssues
   where hasIssue (sig, signer) = not $ verifyUserSig hsh sig signer
-        sigsWithIssues = filter hasIssue (zip sigs signers)   -- assumes nth Signer is responsible for the nth UserSig
-        formatIssues = Just $ "Invalid sig(s) found: " ++ show (A.encode sigsWithIssues)
+        -- assumes nth Signer is responsible for the nth UserSig
+        sigsWithIssues = filter hasIssue (zip sigs signers)
+        formatIssues = Just $ "Invalid sig(s) found: " ++ show (A.encode <$> sigsWithIssues)
 
 
 verifyUserSig :: Hash -> UserSig -> Signer -> Bool

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -180,7 +180,7 @@ hasInvalidSigs :: Hash -> [UserSig] -> [Signer] -> Maybe String
 hasInvalidSigs hsh sigs signers = if (length sigsWithIssues == 0)
                                   then Nothing else formatIssues
   where hasIssue (sig, signer) = not $ verifyUserSig hsh sig signer
-        sigsWithIssues = filter hasIssue (zip sigs signers)
+        sigsWithIssues = filter hasIssue (zip sigs signers)   -- assumes nth Signer is responsible for the nth UserSig
         formatIssues = Just $ "Invalid sig(s) found: " ++ show (A.encode sigsWithIssues)
 
 
@@ -226,7 +226,7 @@ instance ToJSON Signer where
     "pubKey" .= _siPubKey,
     "addr" .= _siAddress]
 instance FromJSON Signer where
-  parseJSON = withObject "UserSig" $ \o -> do
+  parseJSON = withObject "Signer" $ \o -> do
     pub <- o .: "pubKey"
     scheme <- o .:? "scheme"   -- defaults to PPKScheme default
     addr <- o .:? "addr"       -- defaults to full Public Key

--- a/tests/SchemeSpec.hs
+++ b/tests/SchemeSpec.hs
@@ -8,6 +8,7 @@ import System.IO.Error
 import Data.Text (Text)
 import Data.ByteString (ByteString)
 import Data.Aeson as A
+import qualified Control.Lens             as Lens
 import qualified Data.ByteString.Base16   as B16
 import qualified Crypto.Hash              as H
 import qualified Data.ByteString.Lazy     as BSL
@@ -36,20 +37,49 @@ getKeyPairComponents kp = (PubBS $ getPublic kp,
 
 
 someED25519Pair :: (PublicKeyBS, PrivateKeyBS, Address, PPKScheme)
-someED25519Pair = (PubBS $ getByteString "ba54b224d1924dd98403f5c751abdd10de6cd81b0121800bf7bdbdcfaec7388d",
-                   PrivBS $ getByteString "8693e641ae2bbe9ea802c736f42027b03f86afe63cae315e7169c9c496c17332",
+someED25519Pair = (PubBS $ getByteString
+                   "ba54b224d1924dd98403f5c751abdd10de6cd81b0121800bf7bdbdcfaec7388d",
+                   PrivBS $ getByteString
+                   "8693e641ae2bbe9ea802c736f42027b03f86afe63cae315e7169c9c496c17332",
                    "ba54b224d1924dd98403f5c751abdd10de6cd81b0121800bf7bdbdcfaec7388d",
                    ED25519)
 
 someETHPair :: (PublicKeyBS, PrivateKeyBS, Address, PPKScheme)
-someETHPair = (PubBS $ getByteString "836b35a026743e823a90a0ee3b91bf615c6a757e2b60b9e1dc1826fd0dd16106f7bc1e8179f665015f43c6c81f39062fc2086ed849625c06e04697698b21855e",
-               PrivBS $ getByteString "208065a247edbe5df4d86fbdc0171303f23a76961be9f6013850dd2bdc759bbb",
+someETHPair = (PubBS $ getByteString
+               "836b35a026743e823a90a0ee3b91bf615c6a757e2b60b9e1dc1826fd0dd16106f7bc1e8179f665015f43c6c81f39062fc2086ed849625c06e04697698b21855e",
+               PrivBS $ getByteString
+               "208065a247edbe5df4d86fbdc0171303f23a76961be9f6013850dd2bdc759bbb",
                "0bed7abd61247635c1973eb38474a2516ed1d884",
                ETH)
 
-toExecPayload :: [SomeKeyPair] -> Text -> ByteString
-toExecPayload kps t = BSL.toStrict $ A.encode payload
-  where payload = (Payload (Exec (ExecMsg t Null)) "nonce" () (toSigners kps))
+
+toApiKeyPairs :: [(PublicKeyBS, PrivateKeyBS, Address, PPKScheme)] -> [ApiKeyPair]
+toApiKeyPairs kps = map makeAKP kps
+  where makeAKP (pub, priv, add, scheme) =
+          ApiKeyPair priv (Just pub) (Just add) (Just scheme)
+
+
+mkCommandTest :: [SomeKeyPair] -> [Signer] -> Text -> IO (Command ByteString)
+mkCommandTest kps signers code = mkCommand' kps $ toExecPayload signers code
+
+
+toSigners :: [(PublicKeyBS, PrivateKeyBS, Address, PPKScheme)] -> IO [Signer]
+toSigners kps = return $ map makeSigner kps
+  where makeSigner (PubBS pub, _, add, scheme) =
+          Signer scheme (toB16Text pub) add
+
+
+toExecPayload :: [Signer] -> Text -> ByteString
+toExecPayload signers t = BSL.toStrict $ A.encode payload
+  where payload = (Payload (Exec (ExecMsg t Null)) "nonce" () signers)
+
+
+shouldBeProcFail ::  ProcessedCommand () ParsedCode -> Expectation
+shouldBeProcFail pcmd = pcmd `shouldSatisfy` isProcFail
+  where isProcFail result = case result of
+          ProcFail _ -> True
+          _ -> False
+
 
 
 ---- HSPEC TESTS ----
@@ -70,16 +100,13 @@ spec = return ()
 testKeyPairImport :: Spec
 testKeyPairImport = do
   it "imports ED25519 Key Pair" $ do
-    let (pub, priv, addr, scheme) = someED25519Pair
-        apiKP = ApiKeyPair priv (Just pub) (Just addr) (Just scheme)
-    kp <- mkKeyPairs [apiKP]
+    kp <- mkKeyPairs (toApiKeyPairs [someED25519Pair])
     (map getKeyPairComponents kp) `shouldBe` [someED25519Pair]
 
   it "imports ETH Key Pair" $ do
-    let (pub, priv, addr, scheme) = someETHPair
-        apiKP = ApiKeyPair priv (Just pub) (Just addr) (Just scheme)
-    kp <- mkKeyPairs [apiKP]
+    kp <- mkKeyPairs (toApiKeyPairs [someETHPair])
     (map getKeyPairComponents kp) `shouldBe` [someETHPair]
+
 
 
 testDefSchemeApiKeyPair :: Spec
@@ -92,12 +119,14 @@ testDefSchemeApiKeyPair =
       (map getKeyPairComponents kp) `shouldBe` [someED25519Pair]
 
 
+
 testAddrApiKeyPair :: Spec
 testAddrApiKeyPair =
   it "throws error when address provided in API doesn't match derived address" $ do
      let (pub, priv, _, scheme) = someETHPair
          apiKP = ApiKeyPair priv (Just pub) (Just "9f491e44a3f87df60d6cb0eefd5a9083ae6c3f32") (Just scheme)
      mkKeyPairs [apiKP] `shouldThrow` isUserError
+
 
 
 testPublicKeyImport :: Spec
@@ -108,117 +137,95 @@ testPublicKeyImport = do
     kp <- mkKeyPairs [apiKP]
     (map getKeyPairComponents kp) `shouldBe` [someETHPair]
 
+
   it "throws error when PublicKey provided does not match derived PublicKey" $ do
     let (_, priv, addr, scheme) = someETHPair
-        fakePub = PubBS $ getByteString "c640e94730fb7b7fce01b11086645741fcb5174d1c634888b9d146613730243a171833259cd7dab9b3435421dcb2816d3efa55033ff0899de6cc8b1e0b20e56c"
-        apiKP = ApiKeyPair priv (Just fakePub) (Just addr) (Just scheme)
+        fakePub = PubBS $ getByteString
+                  "c640e94730fb7b7fce01b11086645741fcb5174d1c634888b9d146613730243a171833259cd7dab9b3435421dcb2816d3efa55033ff0899de6cc8b1e0b20e56c"
+        apiKP   = ApiKeyPair priv (Just fakePub) (Just addr) (Just scheme)
     mkKeyPairs [apiKP] `shouldThrow` isUserError
+
 
 
 testUserSig :: Spec
 testUserSig = do
-  it "successfully verifies ETH UserSig when using Command's mkUserSig" $ do
-    let (pub, priv, addr, scheme) = someETHPair
-        apiKP = ApiKeyPair priv (Just pub) (Just addr) (Just scheme)
-    kp <- mkKeyPairs [apiKP]
-    cmd <- mkCommand' kp $ toExecPayload kp "(somePactFunction)"
-    let signers = toSigners kp
-        hsh = _cmdHash cmd
-        sigs = _cmdSigs cmd
-    (map (\(sig, signer) -> verifyUserSig hsh sig signer) (zip sigs signers)) `shouldBe` [True]
-
+  it "successfully verifies ETH UserSig when using Command's mkCommand" $ do
+    signers <- toSigners [someETHPair]
+    kps     <- mkKeyPairs $ toApiKeyPairs [someETHPair]
+    cmd     <- mkCommandTest kps signers "(somePactFunction)"
+    let (hsh, sigs)  = (_cmdHash cmd, _cmdSigs cmd)
+        verifiedSigs = (map (\(sig, signer) -> verifyUserSig hsh sig signer)
+                            (zip sigs signers))
+    verifiedSigs `shouldBe` [True]
 
 
 
   it "successfully verifies ETH UserSig when provided by user" $ do
-    let (pub, priv, addr, scheme) = someETHPair
-        apiKP = ApiKeyPair priv (Just pub) (Just addr) (Just scheme)
-        (PubBS pubBS) = pub
-        -- UserSig verification will pass but Command verification might fail
-        -- if hash algorithm provided not supported for hashing commands.
-        hsh = hashTx "(somePactFunction)" H.SHA3_256
-    [kp] <- mkKeyPairs [apiKP]
-    sig <- sign kp hsh
+    -- UserSig verification will pass but Command verification might fail
+    -- if hash algorithm provided not supported for hashing commands.
+    let hsh = hashTx "(somePactFunction)" H.SHA3_256
+    [signer] <- toSigners [someETHPair]
+    [kp]     <- mkKeyPairs $ toApiKeyPairs [someETHPair]
+    sig      <- sign kp hsh
     let myUserSig = UserSig (toB16Text sig)
-        mySigner = Signer scheme (toB16Text pubBS) addr
-    (verifyUserSig hsh myUserSig mySigner) `shouldBe` True
-
+    (verifyUserSig hsh myUserSig signer) `shouldBe` True
 
 
 
   it "fails UserSig validation when UserSig has unexpected Address" $ do
-    let (pub, priv, addr, scheme) = someETHPair
-        apiKP = ApiKeyPair priv (Just pub) (Just addr) (Just scheme)
-        (PubBS pubBS) = pub
-        hsh = hashTx "(somePactFunction)" H.Blake2b_512
-        wrongAddr = (toB16Text pubBS)
-    [kp] <- mkKeyPairs [apiKP]
-    sig <- sign kp hsh
-    let myUserSig = UserSig (toB16Text sig)
-        mySigner = Signer scheme (toB16Text pubBS) wrongAddr
-    (verifyUserSig hsh myUserSig mySigner) `shouldBe` False
-
+    let hsh = hashTx "(somePactFunction)" H.Blake2b_512
+    [signer] <- toSigners [someETHPair]
+    [kp]     <- mkKeyPairs $ toApiKeyPairs [someETHPair]
+    sig      <- sign kp hsh
+    let myUserSig   = UserSig (toB16Text sig)
+        wrongAddr   = Lens.view siPubKey signer
+        wrongSigner = Lens.set siAddress wrongAddr signer
+    (verifyUserSig hsh myUserSig wrongSigner) `shouldBe` False
 
 
 
   it "fails UserSig validation when UserSig has unexpected Scheme" $ do
-    let (pub, priv, addr, scheme) = someETHPair
-        apiKP = ApiKeyPair priv (Just pub) (Just addr) (Just scheme)
-        (PubBS pubBS) = pub
-        hsh = hashTx "(somePactFunction)" H.Blake2b_512
+    let hsh = hashTx "(somePactFunction)" H.Blake2b_512
+    [signer] <- toSigners [someETHPair]
+    [kp]     <- mkKeyPairs $ toApiKeyPairs [someETHPair]
+    sig      <- sign kp hsh
+    let myUserSig   = UserSig (toB16Text sig)
         wrongScheme = ED25519
-    [kp] <- mkKeyPairs [apiKP]
-    sig <- sign kp hsh
-    let myUserSig = UserSig (toB16Text sig)
-        mySigner = Signer wrongScheme (toB16Text pubBS) addr
-    (verifyUserSig hsh myUserSig mySigner) `shouldBe` False
-
+        wrongSigner = Lens.set siScheme wrongScheme signer
+    (verifyUserSig hsh myUserSig wrongSigner) `shouldBe` False
 
 
 
   it "provides default ppkscheme when one not provided" $ do
     let sigJSON = A.object ["addr" .= String "SomeAddr", "pubKey" .= String "SomePubKey",
                             "sig" .= String "SomeSig"]
-        sig = UserSig "SomeSig"
+        sig     = UserSig "SomeSig"
     (fromJSON' sigJSON) `shouldBe` (Right sig)
-
 
 
 
   it "makes address field the full public key when one not provided" $ do
     let sigJSON = A.object ["pubKey" .= String "SomePubKey", "sig" .= String "SomeSig"]
-        sig = UserSig "SomeSig"
+        sig     = UserSig "SomeSig"
     (fromJSON' sigJSON) `shouldBe` (Right sig)
+
 
 
 testSigNonMalleability :: Spec
 testSigNonMalleability = do
   it "fails when invalid signature provided for signer specified in the payload" $ do
-    let (pub1, priv1, addr1, scheme1) = someETHPair
-        apiKP1 = ApiKeyPair priv1 (Just pub1) (Just addr1) (Just scheme1)
-        (pub2, priv2, addr2, scheme2) = someED25519Pair
-        apiKP2 = ApiKeyPair priv2 (Just pub2) (Just addr2) (Just scheme2)
-    kp1 <- mkKeyPairs [apiKP1]
-    wrongPair <- mkKeyPairs [apiKP2]
+    wrongSigners <- toSigners [someED25519Pair]
+    kps          <- mkKeyPairs $ toApiKeyPairs [someETHPair]
     
-    cmdWithWrogSig <- mkCommand' wrongPair $ toExecPayload kp1 "(somePactFunction)"
-    (verifyCommand cmdWithWrogSig :: ProcessedCommand () ParsedCode)
-      `shouldSatisfy`
-      (\t -> case t of
-          ProcFail _ -> True
-          _ -> False)
+    cmdWithWrongSig <- mkCommandTest kps wrongSigners "(somePactFunction)"
+    shouldBeProcFail (verifyCommand cmdWithWrongSig)
+
+
 
   it "fails when number of signatures does not match number of payload signers" $ do
-    let (pub1, priv1, addr1, scheme1) = someETHPair
-        apiKP1 = ApiKeyPair priv1 (Just pub1) (Just addr1) (Just scheme1)
-        (pub2, priv2, addr2, scheme2) = someED25519Pair
-        apiKP2 = ApiKeyPair priv2 (Just pub2) (Just addr2) (Just scheme2)
-    [kp1] <- mkKeyPairs [apiKP1]
-    [wrongPair] <- mkKeyPairs [apiKP2]
-    
-    cmdWithWrogSig <- mkCommand' [kp1, wrongPair] $ toExecPayload [kp1] "(somePactFunction)"
-    (verifyCommand cmdWithWrogSig :: ProcessedCommand () ParsedCode)
-      `shouldSatisfy`
-      (\t -> case t of
-          ProcFail _ -> True
-          _ -> False)
+    [signer]  <- toSigners [someETHPair]
+    [kp]      <- mkKeyPairs $ toApiKeyPairs [someETHPair]
+    [wrongKp] <- mkKeyPairs $ toApiKeyPairs [someED25519Pair]
+
+    cmdWithWrongNumSig <- mkCommandTest [kp, wrongKp] [signer] "(somePactFunction)"
+    shouldBeProcFail (verifyCommand cmdWithWrongNumSig)

--- a/tests/cont-scripts/fail-both-price-up-01-cont.yaml
+++ b/tests/cont-scripts/fail-both-price-up-01-cont.yaml
@@ -4,6 +4,13 @@ pactId: 5
 step: 1
 rollback: False
 data: {final-price: 12.0}
+publicMeta:
+  chainId:
+    id: 0
+    networkVersion: "Testnet10"
+  sender: "Sender0"
+  gasLimit: 0
+  gasPrice: 0
 keyPairs:
     - public: 7d0c9ba189927df85c8c54f8b5c8acd76c1d27e923abbf25a957afdf25550804
       secret: 2e8c91521479537221576a7c3c80c46d0fa3fc663804117f0c7011366dec35de

--- a/tests/cont-scripts/fail-both-price-up-01-cont.yaml
+++ b/tests/cont-scripts/fail-both-price-up-01-cont.yaml
@@ -5,9 +5,7 @@ step: 1
 rollback: False
 data: {final-price: 12.0}
 publicMeta:
-  chainId:
-    id: 0
-    networkVersion: "Testnet10"
+  chainId: "Testnet00/0"
   sender: "Sender0"
   gasLimit: 0
   gasPrice: 0

--- a/tests/pact/pubdata.repl
+++ b/tests/pact/pubdata.repl
@@ -1,5 +1,5 @@
 ;; Chain public metadata should initialize with defaults
-(expect "chain data chain id initializes with 0" "Testnet00/0" (at "chain-id" (chain-data)))
+(expect "chain data chain id initializes with \"\"" "" (at "chain-id" (chain-data)))
 (expect "chain data block height initializes with 0" 0 (at "block-height" (chain-data)))
 (expect "chain data block time id initializes with 0" 0 (at "block-time" (chain-data)))
 (expect "chain data sender initializes with \"\"" "" (at "sender" (chain-data)))

--- a/tests/pact/pubdata.repl
+++ b/tests/pact/pubdata.repl
@@ -1,5 +1,5 @@
 ;; Chain public metadata should initialize with defaults
-(expect "chain data chain id initializes with 0" 0 (at "chain-id" (chain-data)))
+(expect "chain data chain id initializes with 0" "Testnet00/0" (at "chain-id" (chain-data)))
 (expect "chain data block height initializes with 0" 0 (at "block-height" (chain-data)))
 (expect "chain data block time id initializes with 0" 0 (at "block-time" (chain-data)))
 (expect "chain data sender initializes with \"\"" "" (at "sender" (chain-data)))
@@ -7,8 +7,8 @@
 (expect "chain data gas price initializes with 0.0" 0.0 (at "gas-price" (chain-data)))
 
 ;; Chain public metadata should reflect updates
-(env-chain-data { "chain-id": 2, "block-height": 20 })
-(expect "chain data chain id reflects updated value" 2 (at "chain-id" (chain-data)))
+(env-chain-data { "chain-id": "Testnet00/2", "block-height": 20 })
+(expect "chain data chain id reflects updated value" "Testnet00/2" (at "chain-id" (chain-data)))
 (expect "chain data block height reflects updated value" 20 (at "block-height" (chain-data)))
 
 ;; show that updates are granular
@@ -16,7 +16,7 @@
 (expect "chain data sender reflects updated value" "squawk" (at "sender" (chain-data)))
 
 ;; show that updates are cumulative
-(expect "chain data chain id reflects updated value" 2 (at "chain-id" (chain-data)))
+(expect "chain data chain id reflects updated value" "Testnet00/2" (at "chain-id" (chain-data)))
 (expect "chain data block height reflects updated value" 20 (at "block-height" (chain-data)))
 
 ;; Show failure on improper keys
@@ -26,4 +26,4 @@
 (expect-failure "chain data should fail for wrongly-typed keys" (env-chain-data { "chain-id": 0.0 }))
 
 ;; Show failure on duplicate keys
-(expect-failure "chain data should not accept duplicate updates" (env-chain-data { "chain-id": 1, "chain-id:": 2 }))
+(expect-failure "chain data should not accept duplicate updates" (env-chain-data { "chain-id": "Testnet00/1", "chain-id:": "Testnet00/2" }))


### PR DESCRIPTION
Fixes #458 

Main Tasks
- [x] Adds to `PublicMeta` a`ChainId` Text datatype
- [x] Adds Signers information to `Command Payload` and deletes them from `UserSig`
- [x] Edit Signature validation logic
- [x] Edit how Pact PublicKeys (i.e. Addresses) are injected in PactService

Other Tasks
- [x] Remove duplicate use of ChainId in `PublicData` (pending talk with Emily)
- [ ] Use different name for `ChainId` as Chainweb already has a data constructor with this name.