### PR TITLE
Massaging Upper Bounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ matrix:
     addons:
       artifacts:
         paths:
-          - .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/pact/pact
+          - .stack-work/dist/x86_64-osx/Cabal-2.4.0.1/build/pact/pact
 
   # Linux build
   - env: BUILD=stack ARGS="-j1" Z3VERSION="4.8.3"
@@ -105,7 +105,7 @@ matrix:
       apt: {packages: [libgmp-dev]}
       artifacts:
         paths:
-          - .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/pact/pact
+          - .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/pact/pact
 
   # OSX Build Yosemite
   # - env: BUILD=stack ARGS=""

--- a/cabal.project
+++ b/cabal.project
@@ -3,14 +3,6 @@ packages:
 
 allow-newer: pact:all
 
-package pact
-    ghc-options: -Wwarn -Wall
-
-source-repository-package
-    type: git
-    location: https://github.com/LeventErkok/sbv.git
-    tag: 68375576f87d17a2da759c56f7147f4e559471a2
-
 source-repository-package
     type: git
     location: git@github.com:kadena-io/thyme.git

--- a/cabal.project
+++ b/cabal.project
@@ -4,7 +4,7 @@ packages:
 allow-newer: pact:all
 
 package pact
-    ghc-options: -Wwarn -Wall -fmax-pmcheck-iterations=1000
+    ghc-options: -Wwarn -Wall
 
 source-repository-package
     type: git

--- a/pact.cabal
+++ b/pact.cabal
@@ -138,18 +138,18 @@ library
 
   build-depends:       Decimal >= 0.4.2 && < 0.6
                      , aeson >= 0.11.3.0 && < 1.5
-                     , algebraic-graphs >= 0.2 && < 0.3
+                     , algebraic-graphs >= 0.2 && < 0.4
                      , prettyprinter >= 1.2 && < 1.3
                      , prettyprinter-ansi-terminal >= 1.1 && < 1.2
                      , prettyprinter-convert-ansi-wl-pprint
                      , attoparsec >= 0.13.0.2 && < 0.14
-                     , base >=4.9.0.0 && < 4.12
+                     , base >=4.9.0.0 && < 4.13
                      , base16-bytestring >=0.1.1.6 && < 0.2
                      , base64-bytestring >= 1.0.0.1
                      , bound >= 2 && < 2.1
                      , bytestring >=0.10.8.1 && < 0.11
                      , cereal >=0.5.4.0 && < 0.6
-                     , containers >= 0.5.7 && < 0.6
+                     , containers >= 0.5.7 && < 0.7
                      , data-default >= 0.7.1.1 && < 0.8
                      , deepseq >= 1.4.2.0 && < 1.5
                      , deriving-compat >= 0.5.1
@@ -157,8 +157,8 @@ library
                      , exceptions >= 0.8.3 && < 0.11
                      , filepath >= 1.4.1.0 && < 1.5
                      , hashable >= 1.2.4.0 && < 1.3
-                     , hspec >= 2.2.4 && < 2.6
-                     , lens >= 4.14 && < 4.17
+                     , hspec >= 2.2.4 && < 2.8
+                     , lens >= 4.14 && < 4.18
                      , lens-aeson >= 1.0.0.5 && < 1.1
                      , megaparsec >= 6
                      , mtl >= 2.2.1 && < 2.3
@@ -169,7 +169,7 @@ library
                      , safe >= 0.3.11 && < 0.4
                      , scientific >= 0.3.4.9 && < 0.4
                      , semigroups >= 0.18.2 && < 0.19
-                     , stm >= 2.4.4.1 && < 2.5
+                     , stm >= 2.4.4.1 && < 2.6
                      , text >= 1.2.2.1 && < 1.3
                      -- kadena ghcjs compat fork
                      , thyme == 0.3.6.0
@@ -179,7 +179,7 @@ library
                      , utf8-string >= 1.0.1.1 && < 1.1
                      , vector >= 0.11.0.0 && < 0.13
                      , vector-algorithms >= 0.7
-                     , vector-space >= 0.10.4 && < 0.14
+                     , vector-space >= 0.10.4 && < 0.16
                      , mmorph >= 1.1 && < 1.2
                      , constraints
                      , servant
@@ -194,7 +194,7 @@ library
   if !impl(ghcjs)
     build-depends:
         async
-      , criterion >= 1.1.4 && < 1.5
+      , criterion >= 1.1.4 && < 1.6
       , cryptonite
       , direct-sqlite
       , fast-logger
@@ -203,7 +203,7 @@ library
       , safe-exceptions >= 0.1.5.0 && < 0.2
       , sbv >= 7.11
       , servant-server
-      , statistics >= 0.13.3 && < 0.15
+      , statistics >= 0.13.3 && < 0.16
       , wai-cors
       , warp
       , yaml

--- a/pact.cabal
+++ b/pact.cabal
@@ -258,32 +258,33 @@ test-suite hspec
   ghc-options:      -Wall -threaded -rtsopts -O2 -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
                 base
-              , bound
               , Decimal
-              , deepseq
-              , exceptions
-              , hspec
               , HUnit
-              , pact
               , aeson
+              , base16-bytestring >=0.1.1.6 && < 0.2
+              , bound
+              , bytestring
               , containers
-              , directory
-              , filepath
-              , mmorph
               , data-default
+              , deepseq
+              , directory
+              , errors >= 2.3
+              , exceptions
+              , filepath
+              , hedgehog == 0.6.*
+              , hspec
+              , hw-hspec-hedgehog == 0.1.*
+              , intervals
               , lens
-              , unordered-containers
+              , mmorph
+              , mtl
+              , pact
               , prettyprinter
               , prettyprinter-ansi-terminal
               , prettyprinter-convert-ansi-wl-pprint
-              , bytestring
-              , base16-bytestring >=0.1.1.6 && < 0.2
-              , mtl
               , text
               , transformers
-              , hedgehog == 0.6.*
-              , hw-hspec-hedgehog == 0.1.*
-              , intervals
+              , unordered-containers
               , vector
   other-modules:
                 Blake2Spec

--- a/src/Pact/Analyze/Parse/Prop.hs
+++ b/src/Pact/Analyze/Parse/Prop.hs
@@ -376,7 +376,7 @@ inferPreProp preProp = case preProp of
         cm  <- view $ tableEnv . at (TableName litTn)
         case cm of
           Just cm' -> case columnMapToSchema cm' of
-            EType objTy@SObject{} -> pure $
+            EType objTy@SObjectUnsafe{} -> pure $
               Some objTy $ PropSpecific $ PropRead objTy ba' tn' rk'
             _ -> throwErrorIn preProp "expected an object"
           Nothing -> throwErrorT $ "couldn't find table " <> tShow litTn

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -997,7 +997,7 @@ translateNode astNode = withAstContext astNode $ case astNode of
         op'  <- toOp eqNeqP fn ?? MalformedComparison fn args
         pure $ Some SBool $ inject $ ListEqNeq ta op' a' b'
 
-      (Some ta@SObject{} a', Some tb@SObject{} b') -> do
+      (Some ta@SObjectUnsafe{} a', Some tb@SObjectUnsafe{} b') -> do
         op' <- toOp eqNeqP fn ?? MalformedComparison fn args
         pure $ Some SBool $ inject $ ObjectEqNeq ta tb op' a' b'
 
@@ -1066,13 +1066,15 @@ translateNode astNode = withAstContext astNode $ case astNode of
     aT          <- translateNode a
     bT          <- translateNode b
     case (aT, bT) of
-      (Some ty1@SObject{} o1, Some ty2@SObject{} o2) -> do
+      (Some ty1@SObjectUnsafe{} o1, Some ty2@SObjectUnsafe{} o2) -> do
         -- Feature 3: object merge
         pure $ Some retTy $ inject $ ObjMerge ty1 ty2 o1 o2
+
       (Some (SList tyA) a', Some (SList tyB) b') -> do
         Refl <- singEq tyA tyB ?? MalformedArithOp fn args
         -- Feature 4: list concatenation
         pure $ Some (SList tyA) $ inject $ ListConcat tyA a' b'
+
       (Some tyA a', Some tyB b') ->
         case (tyA, tyB) of
           -- Feature 1: string concatenation
@@ -1242,7 +1244,7 @@ translateNode astNode = withAstContext astNode $ case astNode of
     obj'     <- translateNode obj
     EType ty <- translateType node
     case obj' of
-      Some objTy@SObject{} obj'' -> do
+      Some objTy@SObjectUnsafe{} obj'' -> do
         Some SStr colName <- translateNode index
         pure $ Some ty $ CoreTerm $ ObjAt objTy colName obj''
       Some (SList listOfTy) list -> do

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,18 +1,27 @@
 # stack yaml for ghc builds
 
-resolver: lts-12.9
+resolver: lts-13.19
 
 packages:
   - '.'
 
+# GHC 8.6 has a more aggressive Pattern Match exhaustion checker. A number of
+# Pact's `Analysis` modules cause seeming infinite loops in the compiler during
+# this analysis, so here we limit the depth to 5000, then override `-Werror`
+# with `-Wwarn` to avoid failing the build.
+ghc-options:
+  pact: -fmax-pmcheck-iterations=5000 -Wwarn
+
 extra-deps:
-  - aeson-1.4.2.0
-  - algebraic-graphs-0.2
-  - crackNum-2.3
-  - FloatingHex-0.4
-  - compactable-0.1.2.2
-  - ed25519-donna-0.1.1
-  - hw-hspec-hedgehog-0.1.0.5
+  # Missing from Stackage
+  - ed25519-donna-0.1.1@sha256:344c0bb83603ed896012f441e54b380314dc4910320577cd18a9071e34f24fe9,2358
+  - prettyprinter-convert-ansi-wl-pprint-1.1@sha256:ae908ee44422c38a696858f04928d4b2448df656c09e6b5f5b1be05d99669fb0,3022
+
+  # Can't yet upgrade to more recent versions
+  - megaparsec-6.5.0
+  - neat-interpolation-0.3.2.2  # Due to megaparsec 7
+  - sbv-8.1
+
+  # Custom Pins
   - git: https://github.com/kadena-io/thyme.git
     commit: 6ee9fcb026ebdb49b810802a981d166680d867c9
-  - sbv-8.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,15 +13,17 @@ ghc-options:
   pact: -fmax-pmcheck-iterations=5000 -Wwarn
 
 extra-deps:
-  # Missing from Stackage
+  # --- Missing from Stackage --- #
   - ed25519-donna-0.1.1@sha256:344c0bb83603ed896012f441e54b380314dc4910320577cd18a9071e34f24fe9,2358
   - prettyprinter-convert-ansi-wl-pprint-1.1@sha256:ae908ee44422c38a696858f04928d4b2448df656c09e6b5f5b1be05d99669fb0,3022
 
-  # Can't yet upgrade to more recent versions
+  # --- Forced Downgrades --- #
   - megaparsec-6.5.0
   - neat-interpolation-0.3.2.2  # Due to megaparsec 7
-  - sbv-8.1
 
-  # Custom Pins
+  # --- Forced Upgrades --- #
+  - sbv-8.2
+
+  # --- Custom Pins --- #
   - git: https://github.com/kadena-io/thyme.git
     commit: 6ee9fcb026ebdb49b810802a981d166680d867c9

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # stack yaml for ghc builds
 
-resolver: lts-13.19
+resolver: lts-13.22
 
 packages:
   - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,13 +5,6 @@ resolver: lts-13.22
 packages:
   - '.'
 
-# GHC 8.6 has a more aggressive Pattern Match exhaustion checker. A number of
-# Pact's `Analysis` modules cause seeming infinite loops in the compiler during
-# this analysis, so here we limit the depth to 5000, then override `-Werror`
-# with `-Wwarn` to avoid failing the build.
-ghc-options:
-  pact: -fmax-pmcheck-iterations=5000 -Wwarn
-
 extra-deps:
   # --- Missing from Stackage --- #
   - ed25519-donna-0.1.1@sha256:344c0bb83603ed896012f441e54b380314dc4910320577cd18a9071e34f24fe9,2358

--- a/tests/RemoteVerifySpec.hs
+++ b/tests/RemoteVerifySpec.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Tests remote verification on the server side (i.e. no GHCJS involvement)
@@ -11,13 +11,13 @@ import Control.Lens
 import Control.Monad.State.Strict
 import Data.Either
 import qualified Data.Text as T
-import Test.Hspec
 import NeatInterpolation (text)
 import qualified Network.HTTP.Client as HTTP
 import Servant.Client
+import Test.Hspec
 
-import qualified Pact.Analyze.Remote.Types as Remote
 import Pact.Analyze.Remote.Server (runServantServer)
+import qualified Pact.Analyze.Remote.Types as Remote
 import Pact.Repl
 import Pact.Repl.Types
 import Pact.Server.Client


### PR DESCRIPTION
This branch forks off from Pact right before the breaking changes of #482 . It tickles some of Pact's upper bounds, which allows for a simpler `stack.yaml` which full GHC 8.6 support, and eventually a simpler `default.nix`.

In general, this should probably not be merged. It could potentially be the basis of a `2.6.2` release, but we need not spend time on that now. Chainweb's own 8.6 support could be based off this branch in the short-term.

This branch also revealed some compilation issues, as explained in #495 .

Closes #495 