### PR TITLE
module load from db

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,28 @@ Once Homebrew is installed, run the following command to install `pact`:
 brew install kadena-io/pact/pact
 ```
 
+However, see note [below](#z3) about z3 compatibility.
+
 Installing Pact with Binary Distributions
 ---
 Pact can also be installed by following the instructions below:
-- Install [z3](https://github.com/Z3Prover/z3/wiki)
+- Install [z3](https://github.com/Z3Prover/z3/wiki). See note [below](#z3) about z3 compatibility.
 - Download the [prebuilt binaries](http://install.kadena.io/pact/downloads.html) for your distribution. Or see [Building](#Building) for instructions on how to build Pact from the source code.
 - Once you've downloaded the binary, make sure that it is marked as executable by running `chmod +x <executable-file>`.
 - Put the binary somewhere in your PATH.
 
 For installing `pact` on Linux distributions in the Arch family, refer to [this package on the AUR](https://aur.archlinux.org/packages/pact/).
+
+z3 Compatibility
+---
+
+Pact users generally can use the production versions of Z3. However, with the current version at time of writing, 4.8.4, use of the function `str-to-int` can cause problems, and for those building from source or hacking Pact Haskell code, a unit test will fail/hang indefinitely because of this.
+
+The fix is to use the older version 4.8.3:
+- For Mac homebrew users, 4.8.3 can be installed via `brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/a7e7806193f7605c7fef6110655911012d3f1eb3/Formula/z3.rb`.
+- Z3 binaries are available [on github](https://github.com/Z3Prover/z3/releases/tag/z3-4.8.3) for manual installation (Pact uses the z3 in your `$PATH`).
+- Nix builds install the correct version.
+
 
 Verifying Install
 ---
@@ -110,19 +123,18 @@ verbose    - [True|False] Provide extra logging information
 When running pact-serve with persistence enabled, the server automatically replays from the database
 `commands.sqlite` in the persist dir. To prevent replay, simply delete this file before starting the server.
 
-Building
+Building Pact
 ---
 
-Building Pact used to require a working [Haskell Stack install](https://docs.haskellstack.org/en/stable/README/#how-to-install) . After which, building is as simple as 'stack build'.
+### Building with Stack
 
-To install for use with Atom and the command line, issue 'stack install' and then either add `$HOME/.local/bin` to your path, or symlink `$HOME/.local/bin/pact` somewhere in your PATH.
+[Install stack](https://docs.haskellstack.org/en/stable/README/#how-to-install)
 
-NOTE: We are currently transitioning to Nix build infrastructure.  Stack builds
-still work right now, but you should start transitioning to Nix using the
-instructions below.
+Issue `stack build` on the command line.
 
-Building with Nix / NixOS
----
+Use `stack install` to install on the command line and for Atom, ensuring that `$HOME/.local/bin` is on your PATH.
+
+### Building with Nix / NixOS
 
 1. Go to https://nixos.org/nix/, click "Get Nix", follow the instructions to install the Nix package manager.
 2. Edit `$NIX_CONF_DIR/nix.conf`.
@@ -156,7 +168,7 @@ sudo systemctl restart nix-daemon.service
 
 5. Run `nix-build` from the project root.
 
-### Incremental Builds
+#### Incremental Builds
 
 Building with `nix-build` does a full rebuild every time, which is usually not
 what you want when developing. To do incremental builds, you need to enter a nix
@@ -172,7 +184,7 @@ You can also build with stack inside this shell as follows:
 $ stack --stack-yaml stack-nix.yaml build
 ```
 
-### Hoogle Documentation
+#### Hoogle Documentation
 
 Nix has out-of-the-box Hoogle integration.  It allows you to run a local
 Hoogle server with docs for all of the project dependencies.  This is really
@@ -203,10 +215,6 @@ function](https://github.com/kadena-io/pact/blob/master/default.nix#L12)
 replace `[p.pact]` with a list of all the locally defined projects to include.
 For example: `[p.backend p.common p.frontend]` for a project that has those
 three separate local packages.
-
-### z3 Troubleshooting
-
-Note for users of property and invariant verification: z3 version 4.8.4 hangs when checking `str-to-int` calls (this causes one test to fail). The fix is to use the older version 4.8.3, or a newer version in the future (4.8.4 is the latest release at time of writing). Our Nix install uses a working version. For non-Nix Mac users, `brew install` defaults to 4.8.4, but 4.8.3 can be installed via `brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/a7e7806193f7605c7fef6110655911012d3f1eb3/Formula/z3.rb`. For non-brew users, binaries are available [on github](https://github.com/Z3Prover/z3/releases/tag/z3-4.8.3) for manual installation (Pact uses the z3 in your `$PATH`).
 
 License
 ---

--- a/src-ghc/Pact/MockDb.hs
+++ b/src-ghc/Pact/MockDb.hs
@@ -17,7 +17,7 @@ newtype MockRead =
 instance Default MockRead where def = MockRead (\_t _k -> rc Nothing)
 
 newtype MockKeys =
-  MockKeys (TableName -> Method () [RowKey])
+  MockKeys (forall k v . (IsString k,AsString k) => Domain k v -> Method () [k])
 instance Default MockKeys where def = MockKeys (\_t -> rc [])
 
 newtype MockTxIds =

--- a/src-ghc/Pact/PersistPactDb/Regression.hs
+++ b/src-ghc/Pact/PersistPactDb/Regression.hs
@@ -34,7 +34,7 @@ loadModule = do
   case r of
     Left a -> throwFail $ "module load failed: " ++ show a
     Right _ -> case preview (rEvalState . evalRefs . rsLoadedModules . ix mn) s of
-      Just md -> case traverse (traverse toPersistDirect) md of
+      Just (md,_) -> case traverse (traverse toPersistDirect) md of
         Right md' -> return (mn,md,md')
         Left e -> throwFail $ "toPersistDirect failed: " ++ show e
       Nothing -> throwFail $ "Failed to find module 'simple': " ++

--- a/src-ghc/Pact/ReplTools.hs
+++ b/src-ghc/Pact/ReplTools.hs
@@ -40,7 +40,7 @@ completeFn :: (MonadIO m, MonadState ReplState m) => CompletionFunc m
 completeFn = completeQuotedWord (Just '\\') "\"" listFiles $
   completeWord (Just '\\') ("\"\'" ++ filenameWordBreakChars) $ \str -> do
     modules <- use (rEvalState . evalRefs . rsLoadedModules)
-    let namesInModules = toListOf (traverse . mdRefMap . to HM.keys . each) modules
+    let namesInModules = toListOf (traverse . _1 . mdRefMap . to HM.keys . each) modules
         allNames = concat
           [ namesInModules
           , nameOfModule <$> HM.keys modules

--- a/src-ghc/Pact/ReplTools.hs
+++ b/src-ghc/Pact/ReplTools.hs
@@ -35,11 +35,11 @@ import Pact.Repl.Types
 interactiveRepl :: IO (Either () (Term Name))
 interactiveRepl = generalRepl Interactive
 
--- Note(emily): revisit whether we want all _module_ names, or all interface names as well.
+-- | Complete function names for _loaded_ modules
 completeFn :: (MonadIO m, MonadState ReplState m) => CompletionFunc m
 completeFn = completeQuotedWord (Just '\\') "\"" listFiles $
   completeWord (Just '\\') ("\"\'" ++ filenameWordBreakChars) $ \str -> do
-    modules <- use (rEnv . eeRefStore . rsModules)
+    modules <- use (rEvalState . evalRefs . rsLoadedModules)
     let namesInModules = toListOf (traverse . mdRefMap . to HM.keys . each) modules
         allNames = concat
           [ namesInModules

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -48,7 +48,7 @@ initPactService CommandConfig {..} loggers = do
       blockTime = 0
 
   let mkCEI p@PactDbEnv {..} = do
-        cmdVar <- newMVar (CommandState initRefStore M.empty)
+        cmdVar <- newMVar (CommandState M.empty)
         klog "Creating Pact Schema"
         initSchema p
         return CommandExecInterface
@@ -103,16 +103,16 @@ applyExec :: RequestKey -> PactHash -> [Signer] -> ExecMsg ParsedCode -> Command
 applyExec rk hsh signers (ExecMsg parsedCode edata) = do
   CommandEnv {..} <- ask
   when (null (_pcExps parsedCode)) $ throwCmdEx "No expressions found"
-  (CommandState refStore pacts) <- liftIO $ readMVar _ceState
+  (CommandState pacts) <- liftIO $ readMVar _ceState
   let sigs = userSigsToPactKeySet signers
       evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode (MsgData sigs edata Nothing (toUntypedHash hsh))
-        refStore _ceGasEnv permissiveNamespacePolicy noSPVSupport _cePublicData
+        initRefStore _ceGasEnv permissiveNamespacePolicy noSPVSupport _cePublicData
   EvalResult{..} <- liftIO $ evalExec evalEnv parsedCode
   newCmdPact <- join <$> mapM (handlePactExec _erInput) _erExec
   let newPacts = case newCmdPact of
         Nothing -> pacts
         Just cmdPact -> M.insert (_pePactId cmdPact) cmdPact pacts
-  void $ liftIO $ swapMVar _ceState $ CommandState _erRefStore newPacts
+  void $ liftIO $ swapMVar _ceState $ CommandState newPacts
   mapM_ (\p -> liftIO $ logLog _ceLogger "DEBUG" $ "applyExec: new pact added: " ++ show p) newCmdPact
   return $ jsonResult _ceMode rk _erGas $ CommandSuccess (last _erOutput)
 
@@ -146,7 +146,7 @@ applyContinuation rk hsh signers msg@ContMsg{..} = do
           let sigs = userSigsToPactKeySet signers
               pactStep = Just $ PactStep _cmStep _cmRollback _cmPactId (fmap (fmap fromPactValue) _peYield)
               evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode
-                        (MsgData sigs _cmData pactStep (toUntypedHash hsh)) _csRefStore
+                        (MsgData sigs _cmData pactStep (toUntypedHash hsh)) initRefStore
                         _ceGasEnv permissiveNamespacePolicy noSPVSupport _cePublicData
           res <- tryAny (liftIO  $ evalContinuation evalEnv _peContinuation)
 
@@ -165,7 +165,7 @@ rollbackUpdate :: CommandEnv p -> ContMsg -> CommandState -> CommandM p ()
 rollbackUpdate CommandEnv{..} ContMsg{..} CommandState{..} = do
   -- if step doesn't have a rollback function, no error thrown. Therefore, pact will be deleted
   -- from state.
-  let newState = CommandState _csRefStore $ M.delete _cmPactId _csPacts
+  let newState = CommandState $ M.delete _cmPactId _csPacts
   liftIO $ logLog _ceLogger "DEBUG" $ "applyContinuation: rollbackUpdate: reaping pact "
     ++ show _cmPactId
   void $ liftIO $ swapMVar _ceState newState
@@ -174,7 +174,7 @@ continuationUpdate :: CommandEnv p -> ContMsg -> CommandState -> PactExec -> Com
 continuationUpdate CommandEnv{..} ContMsg{..} CommandState{..} newPactExec@PactExec{..} = do
   let nextStep = succ _cmStep
       isLast = nextStep >= _peStepCount
-      updateState pacts = CommandState _csRefStore pacts -- never loading modules during continuations
+      updateState pacts = CommandState pacts -- never loading modules during continuations
   if isLast
     then do
       liftIO $ logLog _ceLogger "DEBUG" $ "applyContinuation: continuationUpdate: reaping pact: "

--- a/src-ghc/Pact/Types/Server.hs
+++ b/src-ghc/Pact/Types/Server.hs
@@ -24,7 +24,7 @@
 module Pact.Types.Server
   ( userSigToPactPubKey, userSigsToPactKeySet
   , CommandConfig(..), ccSqlite, ccEntity, ccGasLimit, ccGasRate
-  , CommandState(..), csRefStore, csPacts
+  , CommandState(..), csPacts
   , CommandEnv(..), ceEntity, ceMode, ceDbEnv, ceState, ceLogger, cePublicData, ceGasEnv
   , CommandM, runCommand, throwCmdEx
   , History(..)
@@ -83,9 +83,8 @@ $(makeLenses ''CommandConfig)
 
 
 
-data CommandState = CommandState {
-       _csRefStore :: RefStore
-     , _csPacts :: M.Map PactId PactExec
+newtype CommandState = CommandState {
+     _csPacts :: M.Map PactId PactExec
      } deriving Show
 $(makeLenses ''CommandState)
 

--- a/src/Pact/Analyze/Remote/Server.hs
+++ b/src/Pact/Analyze/Remote/Server.hs
@@ -35,12 +35,9 @@ import qualified Pact.Analyze.Check        as Check
 import           Pact.Analyze.Remote.Types (Request(..), Response(..),
                                             ClientError(..))
 import           Pact.Repl                 (initReplState, evalRepl')
-import           Pact.Repl.Types           (LibState, ReplMode(StringEval),
-                                            ReplState, rEnv)
+import           Pact.Repl.Types
 import           Pact.Types.Info           (Code(_unCode))
-import           Pact.Types.Runtime        (Domain(KeySets), Method,
-                                            ModuleData, PactDb(_readRow),
-                                            eePactDb, eeRefStore, rsModules)
+import           Pact.Types.Runtime
 import           Pact.Types.Term           (ModuleDef(..), moduleDefName, moduleDefCode,
                                             ModuleName(..), Name(..),
                                             KeySet(..),Ref)
@@ -91,7 +88,7 @@ initializeRepl = do
   pure $ rs & rEnv . eePactDb .~ dbImpl { _readRow = _readRow' }
 
 replStateModules :: ReplState -> HM.HashMap ModuleName (ModuleData Ref)
-replStateModules replState = replState ^. rEnv . eeRefStore . rsModules
+replStateModules replState = replState ^. rEvalState . evalRefs . rsLoadedModules
 
 -- | Parser for strings like: @<interactive>:2:2: Module "mod2" not found@
 moduleNotFoundP :: MP.Parsec Void String ModuleName

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -549,13 +549,13 @@ unify _ (Right r) = r
 unify m (Left t) = m HM.! t
 
 evalConsts :: PureNoDb e => Ref -> Eval e Ref
-evalConsts (Ref r) = case r of
-  c@TConst {..} -> case _tConstVal of
+evalConsts rr@(Ref r) = case r of
+  TConst {..} -> case _tConstVal of
     CVRaw raw -> do
       v <- reduce =<< traverse evalConsts raw
       traverse reduce _tConstArg >>= \a -> typecheck [(a,v)]
       return $ Ref (TConst _tConstArg _tModule (CVEval raw $ liftTerm v) _tMeta _tInfo)
-    _ -> return $ Ref c
+    _ -> return rr
   _ -> Ref <$> traverse evalConsts r
 evalConsts r = return r
 

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -643,9 +643,9 @@ typeof'' _ [t] = return $ tStr $ typeof' t
 typeof'' i as = argsError i as
 
 listModules :: RNativeFun e
-listModules _ _ = do
-  mods <- view $ eeRefStore.rsModules
-  return $ toTermList tTyString $ map asString $ HM.keys mods
+listModules i _ = do
+  mods <- keys (_faInfo i) Modules
+  return $ toTermList tTyString $ map asString mods
 
 yield :: RNativeFun e
 yield i [t@(TObject (Object o _ _ _) _)] = do

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -203,7 +203,7 @@ createUserGuard =
     createUserGuard' i [TObject udata _,TLitString predfun] =
       case parseName (_faInfo i) predfun of
         Right n -> do
-          rn <- resolveRef n >>= \nm -> case nm of
+          rn <- resolveRef i n >>= \nm -> case nm of
             Just (Direct {}) -> return n
             Just (Ref (TDef Def{..} _)) ->
               return $ QName _dModule (asString _dDefName) _dInfo

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -34,22 +34,20 @@ module Pact.Native.Internal
   ,findCallingModule
   ) where
 
-import Control.Monad
-import Prelude
-import Data.Default
-import Pact.Eval
-import Unsafe.Coerce
+import Bound
 import Control.Lens hiding (Fold)
+import Control.Monad
 import Data.Aeson hiding (Object)
 import qualified Data.Aeson.Lens as A
-import Bound
-import qualified Data.HashMap.Strict as HM
-import Pact.Types.Pretty
+import Data.Default
 import qualified Data.Vector as V
+import Unsafe.Coerce
 
-import Pact.Types.Runtime
-import Pact.Types.Native
+import Pact.Eval
 import Pact.Gas
+import Pact.Types.Native
+import Pact.Types.Pretty
+import Pact.Types.Runtime
 
 success :: Functor m => Text -> m a -> m (Term Name)
 success = fmap . const . toTerm
@@ -124,17 +122,11 @@ funType t as = funTypes $ funType' t as
 funType' :: Type n -> [(Text,Type n)] -> FunType n
 funType' t as = FunType (map (\(s,ty) -> Arg s ty def) as) t
 
-
-getModule :: Info -> ModuleName -> Eval e (ModuleDef (Def Ref))
-getModule i n = do
-  lm <- HM.lookup n <$> use (evalRefs.rsLoadedModules)
-  case lm of
-    Just m -> return m
-    Nothing -> do
-      rm <- HM.lookup n <$> view (eeRefStore.rsModules)
-      case rm of
-        Just ModuleData{..} -> return _mdModule
-        Nothing -> evalError i $ "Unable to resolve module " <> pretty n
+-- | Lookup a module and fail if not found.
+getModule :: HasInfo i => i -> ModuleName -> Eval e (ModuleData Ref)
+getModule i mn = lookupModule i mn >>= \r -> case r of
+  Just m -> return m
+  Nothing -> evalError' i $ "Unable to resolve module " <> pretty mn
 
 tTyInteger :: Type n; tTyInteger = TyPrim TyInteger
 tTyDecimal :: Type n; tTyDecimal = TyPrim TyDecimal
@@ -169,14 +161,14 @@ enforceGuardDef dn =
 
 enforceGuard :: FunApp -> Guard -> Eval e ()
 enforceGuard i g = case g of
-  GKeySet k -> runPure $ enforceKeySet (_faInfo i) Nothing k
+  GKeySet k -> runReadOnly i $ enforceKeySet (_faInfo i) Nothing k
   GKeySetRef n -> enforceKeySetName (_faInfo i) n
   GPact PactGuard{..} -> do
     pid <- getPactId i
     unless (pid == _pgPactId) $
       evalError' i $ "Pact guard failed, intended: " <> pretty _pgPactId <> ", active: " <> pretty pid
   GModule mg@ModuleGuard{..} -> do
-    m <- getModule (_faInfo i) _mgModuleName
+    m <- _mdModule <$> getModule (_faInfo i) _mgModuleName
     case m of
       MDModule Module{..} -> enforceModuleAdmin (_faInfo i) _mGovernance
       MDInterface{} -> evalError' i $ "ModuleGuard not allowed on interface: " <> pretty mg
@@ -192,7 +184,7 @@ guardForModuleCall :: Info -> ModuleName -> Eval e () -> Eval e ()
 guardForModuleCall i modName onFound = findCallingModule >>= \r -> case r of
     (Just mn) | mn == modName -> onFound
     _ -> do
-      md <- getModule i modName
+      md <- _mdModule <$> getModule i modName
       case md of
         MDModule m -> void $ acquireModuleAdmin i (_mName m) (_mGovernance m)
         MDInterface iface -> evalError i $

--- a/src/Pact/Native/Keysets.hs
+++ b/src/Pact/Native/Keysets.hs
@@ -72,7 +72,7 @@ defineKeyset fi as = case as of
       case old of
         Nothing -> writeRow i Write KeySets ksn ks & success "Keyset defined"
         Just oldKs -> do
-          runPure $ enforceKeySet i (Just ksn) oldKs
+          runReadOnly i $ enforceKeySet i (Just ksn) oldKs
           writeRow i Write KeySets ksn ks & success "Keyset defined"
 
 keyPred :: (Integer -> Integer -> Bool) -> RNativeFun e

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -39,6 +39,8 @@ module Pact.Repl
   , setReplLib
   , unsetReplLib
   , utf8BytesLength
+  , evalReplEval
+  , replGetModules
   ) where
 
 import Control.Applicative
@@ -103,9 +105,8 @@ initReplState m verifyUri =
 initPureEvalEnv :: Maybe String -> IO (EvalEnv LibState)
 initPureEvalEnv verifyUri = do
   mv <- initLibState neverLog verifyUri >>= newMVar
-  return $ EvalEnv (RefStore nativeDefs mempty) def Null (Just 0)
+  return $ EvalEnv (RefStore nativeDefs) def Null (Just 0)
     def def mv repldb def pactInitialHash freeGasEnv permissiveNamespacePolicy (SPVSupport $ spv mv) def
-
 
 spv :: MVar (LibState) -> Text -> Object Name -> IO (Either Text (Object Name))
 spv mv ty pay = readMVar mv >>= \LibState{..} -> case M.lookup (SPVMockKey (ty,pay)) _rlsMockSPV of
@@ -184,11 +185,7 @@ compileEval src exp = handleCompile src exp $ \e -> pureEval (_tInfo e) (eval e)
 
 pureEval :: Info -> Eval LibState (Term Name) -> Repl (Either String (Term Name))
 pureEval ei e = do
-  (ReplState evalE evalS _ _ _ _) <- get
-  er <- try (liftIO $ runEval' evalS evalE e)
-  let (r,es) = case er of
-                 Left (SomeException ex) -> (Left (PactError EvalError def def (prettyString (show ex))),evalS)
-                 Right v -> v
+  (r,es) <- evalEval ei e
   mode <- use rMode
   case r of
     Right a -> do
@@ -218,6 +215,14 @@ pureEval ei e = do
                 outStrLn HErr (" at " ++ serr)
               mapM_ (\c -> outStrLn HErr $ " at " ++ show c) cs
             return (Left serr)
+
+evalEval :: Info -> Eval LibState a -> Repl (Either PactError a, EvalState)
+evalEval ei e = do
+  (ReplState evalE evalS _ _ _ _) <- get
+  er <- try (liftIO $ runEval' evalS evalE e)
+  return $ case er of
+    Left (SomeException ex) -> (Left (PactError EvalError ei def (prettyString (show ex))),evalS)
+    Right v -> v
 
 doOut :: Info -> ReplMode -> Term Name -> Repl ()
 doOut ei mode a = case mode of
@@ -274,11 +279,6 @@ doTx i t n = do
     Rollback -> return $ evalRollbackTx i
     Commit -> return $ void $ evalCommitTx i
   pureEval i (e >> return (tStr "")) >>= \r -> forM r $ \_ -> do
-    case t of
-      Commit -> do
-        newmods <- use (rEvalState . evalRefs . rsNewModules)
-        rEnv . eeRefStore . rsModules %= HM.union newmods
-      _ -> return ()
     rEvalState .= def
     useReplLib
     tid <- use $ rEnv . eeTxId
@@ -356,6 +356,17 @@ execScript' m fp = do
   s <- initReplState m Nothing
   runStateT (useReplLib >> loadFile fp) s
 
+evalReplEval :: Info -> ReplState -> Eval LibState a -> IO (Either PactError (a, ReplState))
+evalReplEval i rs e = do
+  ((r,es),rs') <- runStateT (evalEval i e) rs
+  case r of
+    Left err -> return $ Left err
+    Right a -> return $ Right (a, set rEvalState es rs')
+
+replGetModules :: ReplState ->
+                  IO (Either PactError
+                      (HM.HashMap ModuleName (ModuleData Ref), ReplState))
+replGetModules rs = evalReplEval def rs (getAllModules (def :: Info))
 
 -- | install repl lib functions into monad state
 useReplLib :: Repl ()

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -41,6 +41,7 @@ module Pact.Repl
   , utf8BytesLength
   , evalReplEval
   , replGetModules
+  , replLookupModule
   ) where
 
 import Control.Applicative
@@ -367,6 +368,16 @@ replGetModules :: ReplState ->
                   IO (Either PactError
                       (HM.HashMap ModuleName (ModuleData Ref), ReplState))
 replGetModules rs = evalReplEval def rs (getAllModules (def :: Info))
+
+replLookupModule :: ReplState -> ModuleName -> IO (Either String (ModuleData Ref))
+replLookupModule rs mn = do
+  modulesM <- replGetModules rs
+  pure $ case modulesM of
+    Left err -> Left $ show err
+    Right (modules,_) ->
+      case HM.lookup mn modules of
+        Nothing         -> Left $ "module not found: " ++ show mn ++ ", modules=" ++ show (HM.keys modules)
+        Just moduleData -> Right moduleData
 
 -- | install repl lib functions into monad state
 useReplLib :: Repl ()

--- a/src/Pact/Repl/Types.hs
+++ b/src/Pact/Repl/Types.hs
@@ -9,19 +9,23 @@ module Pact.Repl.Types
   , LibState(..),rlsPure,rlsOp,rlsTxName,rlsTests,rlsVerifyUri,rlsMockSPV,rlsPacts
   , Tx(..)
   , SPVMockKey(..)
+  , getAllModules
   ) where
 
 import Control.Lens (makeLenses)
+import Control.Monad
 import Data.Default (Default(..))
 import Data.Monoid (Endo(..))
 import Control.Monad.State.Strict (StateT)
 import Control.Concurrent (MVar)
 import Pact.PersistPactDb (DbEnv)
 import Pact.Persist.Pure (PureDb)
-import Pact.Types.Runtime (EvalEnv,EvalState,Term,Name,FunApp,Info,Object,Term(..),PactId,PactExec)
+import Pact.Types.Runtime
 import Data.Text (Text)
 import qualified Data.Map.Strict as M
+import qualified Data.HashMap.Strict as HM
 import Pact.Types.Pretty (Pretty,pretty,renderCompactText)
+import Pact.Native.Internal
 
 data ReplMode =
     Interactive |
@@ -83,3 +87,10 @@ data LibState = LibState {
 
 makeLenses ''LibState
 makeLenses ''ReplState
+
+getAllModules :: HasInfo i => i -> Eval e (HM.HashMap ModuleName (ModuleData Ref))
+getAllModules i = do
+  mks <- keys (getInfo i) Modules
+  fmap HM.fromList $ forM mks $ \mk -> do
+    m <- getModule i mk
+    return (mk,m)

--- a/src/Pact/Types/Persistence.hs
+++ b/src/Pact/Types/Persistence.hs
@@ -196,8 +196,8 @@ data PactDb e = PactDb {
     -- | Write a domain value at key. WriteType argument governs key behavior.
   , _writeRow :: forall k v . (AsString k,ToJSON v) =>
                  WriteType -> Domain k v -> k -> v -> Method e ()
-    -- | Retrieve all keys for user table.
-  , _keys ::  TableName -> Method e [RowKey]
+    -- | Retrieve all keys for a domain.
+  , _keys :: forall k v . (IsString k,AsString k) => Domain k v -> Method e [k]
     -- | Retrieve all transaction ids greater than supplied txid for table.
   , _txids ::  TableName -> TxId -> Method e [TxId]
     -- | Create a user table.

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -245,8 +245,8 @@ makeLenses ''EvalEnv
 data RefState = RefState {
       -- | Imported Module-local defs and natives.
       _rsLoaded :: HM.HashMap Name Ref
-      -- | Modules that were loaded.
-    , _rsLoadedModules :: HM.HashMap ModuleName (ModuleData Ref)
+      -- | Modules that were loaded, and flag if updated.
+    , _rsLoadedModules :: HM.HashMap ModuleName (ModuleData Ref, Bool)
       -- | Current Namespace
     , _rsNamespace :: Maybe Namespace
     } deriving (Eq,Show)

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -447,6 +447,10 @@ data Name
   | Name { _nName :: Text, _nInfo :: Info }
   deriving (Generic, Show)
 
+instance HasInfo Name where
+  getInfo (QName _ _ i) = i
+  getInfo (Name _ i) = i
+
 instance Pretty Name where
   pretty = \case
     QName modName nName _ -> pretty modName <> "." <> pretty nName

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -687,10 +687,10 @@ instance ToJSON n => ToJSON (ConstVal n) where
 
 instance FromJSON n => FromJSON (ConstVal n) where
   parseJSON v =
-    (withObject "CVRaw"
-     (\o -> CVRaw <$> o .: "raw") v) <|>
     (withObject "CVEval"
-     (\o -> CVEval <$> o .: "raw" <*> o .: "eval") v)
+     (\o -> CVEval <$> o .: "raw" <*> o .: "eval") v) <|>
+    (withObject "CVRaw"
+     (\o -> CVRaw <$> o .: "raw") v)
 
 
 data Example

--- a/tests/TypecheckSpec.hs
+++ b/tests/TypecheckSpec.hs
@@ -97,9 +97,9 @@ loadModule :: FilePath -> ModuleName -> IO (ModuleData Ref)
 loadModule fp mn = do
   (r,s) <- execScript' Quiet fp
   either (die def) (const (return ())) r
-  case view (rEnv . eeRefStore . rsModules . at mn) s of
-    Just m -> return m
-    Nothing -> die def $ "Module not found: " ++ show (fp,mn)
+  replLookupModule s mn >>= \mr -> case mr of
+    Right m -> return m
+    Left e -> die def $ "Module not found: " ++ show (fp,mn,e)
 
 loadFun :: FilePath -> ModuleName -> Text -> IO Ref
 loadFun fp mn fn = loadModule fp mn >>= \(ModuleData _ m) -> case HM.lookup fn m of


### PR DESCRIPTION
Modules are no longer stored in `RefStore` but directly loaded from database and stored in `rsLoadedModules` in state; as this is cleared out after a tx it is no longer reliable to interrogate state to find loaded modules in tests etc so this has to be accomplished via a utility in Repl.