### PR TITLE
Move txid management to backend

### DIFF
--- a/src-ghc/Pact/MockDb.hs
+++ b/src-ghc/Pact/MockDb.hs
@@ -62,7 +62,7 @@ pactdb (MockDb (MockRead r) (MockKeys ks) (MockTxIds tids) (MockGetUserTableInfo
   ,
   _getUserTableInfo = uti
   ,
-  _beginTx = \_t -> rc ()
+  _beginTx = \_t -> rc Nothing
   ,
   _commitTx = c
   ,

--- a/src-ghc/Pact/Persist/SQLite.hs
+++ b/src-ghc/Pact/Persist/SQLite.hs
@@ -26,6 +26,7 @@ import System.Directory
 import Control.Monad.State
 
 import Pact.Persist
+import Pact.Types.Persistence
 import Pact.Types.Pretty
 import Pact.Types.SQLite
 import Pact.Types.Util (AsString(..))
@@ -235,11 +236,11 @@ _test = do
   void $ closeSQLite e
   e' <- refresh e
   (`evalStateT` e') $ do
-    run $ beginTx p True
+    run $ beginTx p Transactional
     run $ createTable p dt
     run $ createTable p tt
     run $ commitTx p
-    run $ beginTx p True
+    run $ beginTx p Transactional
     run $ writeValue p dt Insert "stuff" (String "hello")
     run $ writeValue p dt Insert "tough" (String "goodbye")
     run $ writeValue p tt Write 1 (String "txy goodness")
@@ -251,7 +252,7 @@ _test = do
     run (queryKeys p dt (Just (KQKey KGTE "stuff"))) >>= liftIO . print
     run (query p tt (Just (KQKey KGT 0 `kAnd` KQKey KLT 2))) >>=
       (liftIO . (print :: [(TxKey,Value)] -> IO ()))
-    run $ beginTx p True
+    run $ beginTx p Transactional
     run $ writeValue p tt Update 2 (String "txalicious-2!")
     run (readValue p tt 2) >>= (liftIO . (print :: Maybe Value -> IO ()))
     run $ rollbackTx p

--- a/src/Pact/Persist.hs
+++ b/src/Pact/Persist.hs
@@ -134,10 +134,7 @@ instance PactDbValue Namespace                where prettyPactDbValue = pretty
 data Persister s = Persister {
   createTable :: forall k . PactDbKey k => Table k -> Persist s ()
   ,
-  -- | Boolean argument to indicate if this is "transactional for real":
-  -- local execution mode starts a tx knowing full well it will roll back.
-  -- This allows backing layer to be aware of non-transactional exec.
-  beginTx :: Bool -> Persist s ()
+  beginTx :: ExecutionMode -> Persist s ()
   ,
   commitTx :: Persist s ()
   ,

--- a/src/Pact/Persist/Pure.hs
+++ b/src/Pact/Persist/Pure.hs
@@ -26,6 +26,7 @@ import Control.Monad.State
 import Data.Default
 import Data.Typeable
 
+import Pact.Types.Persistence
 import Pact.Persist hiding (compileQuery)
 import Pact.Types.Pretty
 
@@ -144,11 +145,11 @@ _test = do
         put s'
         return r
   (`evalStateT` e) $ do
-    run $ beginTx p True
+    run $ beginTx p Transactional
     run $ createTable p dt
     run $ createTable p tt
     run $ commitTx p
-    run $ beginTx p True
+    run $ beginTx p Transactional
     run $ writeValue p dt Insert "stuff" (String "hello")
     run $ writeValue p dt Insert "tough" (String "goodbye")
     run $ writeValue p tt Write 1 (String "txy goodness")
@@ -160,7 +161,7 @@ _test = do
     run (queryKeys p dt (Just (KQKey KGTE "stuff"))) >>= liftIO . print
     run (query p tt (Just (KQKey KGT 0 `kAnd` KQKey KLT 2))) >>=
       (liftIO . (print :: [(TxKey,Value)] -> IO ()))
-    run $ beginTx p True
+    run $ beginTx p Transactional
     run $ writeValue p tt Update 2 (String "txalicious-2!")
     run (readValue p tt 2) >>= (liftIO . (print :: Maybe Value -> IO ()))
     run $ rollbackTx p

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -75,7 +75,7 @@ initLibState :: Loggers -> Maybe String -> IO LibState
 initLibState loggers verifyUri = do
   m <- newMVar (DbEnv def persister
                 (newLogger loggers "Repl")
-                def def)
+                def 0 def)
   createSchema m
   return (LibState m Noop def def verifyUri M.empty M.empty)
 

--- a/src/Pact/Repl/Types.hs
+++ b/src/Pact/Repl/Types.hs
@@ -2,7 +2,7 @@
 module Pact.Repl.Types
   ( ReplMode(..)
   , Hdl(..)
-  , ReplState(..),rEnv,rEvalState,rMode,rOut,rFile,rTermOut
+  , ReplState(..),rEnv,rEvalState,rMode,rOut,rFile,rTermOut,rTxId
   , TestResult(..)
   , Repl
   , LibOp(..)
@@ -50,6 +50,7 @@ data ReplState = ReplState {
     , _rOut :: String
     , _rTermOut :: [Term Name]
     , _rFile :: Maybe FilePath
+    , _rTxId :: Maybe TxId
     }
 
 type Repl a = StateT ReplState IO a

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -38,7 +38,6 @@ module Pact.Types.Command
   , CommandError(..),ceMsg,ceDetail
   , CommandSuccess(..),csData
   , CommandResult(..),crReqKey,crTxId,crResult,crGas
-  , ExecutionMode(..), emTxId
   , CommandExecInterface(..),ceiApplyCmd,ceiApplyPPCmd
   , ApplyCmd, ApplyPPCmd
   , RequestKey(..)
@@ -294,10 +293,6 @@ cmdToRequestKey :: Command a -> RequestKey
 cmdToRequestKey Command {..} = RequestKey (toUntypedHash _cmdHash)
 
 
-data ExecutionMode =
-    Transactional { _emTxId :: TxId } |
-    Local
-    deriving (Eq,Show)
 
 
 type ApplyCmd = ExecutionMode -> Command ByteString -> IO CommandResult

--- a/src/Pact/Types/Persistence.hs
+++ b/src/Pact/Types/Persistence.hs
@@ -30,7 +30,8 @@ module Pact.Types.Persistence
    TxId(..),
    PersistDirect(..),toPersistDirect,fromPersistDirect,
    ModuleData(..),mdModule,mdRefMap,
-   PersistModuleData
+   PersistModuleData,
+   ExecutionMode(..)
    ) where
 
 import Control.Applicative ((<|>))
@@ -182,6 +183,10 @@ instance Pretty TxId where
 instance ToTerm TxId where toTerm = tLit . LInteger . fromIntegral
 instance AsString TxId where asString = pack . show
 
+data ExecutionMode =
+    Transactional |
+    Local
+    deriving (Eq,Show)
 
 
 
@@ -204,12 +209,18 @@ data PactDb e = PactDb {
   , _createUserTable ::  TableName -> ModuleName -> Method e ()
     -- | Get module, keyset for user table.
   , _getUserTableInfo ::  TableName -> Method e ModuleName
-    -- | Initiate transaction. If TxId not provided, commit fails/rolls back.
-  , _beginTx :: Maybe TxId -> Method e ()
-    -- | Commit transaction, if in tx. If not in tx, rollback and throw error.
-    -- Return raw TxLogs, for use in checkpointing only (not for transmission to user).
+    -- | Initiate transactional state. Returns txid for 'Transactional' mode
+    -- or Nothing for 'Local' mode. If state already initiated, rollback and throw error.
+  , _beginTx :: ExecutionMode -> Method e (Maybe TxId)
+    -- | Conclude transactional state with commit.
+    -- In transactional mode, commits backend to TxId.
+    -- In Local mode, releases TxId for re-use.
+    -- Returns all TxLogs.
   , _commitTx ::  Method e [TxLog Value]
-    -- | Rollback database transaction.
+    -- | Conclude transactional state with rollback.
+    -- Safe to call at any time.
+    -- Rollback all backend changes.
+    -- Releases TxId for re-use.
   , _rollbackTx :: Method e ()
     -- | Get transaction log for table. TxLogs are expected to be user-visible format.
   , _getTxLog :: forall k v . (IsString k,FromJSON v) =>

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -21,7 +21,7 @@ module Pact.Types.Runtime
    PactId(..),
    PactStep(..),psStep,psRollback,psPactId,psResume,
    RefStore(..),rsNatives,
-   EvalEnv(..),eeRefStore,eeMsgSigs,eeMsgBody,eeTxId,eeEntity,eePactStep,eePactDbVar,
+   EvalEnv(..),eeRefStore,eeMsgSigs,eeMsgBody,eeMode,eeEntity,eePactStep,eePactDbVar,
    eePactDb,eePurity,eeHash,eeGasEnv,eeNamespacePolicy,eeSPVSupport,eePublicData,
    toPactId,
    Purity(..),PureNoDb,PureReadOnly,EnvNoDb(..),EnvReadOnly(..),mkNoDbEnv,mkReadOnlyEnv,
@@ -215,8 +215,8 @@ data EvalEnv e = EvalEnv {
     , _eeMsgSigs :: !(S.Set PublicKey)
       -- | JSON body accompanying message.
     , _eeMsgBody :: !Value
-      -- | Transaction id. 'Nothing' indicates local execution.
-    , _eeTxId :: !(Maybe TxId)
+      -- | Execution mode
+    , _eeMode :: ExecutionMode
       -- | Entity governing private/encrypted 'pact' executions.
     , _eeEntity :: !(Maybe EntityName)
       -- | Step value for 'pact' executions.
@@ -348,7 +348,7 @@ getUserTableInfo :: Info -> TableName -> Eval e ModuleName
 getUserTableInfo i t = method i $ \db -> _getUserTableInfo db t
 
 -- | Invoke _beginTx
-beginTx :: Info -> Maybe TxId -> Eval e ()
+beginTx :: Info -> ExecutionMode -> Eval e (Maybe TxId)
 beginTx i t = method i $ \db -> _beginTx db t
 
 -- | Invoke _commitTx
@@ -436,7 +436,7 @@ mkPureEnv holder purity readRowImpl env@EvalEnv{..} = do
     _eeRefStore
     _eeMsgSigs
     _eeMsgBody
-    _eeTxId
+    _eeMode
     _eeEntity
     _eePactStep
     v

--- a/tests/pact/db.repl
+++ b/tests/pact/db.repl
@@ -39,12 +39,12 @@
 (begin-tx)
 (use dbtest)
 (expect "keys works" [ID_A] (keys persons))
-(expect "txids works" [2] (txids persons 2))
+(expect "txids works" [1] (txids persons 0))
 (expect "txlog works"
         [{"value":ROW_A,"key":ID_A,"table":"USER_dbtest_persons"}]
-        (txlog persons 2))
+        (txlog persons 1))
 
-(expect "keylog works" [{"txid": 2, "value": ROW_A}] (keylog persons ID_A 1))
+(expect "keylog works" [{"txid": 1, "value": ROW_A}] (keylog persons ID_A 1))
 
 (insert stuff "k" { "stuff": { "dec": 1.2, "bool": true, "int": -3, "time": (parse-time "%F" "1970-01-01") } })
 (expect "object stored as object" "object:*" (typeof (at "stuff" (read stuff "k"))))


### PR DESCRIPTION
March to "all state in the backend" continues, this time with a very satisfying cleanup where TxId incrementing is entirely handled by the PactDb backend and is simply an output of `beginTx` for use in environments that care (ie PactService, Repl etc). 

Also means as an unexpected bonus that `defpact`s can be run in local mode, which is pretty sweet.