### PR TITLE
support for ghc 8.6

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,20 @@
+packages:
+    pact.cabal
+
+allow-newer: pact:all
+
+package pact
+    ghc-options: -Wwarn -Wall -fmax-pmcheck-iterations=1000
+
+source-repository-package
+    type: git
+    location: https://github.com/LeventErkok/sbv.git
+    tag: 68375576f87d17a2da759c56f7147f4e559471a2
+
+source-repository-package
+    type: git
+    location: git@github.com:kadena-io/thyme.git
+    tag: 6ee9fcb026ebdb49b810802a981d166680d867c9
+
+constraints:
+    megaparsec <7.0

--- a/src-ghc/Pact/Server/ApiServer.hs
+++ b/src-ghc/Pact/Server/ApiServer.hs
@@ -1,11 +1,12 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- |
 -- Module      :  Pact.Server.ApiServer
@@ -53,6 +54,10 @@ import Pact.Types.API
 import Pact.Types.Server
 import Pact.Types.Version
 
+#if !MIN_VERSION_servant(0,16,0)
+type ServerError = ServantErr
+#endif
+
 data ApiEnv = ApiEnv
   { _aiLog :: String -> IO ()
   , _aiHistoryChan :: HistoryChannel
@@ -60,7 +65,7 @@ data ApiEnv = ApiEnv
   }
 makeLenses ''ApiEnv
 
-type Api a = ReaderT ApiEnv (ExceptT ServantErr IO) a
+type Api a = ReaderT ApiEnv (ExceptT ServerError IO) a
 
 runApiServer :: HistoryChannel -> InboundPactChan -> (String -> IO ()) -> Int -> FilePath -> IO ()
 runApiServer histChan inbChan logFn port _logDir = do

--- a/src/Pact/Analyze/Eval/Prop.hs
+++ b/src/Pact/Analyze/Eval/Prop.hs
@@ -11,10 +11,12 @@
 -- 'Term' or 'Invariant' languages).
 module Pact.Analyze.Eval.Prop where
 
+import Control.Monad.Fail
 import           Control.Lens               (Lens', at, ix, view, (%=), (?~))
 import           Control.Monad.Except       (ExceptT, MonadError (throwError))
 import           Control.Monad.Reader       (MonadReader (local), ReaderT)
 import           Control.Monad.State.Strict (MonadState, StateT (..))
+import           Data.Default               (def)
 import qualified Data.Map.Strict            as Map
 import           Data.SBV                   (EqSymbolic ((.==)),
                                              Mergeable (symbolicMerge), literal)
@@ -44,6 +46,9 @@ newtype Query a
     { queryAction :: StateT SymbolicSuccess (ReaderT QueryEnv (ExceptT AnalyzeFailure Alloc)) a }
   deriving (Functor, Applicative, Monad, MonadReader QueryEnv,
             MonadError AnalyzeFailure, MonadState SymbolicSuccess, MonadAlloc)
+
+instance MonadFail Query where
+    fail = throwError . AnalyzeFailure def . fromString
 
 instance (Mergeable a) => Mergeable (Query a) where
   -- We merge the result and state, performing any 'Alloc' actions that occur

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -19,12 +19,14 @@ import           Control.Lens                (At (at), Lens', preview, use,
                                               (^?), _1, _2, _head, _Just,
                                               ifoldlM)
 import           Control.Monad               (void)
+import           Control.Monad.Fail          (MonadFail(..))
 import           Control.Monad.Except        (Except, MonadError (throwError))
 import           Control.Monad.Reader        (MonadReader (ask, local), runReaderT)
 import           Control.Monad.RWS.Strict    (RWST (RWST, runRWST))
 import           Control.Monad.State.Strict  (MonadState, modify', runStateT)
 import qualified Data.Aeson                  as Aeson
 import           Data.ByteString.Lazy        (toStrict)
+import           Data.Default                (def)
 import           Data.Foldable               (foldl', foldlM)
 import           Data.Map.Strict             (Map)
 import qualified Data.Map.Strict             as Map
@@ -69,6 +71,9 @@ newtype Analyze a
     { runAnalyze :: RWST AnalyzeEnv () EvalAnalyzeState (Except AnalyzeFailure) a }
   deriving (Functor, Applicative, Monad, MonadReader AnalyzeEnv,
             MonadState EvalAnalyzeState, MonadError AnalyzeFailure)
+
+instance MonadFail Analyze where
+    fail = throwError . AnalyzeFailure def . fromString
 
 instance Analyzer Analyze where
   type TermOf Analyze = Term

--- a/src/Pact/Analyze/Parse/Prop.hs
+++ b/src/Pact/Analyze/Parse/Prop.hs
@@ -725,7 +725,7 @@ expToProp tableEnv' genStart nameEnv idEnv consts propDefs ty body = do
     <- parseToPreProp genStart nameEnv propDefs body
   let env = PropCheckEnv (coerceQType <$> idEnv) tableEnv' Set.empty Set.empty
         preTypedPropDefs consts
-  runReaderT (checkPreProp ty preTypedBody) env
+  _getEither $ runReaderT (checkPreProp ty preTypedBody) env
 
 inferProp
   :: TableEnv
@@ -748,7 +748,7 @@ inferProp tableEnv' genStart nameEnv idEnv consts propDefs body = do
     <- parseToPreProp genStart nameEnv propDefs body
   let env = PropCheckEnv (coerceQType <$> idEnv) tableEnv' Set.empty Set.empty
         preTypedPropDefs consts
-  runReaderT (inferPreProp preTypedBody) env
+  _getEither $ runReaderT (inferPreProp preTypedBody) env
 
 parseToPreProp
   :: Traversable t

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -90,24 +90,24 @@ walkAST f t@Prim {} = f Pre t >>= f Post
 walkAST f t@Var {} = f Pre t >>= f Post
 walkAST f t@Table {} = f Pre t >>= f Post
 walkAST f t@Object {} = do
-  Object {..} <- f Pre t
-  t' <- Object _aNode <$>
-         mapM (walkAST f) _aObject
+  a <- f Pre t
+  t' <- Object (_aNode a) <$>
+         mapM (walkAST f) (_aObject a)
   f Post t'
 walkAST f t@List {} = do
-  List {..} <- f Pre t
-  t' <- List _aNode <$> mapM (walkAST f) _aList
+  a <- f Pre t
+  t' <- List (_aNode a) <$> mapM (walkAST f) (_aList a)
   f Post t'
 walkAST f t@Binding {} = do
-  Binding {..} <- f Pre t
-  t' <- Binding _aNode <$>
-        forM _aBindings (\(k,v) -> (k,) <$> walkAST f v) <*>
-        mapM (walkAST f) _aBody <*> pure _aBindType
+  a <- f Pre t
+  t' <- Binding (_aNode a) <$>
+        forM (_aBindings a) (\(k,v) -> (k,) <$> walkAST f v) <*>
+        mapM (walkAST f) (_aBody a) <*> pure (_aBindType a)
   f Post t'
 walkAST f t@App {} = do
-  App {..} <- f Pre t
-  t' <- App _aNode <$>
-        (case _aAppFun of
+  a <- f Pre t
+  t' <- App (_aNode a) <$>
+        (case _aAppFun a of
            fun@FNative {..} -> case _fSpecial of
              Nothing -> return fun
              Just (fs,SBinding bod) -> do
@@ -118,15 +118,15 @@ walkAST f t@App {} = do
              db <- mapM (walkAST f) _fBody
              return $ set fBody db fun
         ) <*>
-        mapM (walkAST f) _aAppArgs
+        mapM (walkAST f) (_aAppArgs a)
   f Post t'
 walkAST f t@Step {} = do
-  Step {..} <- f Pre t
-  t' <- Step _aNode
-    <$> traverse (walkAST f) _aEntity
-    <*> walkAST f _aExec
-    <*> traverse (walkAST f) _aRollback
-    <*> pure _aYieldResume
+  a <- f Pre t
+  t' <- Step (_aNode a)
+    <$> traverse (walkAST f) (_aEntity a)
+    <*> walkAST f (_aExec a)
+    <*> traverse (walkAST f) (_aRollback a)
+    <*> pure (_aYieldResume a)
   f Post t'
 
 isConcreteTy :: Type n -> Bool


### PR DESCRIPTION
This PR adds support for building pact with ghc-8.6 and recent versions of servant. The PR only adds support to the code. It doesn't change any bounds or dependencies.

In summary the changes are:

* [x] add cabal.project file,
* [x] support for servant >= 0.15,
* [x] `MonadFail` instances for `Query` and `Analyze`,
* [x] add `EitherFail` monad that is `Either` with a `MonadFail` instance,
* [x] change `PropCheck` to use `EitherFail` instead of `Either`, and
* [x] remove a few redundant incomplete pattern matches.
