### PR TITLE
Deletes ETH Signature generation in test suite

### DIFF
--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -115,7 +115,7 @@ testSimpleServerCmd mgr = do
 testCorrectNextStep :: HTTP.Manager -> Expectation
 testCorrectNextStep mgr = do
   let moduleName = "testCorrectNextStep"
-  adminKeys <- genKeysEth
+  adminKeys <- genKeys
   
   let makeExecCmdWith = makeExecCmd adminKeys
   moduleCmd       <- makeExecCmdWith (T.unpack (threeStepPactCode moduleName))

--- a/tests/SchemeSpec.hs
+++ b/tests/SchemeSpec.hs
@@ -148,37 +148,24 @@ testPublicKeyImport = do
     mkKeyPairs [apiKP] `shouldThrow` isUserError
 
 
-
 testUserSig :: Spec
 testUserSig = do
-  it "successfully verifies ETH UserSig when using Command's mkCommand" $ do
-    signers <- toSigners [someETHPair]
-    kps     <- mkKeyPairs $ toApiKeyPairs [someETHPair]
-    cmd     <- mkCommandTest kps signers "(somePactFunction)"
-    let (hsh, sigs)  = (_cmdHash cmd, _cmdSigs cmd)
-        verifiedSigs = (map (\(sig, signer) -> verifyUserSig hsh sig signer)
-                            (zip sigs signers))
-    verifiedSigs `shouldBe` [True]
-
-
-
-  it "successfully verifies ETH UserSig when provided by user" $ do
+  it "successfully verifies user-provided ETH Signature" $ do
     let hsh = hash "(somePactFunction)"
+        userSig = UserSig
+                  "780c2a6d11baae240a2888c4cfa7243dabba26b6121e68d0ea3b3dff779024c0c847eff27c6499ea29e7aea5f5744b98e550f6e3f7514d08c6cc2230564a1339"
     [signer] <- toSigners [someETHPair]
-    [kp]     <- mkKeyPairs $ toApiKeyPairs [someETHPair]
-    sig      <- sign kp (toUntypedHash hsh)
-    let myUserSig = UserSig (toB16Text sig)
-    (verifyUserSig hsh myUserSig signer) `shouldBe` True
+    (verifyUserSig hsh userSig signer) `shouldBe` True
 
 
 
   it "fails UserSig validation when UserSig has unexpected Address" $ do
     let hsh = hash "(somePactFunction)"
-    [signer] <- toSigners [someETHPair]
-    [kp]     <- mkKeyPairs $ toApiKeyPairs [someETHPair]
+        (_,_,wrongAddr,_) = someETHPair
+    [signer] <- toSigners [someED25519Pair]
+    [kp]     <- mkKeyPairs $ toApiKeyPairs [someED25519Pair]
     sig      <- sign kp (toUntypedHash hsh)
     let myUserSig   = UserSig (toB16Text sig)
-        wrongAddr   = Lens.view siPubKey signer
         wrongSigner = Lens.set siAddress wrongAddr signer
     (verifyUserSig hsh myUserSig wrongSigner) `shouldBe` False
 
@@ -186,11 +173,11 @@ testUserSig = do
 
   it "fails UserSig validation when UserSig has unexpected Scheme" $ do
     let hsh = hash "(somePactFunction)"
-    [signer] <- toSigners [someETHPair]
-    [kp]     <- mkKeyPairs $ toApiKeyPairs [someETHPair]
+    [signer] <- toSigners [someED25519Pair]
+    [kp]     <- mkKeyPairs $ toApiKeyPairs [someED25519Pair]
     sig      <- sign kp (toUntypedHash hsh)
     let myUserSig   = UserSig (toB16Text sig)
-        wrongScheme = ED25519
+        wrongScheme = ETH
         wrongSigner = Lens.set siScheme wrongScheme signer
     (verifyUserSig hsh myUserSig wrongSigner) `shouldBe` False
 

--- a/tests/Utils/TestRunner.hs
+++ b/tests/Utils/TestRunner.hs
@@ -10,7 +10,6 @@ module Utils.TestRunner
   , flushDb
   , Crypto.SomeKeyPair
   , genKeys
-  , genKeysEth
   , formatPubKeyForCmd
   , makeCheck
   , checkResult
@@ -31,7 +30,6 @@ import Pact.Types.API
 import Pact.Types.Command
 import Pact.Types.Crypto as Crypto
 import Pact.Types.Util (toB16JSON)
-import qualified Data.ByteString.Base16   as B16
 
 import Control.Exception
 import Data.Aeson
@@ -148,14 +146,6 @@ flushDb = mapM_ deleteIfExists _logFiles
 
 genKeys :: IO SomeKeyPair
 genKeys = genKeyPair defaultScheme
-
--- Note: some randomly-generated keys were failing so using static one here
-genKeysEth :: IO SomeKeyPair
-genKeysEth = return k
-  where k = either error id $ importKeyPair (toScheme ETH) (Just $ pub) priv
-        pub = PubBS $ getByteString "836b35a026743e823a90a0ee3b91bf615c6a757e2b60b9e1dc1826fd0dd16106f7bc1e8179f665015f43c6c81f39062fc2086ed849625c06e04697698b21855e"
-        priv = PrivBS $ getByteString "208065a247edbe5df4d86fbdc0171303f23a76961be9f6013850dd2bdc759bbb"
-        getByteString = fst . B16.decode
 
 formatPubKeyForCmd :: SomeKeyPair -> Value
 formatPubKeyForCmd kp = toB16JSON $ formatPublicKey kp


### PR DESCRIPTION
Refactors Scheme and Continuation tests to omit ETH signature generation. 

Randomness is needed for ECDSA Public/Private Key generation as well as ECDSA signatures.
Since we've been seeing some non-deterministic test failures surrounding ETH keys and signatures, this PR omits ETH signature generation from the test suite. It still tests whether verifyUserSig works for ETH by hardcoding the ETH Signature.

As a result, ETH signature generation, which is used primarily by `mkCommand`, is not being tested.