### PR TITLE
Pacts in backend

### DIFF
--- a/examples/accounts/accounts.repl
+++ b/examples/accounts/accounts.repl
@@ -54,13 +54,19 @@
 (expect "balance of 123 after rollback" 229.0 (with-read accounts "123" { "balance" := b } b))
 
 ; test success step 1
+(pact-state true)
+(payment "123" "us" "456" "them" 12.0 (time "2016-07-22T11:26:35Z"))
 (continue-pact 1)
 (expect "balance of 456 unchanged" 5.0 (with-read accounts "456" { "balance" := b } b))
+(rollback-tx)
 
+(begin-tx)
+(use accounts)
+(payment "123" "us" "456" "them" 12.0 (time "2016-07-22T11:26:35Z"))
 (env-entity "them")
 (continue-pact 1)
 (expect "balance of 456 after credit step" 17.0 (with-read accounts "456" { "balance" := b } b))
-(commit-tx)
+(rollback-tx)
 
 ;; test public pact escrow
 (begin-tx)
@@ -101,6 +107,7 @@
 (test.reset-time)
 (env-keys ["user456"])
 (continue-pact 0 true (hash "run-escrow-pact-id"))
+(expect "no money paid to 456" 5.0 (test.get-balance "456"))
 (env-keys ["user123"]) ; for balance check
 (expect "escrow canceled" 229.0 (test.get-balance "123"))
 
@@ -120,7 +127,7 @@
 
 (env-data { "final-price": 1.75 })
 (continue-pact 1 false (hash "run-escrow-pact-id"))
-(expect "seller paid 1.75" 18.75 (test.get-balance "456"))
+(expect "seller paid 1.75" 6.75 (test.get-balance "456"))
 (expect "buyer refunded .25" 227.25 (test.get-balance "123"))
 
 

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -83,7 +83,7 @@ loadBenchModule db = do
            pactInitialHash
   let e = setupEvalEnv db entity Transactional md initRefStore
           freeGasEnv permissiveNamespacePolicy noSPVSupport def
-  void $ evalExec e pc
+  void $ evalExec def e pc
   (benchMod,_) <- runEval def e $ getModule (def :: Info) (ModuleName "bench" Nothing)
   p <- either (throwIO . userError . show) (return $!) $ traverse (traverse toPersistDirect) benchMod
   return (benchMod,p)
@@ -100,7 +100,7 @@ runPactExec benchMod dbEnv pc = do
   let e = setupEvalEnv dbEnv entity Transactional (initMsgData pactInitialHash)
           initRefStore freeGasEnv permissiveNamespacePolicy noSPVSupport def
       s = maybe def (initStateModules . HM.singleton (ModuleName "bench" Nothing)) benchMod
-  toJSON . _erOutput <$> evalExecState s e pc
+  toJSON . _erOutput <$> evalExec s e pc
 
 benchKeySet :: KeySet
 benchKeySet = KeySet [PublicKey "benchadmin"] (Name ">" def)

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -15,15 +15,14 @@ module Pact.Server.PactService where
 
 import Prelude
 
-import Control.Concurrent
 import Control.Exception.Safe
 import Control.Monad.Except
 import Control.Monad.Reader
 import Data.Aeson as A
 import Data.Int (Int64)
-import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
 import Data.Word (Word64)
+import Data.Default
 
 import Pact.Gas
 import Pact.Interpreter
@@ -31,7 +30,6 @@ import Pact.Parse (ParsedDecimal(..))
 import Pact.Types.Command
 import Pact.Types.Gas
 import Pact.Types.Logger
-import Pact.Types.PactValue
 import Pact.Types.Persistence
 import Pact.Types.RPC
 import Pact.Types.Runtime hiding (PublicKey)
@@ -48,14 +46,13 @@ initPactService CommandConfig {..} loggers = do
       blockTime = 0
 
   let mkCEI p@PactDbEnv {..} = do
-        cmdVar <- newMVar (CommandState M.empty)
         klog "Creating Pact Schema"
         initSchema p
         return CommandExecInterface
           { _ceiApplyCmd = \eMode cmd ->
-              applyCmd logger _ccEntity p cmdVar gasModel
+              applyCmd logger _ccEntity p gasModel
                 blockHeight blockTime eMode cmd (verifyCommand cmd)
-          , _ceiApplyPPCmd = applyCmd logger _ccEntity p cmdVar gasModel blockHeight blockTime }
+          , _ceiApplyPPCmd = applyCmd logger _ccEntity p gasModel blockHeight blockTime }
   case _ccSqlite of
     Nothing -> do
       klog "Initializing pure pact"
@@ -65,18 +62,18 @@ initPactService CommandConfig {..} loggers = do
       mkSQLiteEnv logger True sqlc loggers >>= mkCEI
 
 
-applyCmd :: Logger -> Maybe EntityName -> PactDbEnv p -> MVar CommandState ->
+applyCmd :: Logger -> Maybe EntityName -> PactDbEnv p ->
             GasModel -> Word64 -> Int64 -> ExecutionMode -> Command a ->
             ProcessedCommand PublicMeta ParsedCode -> IO CommandResult
-applyCmd _ _ _ _ _ _ _ _ cmd (ProcFail s) = return $ jsonResult Nothing (cmdToRequestKey cmd) (Gas 0) s
-applyCmd logger conf dbv cv gasModel bh bt exMode _ (ProcSucc cmd) = do
+applyCmd _ _ _ _ _ _ _ cmd (ProcFail s) = return $ jsonResult Nothing (cmdToRequestKey cmd) (Gas 0) s
+applyCmd logger conf dbv gasModel bh bt exMode _ (ProcSucc cmd) = do
   let pubMeta = _pMeta $ _cmdPayload cmd
       (ParsedDecimal gasPrice) = _pmGasPrice pubMeta
       gasEnv = GasEnv (fromIntegral $ _pmGasLimit pubMeta) (GasPrice gasPrice) gasModel
 
   let pd = PublicData pubMeta bh bt
 
-  r <- tryAny $ runCommand (CommandEnv conf exMode dbv cv logger gasEnv pd) $ runPayload cmd
+  r <- tryAny $ runCommand (CommandEnv conf exMode dbv logger gasEnv pd) $ runPayload cmd
   case r of
     Right cr -> do
       logLog logger "DEBUG" $ "success for requestKey: " ++ show (cmdToRequestKey cmd)
@@ -100,81 +97,22 @@ applyExec :: RequestKey -> PactHash -> [Signer] -> ExecMsg ParsedCode -> Command
 applyExec rk hsh signers (ExecMsg parsedCode edata) = do
   CommandEnv {..} <- ask
   when (null (_pcExps parsedCode)) $ throwCmdEx "No expressions found"
-  (CommandState pacts) <- liftIO $ readMVar _ceState
   let sigs = userSigsToPactKeySet signers
       evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode (MsgData sigs edata Nothing (toUntypedHash hsh))
                 initRefStore _ceGasEnv permissiveNamespacePolicy noSPVSupport _cePublicData
-  EvalResult{..} <- liftIO $ evalExec evalEnv parsedCode
-  newCmdPact <- join <$> mapM (handlePactExec _erInput) _erExec
-  let newPacts = case newCmdPact of
-        Nothing -> pacts
-        Just cmdPact -> M.insert (_pePactId cmdPact) cmdPact pacts
-  void $ liftIO $ swapMVar _ceState $ CommandState newPacts
-  mapM_ (\p -> liftIO $ logLog _ceLogger "DEBUG" $ "applyExec: new pact added: " ++ show p) newCmdPact
+  EvalResult{..} <- liftIO $ evalExec def evalEnv parsedCode
+  mapM_ (\p -> liftIO $ logLog _ceLogger "DEBUG" $ "applyExec: new pact added: " ++ show p) _erExec
   return $ jsonResult _erTxId rk _erGas $ CommandSuccess (last _erOutput)
-
-handlePactExec :: Either PactContinuation [Term Name] -> PactExec -> CommandM p (Maybe PactExec)
-handlePactExec (Left pc) _ = throwCmdEx $ "handlePactExec: internal error, continuation input: " ++ show pc
-handlePactExec (Right em) pe = do
-  unless (length em == 1) $
-    throwCmdEx $ "handlePactExec: defpact execution must occur as a single command: " ++ show em
-  return $ Just pe
 
 
 applyContinuation :: RequestKey -> PactHash -> [Signer] -> ContMsg -> CommandM p CommandResult
-applyContinuation rk hsh signers msg@ContMsg{..} = do
-  env@CommandEnv{..} <- ask
-  state@CommandState{..} <- liftIO $ readMVar _ceState
-  case M.lookup _cmPactId _csPacts of
-    Nothing -> throwCmdEx $ "applyContinuation: pact ID not found: " ++ show _cmPactId
-    Just PactExec{..} -> do
-      -- Verify valid ContMsg Step
-      when (_cmStep < 0 || _cmStep >= _peStepCount) $ throwCmdEx $ "Invalid step value: " ++ show _cmStep
-      if _cmRollback
-        then when (_cmStep /= _peStep) $ throwCmdEx $ "Invalid rollback step value: Received "
-             ++ show _cmStep ++ " but expected " ++ show _peStep
-        else when (_cmStep /= (_peStep + 1)) $ throwCmdEx $ "Invalid continuation step value: Received "
-             ++ show _cmStep ++ " but expected " ++ show (_peStep + 1)
-
-      -- Setup environment and get result
-      let sigs = userSigsToPactKeySet signers
-          pactStep = Just $ PactStep _cmStep _cmRollback _cmPactId (fmap (fmap fromPactValue) _peYield)
-          evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode
-                    (MsgData sigs _cmData pactStep (toUntypedHash hsh)) initRefStore
-                    _ceGasEnv permissiveNamespacePolicy noSPVSupport _cePublicData
-      res <- tryAny (liftIO  $ evalContinuation evalEnv _peContinuation)
-
-      -- Update pacts state
-      case res of
-        Left (SomeException ex) -> throwM ex
-        Right EvalResult{..} -> do
-          exec@PactExec{..} <- maybe (throwCmdEx "No pact execution in continuation exec!")
-                               return _erExec
-          if _cmRollback
-            then rollbackUpdate env msg state
-            else continuationUpdate env msg state exec
-          return $ jsonResult _erTxId rk _erGas $ CommandSuccess (last _erOutput)
-
-rollbackUpdate :: CommandEnv p -> ContMsg -> CommandState -> CommandM p ()
-rollbackUpdate CommandEnv{..} ContMsg{..} CommandState{..} = do
-  -- if step doesn't have a rollback function, no error thrown. Therefore, pact will be deleted
-  -- from state.
-  let newState = CommandState $ M.delete _cmPactId _csPacts
-  liftIO $ logLog _ceLogger "DEBUG" $ "applyContinuation: rollbackUpdate: reaping pact "
-    ++ show _cmPactId
-  void $ liftIO $ swapMVar _ceState newState
-
-continuationUpdate :: CommandEnv p -> ContMsg -> CommandState -> PactExec -> CommandM p ()
-continuationUpdate CommandEnv{..} ContMsg{..} CommandState{..} newPactExec@PactExec{..} = do
-  let nextStep = succ _cmStep
-      isLast = nextStep >= _peStepCount
-      updateState pacts = CommandState pacts -- never loading modules during continuations
-  if isLast
-    then do
-      liftIO $ logLog _ceLogger "DEBUG" $ "applyContinuation: continuationUpdate: reaping pact: "
-        ++ show _pePactId
-      void $ liftIO $ swapMVar _ceState $ updateState $ M.delete _pePactId _csPacts
-    else do
-      liftIO $ logLog _ceLogger "DEBUG" $ "applyContinuation: updated state of pact "
-        ++ show _pePactId ++ ": " ++ show newPactExec
-      void $ liftIO $ swapMVar _ceState $ updateState $ M.insert _pePactId newPactExec _csPacts
+applyContinuation rk hsh signers ContMsg{..} = do
+  CommandEnv{..} <- ask
+  -- Setup environment and get result
+  let sigs = userSigsToPactKeySet signers
+      pactStep = Just $ PactStep _cmStep _cmRollback _cmPactId Nothing
+      evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode
+                (MsgData sigs _cmData pactStep (toUntypedHash hsh)) initRefStore
+                _ceGasEnv permissiveNamespacePolicy noSPVSupport _cePublicData
+  EvalResult{..} <- liftIO $ evalContinuation def evalEnv Nothing
+  return $ jsonResult _erTxId rk _erGas $ CommandSuccess (last _erOutput)

--- a/src-ghc/Pact/Types/Server.hs
+++ b/src-ghc/Pact/Types/Server.hs
@@ -24,8 +24,7 @@
 module Pact.Types.Server
   ( userSigToPactPubKey, userSigsToPactKeySet
   , CommandConfig(..), ccSqlite, ccEntity, ccGasLimit, ccGasRate
-  , CommandState(..), csPacts
-  , CommandEnv(..), ceEntity, ceMode, ceDbEnv, ceState, ceLogger, cePublicData, ceGasEnv
+  , CommandEnv(..), ceEntity, ceMode, ceDbEnv, ceLogger, cePublicData, ceGasEnv
   , CommandM, runCommand, throwCmdEx
   , History(..)
   , ExistenceResult(..)
@@ -47,8 +46,7 @@ import Control.Concurrent.Chan
 import Data.Maybe
 import Data.String
 import Data.ByteString (ByteString)
-import qualified Data.Map.Strict         as M
-import qualified Data.Set                as S
+import qualified Data.Set as S
 import Data.Text.Encoding
 import Data.Aeson
 import Data.HashSet (HashSet)
@@ -83,16 +81,10 @@ $(makeLenses ''CommandConfig)
 
 
 
-newtype CommandState = CommandState {
-     _csPacts :: M.Map PactId PactExec
-     } deriving Show
-$(makeLenses ''CommandState)
-
 data CommandEnv p = CommandEnv {
       _ceEntity :: Maybe EntityName
     , _ceMode :: ExecutionMode
     , _ceDbEnv :: PactDbEnv p
-    , _ceState :: MVar CommandState
     , _ceLogger :: Logger
     , _ceGasEnv :: GasEnv
     , _cePublicData :: PublicData

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -9,10 +9,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 
--- TODO This is to hide a warning involving `enforceKeySet`, which has a typeclass
--- constraint unused in the function itself, but is critical for preventing misuse
--- by a caller. There is probably a better way to enforce this restriction,
--- allowing us to remove this warning suppression.
+-- Suppress unused constraint on enforce-keyset.
+-- TODO unused constraint is a dodgy warning, probably should not do it.
 -- See: https://github.com/kadena-io/pact/pull/206/files#r215468087
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
@@ -41,7 +39,7 @@ module Pact.Eval
     ,revokeCapability,revokeAllCapabilities
     ,computeUserAppGas,prepareUserAppArgs,evalUserAppBody
     ,evalByName
-    ,evalContinuation
+    ,resumePact
     ,enforcePactValue,enforcePactValue'
     ,toPersistDirect
     ) where
@@ -630,7 +628,7 @@ reduceApp (App (TDef d@Def{..} _) as ai) = do
       Defpact -> do
         continuation <- PactContinuation (QName _dModule (asString _dDefName) def)
           <$> enforcePactValue' (fst af)
-        applyPact continuation bod'
+        initPact ai continuation bod'
       Defcap ->
         evalError ai "Cannot directly evaluate defcap"
 reduceApp (App (TLitString errMsg) _ i) = evalError i $ pretty errMsg
@@ -674,80 +672,129 @@ reduceDirect TNative {..} as ai =
 reduceDirect (TLitString errMsg) _ i = evalError i $ pretty errMsg
 reduceDirect r _ ai = evalError ai $ "Unexpected non-native direct ref: " <> pretty r
 
--- | Apply a pactdef, which will execute a step based on env 'PactStep'
--- defaulting to the first step.
-applyPact :: PactContinuation -> Term Ref -> Eval e (Term Name)
-applyPact app (TList steps _ i) = do
+initPact :: Info -> PactContinuation -> Term Ref -> Eval e (Term Name)
+initPact i app bod = view eePactStep >>= \es -> case es of
+  Just v -> evalError i $ "initPact: internal error: step already in environment: " <> pretty v
+  Nothing -> view eeHash >>= \hsh ->
+    applyPact i app bod $ PactStep 0 False (toPactId hsh) Nothing
 
-  -- only one pact allowed in a transaction
+
+-- | Apply or resume a pactdef step.
+applyPact :: Info -> PactContinuation -> Term Ref -> PactStep -> Eval e (Term Name)
+applyPact i app (TList steps _ _) PactStep {..} = do
+
+  -- only one pact state allowed in a transaction
   use evalPactExec >>= \bad -> unless (isNothing bad) $
-    evalError i "Nested pact execution, aborting"
-
-  -- get step from environment or create a new one
-  PactStep{..} <- view eePactStep >>= \ps -> case ps of
-    Nothing -> view eeHash >>= \hsh ->
-      return $ PactStep 0 False (toPactId hsh) Nothing
-    Just v -> return v
+    evalError i "Multiple or nested pact exec found"
 
   -- retrieve indicated step from code
-  s <- maybe (evalError i $ "applyPact: step not found: " <> pretty _psStep) return $ steps V.!? _psStep
-  case s of
-    TStep step _i -> do
-      stepEntity <- traverse reduce (_sEntity step)
-
-      let
-
-        initExec executing = evalPactExec .=
-          Just (PactExec (length steps) Nothing executing _psStep _psPactId app)
-
-        execStep = do
-          initExec True
-          r <- case (_psRollback,_sRollback step) of
-            (False,_) -> reduce $ _sExec step
-            (True,Just rexp) -> reduce rexp
-            (True,Nothing) -> evalError' step $ "Rollback requested but none in step"
-          pe <- maybe (evalError' step "Internal error, no pact exec") return =<< use evalPactExec
-          writeRow (getInfo step) Write Pacts _psPactId pe
-          return r
-
-      case stepEntity of
-
-        -- private execution
-        Just (TLitString se) -> view eeEntity >>= \envEnt -> case envEnt of
-          Just (EntityName en)
-              -- matched for "private" step exec
-            | se == en -> execStep
-              -- unmatched, skip
-            | otherwise -> initExec False >> return (tStr "Skip step")
-          Nothing -> evalError (getInfo step) "Private step executed against non-private environment"
-        Just t -> evalError (_tInfo t) "step entity must be String value"
-
-        -- public execution
-        Nothing -> execStep -- "public" step exec
-
+  st <- maybe (evalError i $ "applyPact: step not found: " <> pretty _psStep) return $ steps V.!? _psStep
+  step <- case st of
+    TStep step _i -> return step
     t -> evalError (_tInfo t) "expected step"
 
-applyPact _ t = evalError (_tInfo t) "applyPact: expected list of steps"
+  -- determine if step is skipped (for private execution)
+  (executing,private) <- traverse reduce (_sEntity step) >>= \stepEntity -> case stepEntity of
+    Nothing -> return (True,False)
+    Just (TLitString se) -> view eeEntity >>= \envEnt -> case envEnt of
+      Just (EntityName en) -> return (se == en,True) -- execute if req entity matches context entity
+      Nothing -> evalError' step "applyPact: private step executed against non-private environment"
+    Just t -> evalError' t "applyPact: step entity must be String value"
 
-resumePact :: Info -> Eval e (Term Name)
-resumePact i = do
+  let stepCount = length steps
+      isLastStep = _psStep == pred stepCount
+
+  -- init pact state
+  evalPactExec .=
+      Just (PactExec stepCount Nothing executing _psStep _psPactId app)
+
+  -- evaluate
+  result <- if not executing then return $ tStr "skip step" else
+    case (_psRollback,_sRollback step) of
+      (False,_) -> reduce $ _sExec step
+      (True,Just rexp) -> reduce rexp
+      (True,Nothing) -> evalError' step $ "Rollback requested but none in step"
+
+  resultState <- use evalPactExec >>= (`maybe` pure)
+    (evalError i "Internal error, pact exec state not found after execution")
+
+  -- update database, determine if done
+  let done =
+        (not _psRollback && isLastStep) -- done if normal exec of last step
+        || (not private && _psRollback) -- done if public rollback
+        || (private && _psRollback && _psStep == 0) -- done if private and rolled back to step 0
+
+  writeRow i Write Pacts _psPactId $ if done then Nothing else Just resultState
+
+  return result
+
+applyPact _ _ t _ = evalError' t "applyPact: invalid defpact body, expected list of steps"
+
+
+
+-- | Resume a pact, either as specified or as found in database.
+-- Expects a 'PactStep' to be populated in the environment.
+resumePact :: Info -> Maybe PactExec -> Eval e (Term Name)
+resumePact i pe = do
+
   ps@PactStep{..} <- view eePactStep >>= (`maybe` pure)
     (evalError i "resumePact: no step in environment")
 
-  oldExec <- readRow i Pacts _psPactId >>= (`maybe` pure)
-    (evalError i $ "resumePact: no previous execution found for: " <> pretty _psPactId)
+  context <- case pe of
+    Just p -> return p
+    Nothing -> do
+      contextM <- readRow i Pacts _psPactId >>= (`maybe` pure)
+        (evalError i $ "resumePact: no previous execution found for: " <> pretty _psPactId)
 
-  resumePactExec i ps oldExec
+      case contextM of
+        Nothing -> evalError i $ "resumePact: pact completed: " <> pretty _psPactId
+        Just c -> return c
 
+  resumePactExec i ps context
+
+
+-- | Resume a pact with supplied PactExec context.
 resumePactExec :: Info -> PactStep -> PactExec -> Eval e (Term Name)
-resumePactExec i ps oldExec = undefined
+resumePactExec i req ctx = do
 
+  when (_psPactId req /= _pePactId ctx) $ evalError i $
+    "resumePactExec: request and context pact IDs do not match: " <>
+    pretty (_psPactId req,_pePactId ctx)
 
-evalContinuation :: PactContinuation -> Eval e (Term Name)
-evalContinuation (PactContinuation d args) = undefined
-  -- reduceApp (App (TDef d def) (map (liftTerm . fromPactValue) args) def)
+  when (_psStep req < 0 || _psStep req >= _peStepCount ctx) $ evalError i $
+    "resumePactExec: invalid step in request: " <> pretty (_psStep req)
 
+  if _psRollback req
+    then when (_psStep req /= _peStep ctx) $ evalError i $
+         "resumePactExec: rollback step mismatch with context: " <> pretty (_psStep req,_peStep ctx)
+    else when (_psStep req /= succ (_peStep ctx)) $ evalError i $
+         "resumePactExec: exec step mismatch with context: " <> pretty (_psStep req,_peStep ctx)
 
+  target <- resolveRef i (_pcDef (_peContinuation ctx)) >>= (`maybe` pure)
+    (evalError i $ "resumePactExec: could not resolve continuation ref: " <>
+     pretty (_pcDef $ _peContinuation ctx))
+
+  def' <- case target of
+    (Ref (TDef d _)) -> do
+      when (_dDefType d /= Defpact) $
+         evalError' d $ "resumePactExec: defpact required"
+      return d
+    t -> evalError' t $ "resumePactExec: defpact ref required"
+
+  let args = map (liftTerm . fromPactValue) (_pcArgs (_peContinuation ctx))
+
+  g <- computeUserAppGas def' i
+  af <- prepareUserAppArgs def' args
+
+  -- if resume is in step, use that, otherwise get from exec state
+  let resume = case _psResume req of
+        r@Just {} -> r
+        Nothing -> fmap (fmap fromPactValue) $ _peYield ctx
+
+  -- run local environment with yield from pact exec
+  local (set eePactStep (Just $ set psResume resume req)) $
+    evalUserAppBody def' af i g $ \bod ->
+      applyPact i (_peContinuation ctx) bod req
 
 
 -- | Create special error form handled in 'reduceApp'

--- a/src/Pact/Persist.hs
+++ b/src/Pact/Persist.hs
@@ -123,13 +123,20 @@ class (Eq v,Show v,ToJSON v,FromJSON v,Typeable v) => PactDbValue v where
 
 instance PactDbValue v => PactDbValue (TxLog v) where
   prettyPactDbValue = pretty . fmap (SomeDoc . prettyPactDbValue)
-instance PactDbValue (ObjectMap PactValue)    where prettyPactDbValue = pretty
-instance PactDbValue a => PactDbValue [a]       where
+instance PactDbValue (ObjectMap PactValue) where
+  prettyPactDbValue = pretty
+instance PactDbValue a => PactDbValue [a] where
   prettyPactDbValue = prettyList . fmap (SomeDoc . prettyPactDbValue)
-instance PactDbValue PersistModuleData         where prettyPactDbValue = (pretty . _mdModule)
-instance PactDbValue KeySet                   where prettyPactDbValue = pretty
-instance PactDbValue Value                    where prettyPactDbValue = pretty
-instance PactDbValue Namespace                where prettyPactDbValue = pretty
+instance PactDbValue PersistModuleData where
+  prettyPactDbValue = (pretty . _mdModule)
+instance PactDbValue KeySet where
+  prettyPactDbValue = pretty
+instance PactDbValue Value where
+  prettyPactDbValue = pretty
+instance PactDbValue Namespace where
+  prettyPactDbValue = pretty
+instance PactDbValue (Maybe PactExec) where
+  prettyPactDbValue = pretty
 
 data Persister s = Persister {
   createTable :: forall k . PactDbKey k => Table k -> Persist s ()

--- a/src/Pact/PersistPactDb.hs
+++ b/src/Pact/PersistPactDb.hs
@@ -102,6 +102,8 @@ modulesTable :: TableId
 modulesTable = "SYS_modules"
 namespacesTable :: TableId
 namespacesTable = "SYS_namespaces"
+pactsTable :: TableId
+pactsTable = "SYS_pacts"
 userTableInfo :: TableId
 userTableInfo = "SYS_usertables"
 
@@ -123,6 +125,7 @@ toTableId :: Domain k v -> TableId
 toTableId KeySets = keysetsTable
 toTableId Modules = modulesTable
 toTableId Namespaces = namespacesTable
+toTableId Pacts = pactsTable
 toTableId (UserTables t) = userTable t
 
 pactdb :: PactDb (DbEnv p)
@@ -132,6 +135,7 @@ pactdb = PactDb
            KeySets    -> readSysTable e (DataTable keysetsTable) (asString k)
            Modules    -> readSysTable e (DataTable modulesTable) (asString k)
            Namespaces -> readSysTable e (DataTable namespacesTable) (asString k)
+           Pacts -> readSysTable e (DataTable pactsTable) (asString k)
            (UserTables t) -> readUserTable e t k
 
  , _writeRow = \wt d k v e ->
@@ -139,6 +143,7 @@ pactdb = PactDb
            KeySets    -> writeSys e wt keysetsTable k v
            Modules    -> writeSys e wt modulesTable k v
            Namespaces -> writeSys e wt namespacesTable k v
+           Pacts -> writeSys e wt pactsTable k v
            (UserTables t) -> writeUser e wt t k v
 
  , _keys = \tn e -> runMVState e
@@ -214,6 +219,7 @@ getLogs d tid = mapM convLog . fromMaybe [] =<< doPersist (\p -> readValue p (tn
     tn KeySets    = TxTable keysetsTable
     tn Modules    = TxTable modulesTable
     tn Namespaces = TxTable namespacesTable
+    tn Pacts = TxTable pactsTable
     tn (UserTables t) = userTxRecord t
     convLog tl = case fromJSON (_txValue tl) of
       Error s -> throwDbError $ "Unexpected value, unable to deserialize log: " <> prettyString s
@@ -308,4 +314,5 @@ createSchema e = runMVState e $ do
   createTable' keysetsTable
   createTable' modulesTable
   createTable' namespacesTable
+  createTable' pactsTable
   doPersist P.commitTx

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -58,7 +58,7 @@ import Safe hiding (at)
 import Pact.Types.Native
 import Pact.Types.Pretty
 import qualified Pact.Types.Runtime as Term
-import Pact.Types.Runtime hiding (App,appInfo,Object)
+import Pact.Types.Runtime hiding (App,appInfo,Object,Step)
 import Pact.Types.Typecheck
 
 die :: MonadThrow m => Info -> String -> m a
@@ -943,18 +943,18 @@ toAST TTable {..} = do
     <*> pure _tTableName
 toAST TModule {..} = die _tInfo "Modules not supported"
 toAST TUse {..} = die _tInfo "Use not supported"
-toAST TStep {..} = do
-  ent <- forM _tStepEntity $ \e -> do
+toAST (TStep Term.Step {..} _) = do
+  ent <- forM _sEntity $ \e -> do
     e' <- toAST e
     assocAstTy (_aNode e') $ TyPrim TyString
     return e'
-  si <- freshId _tInfo "step"
+  si <- freshId _sInfo "step"
   sn <- trackIdNode si
   tcYieldResume .= Nothing
-  ex <- toAST _tStepExec
+  ex <- toAST _sExec
   assocAST si ex
   yr <- state (_tcYieldResume &&& set tcYieldResume Nothing)
-  Step sn ent ex <$> traverse toAST _tStepRollback <*> pure yr
+  Step sn ent ex <$> traverse toAST _sRollback <*> pure yr
 
 trackPrim :: Info -> PrimType -> PrimValue -> TC (AST Node)
 trackPrim inf pty v = do

--- a/src/Pact/Types/Persistence.hs
+++ b/src/Pact/Types/Persistence.hs
@@ -133,7 +133,7 @@ data PactExec = PactExec
   , _peExecuted :: Bool
     -- | Step that was executed or skipped
   , _peStep :: Int
-    -- | Pact id. On a new pact invocation, is copied from tx id.
+    -- | Pact id. Should be unique for a given invocation for entire network.
   , _pePactId :: PactId
     -- | Strict (in arguments) application of pact, for future step invocations.
   , _peContinuation :: PactContinuation
@@ -142,6 +142,7 @@ makeLenses ''PactExec
 instance NFData PactExec
 instance ToJSON PactExec where toJSON = lensyToJSON 3
 instance FromJSON PactExec where parseJSON = lensyParseJSON 3
+instance Pretty PactExec where pretty = viaShow
 
 
 -- | Row key type for user tables.
@@ -155,7 +156,7 @@ data Domain k v where
   KeySets :: Domain KeySetName KeySet
   Modules :: Domain ModuleName PersistModuleData
   Namespaces :: Domain NamespaceName Namespace
-  Pacts :: Domain PactId PactExec
+  Pacts :: Domain PactId (Maybe PactExec)
 
 deriving instance Eq (Domain k v)
 deriving instance Show (Domain k v)

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -218,7 +218,7 @@ makeLenses ''EvalEnv
 
 
 toPactId :: Hash -> PactId
-toPactId = PactId
+toPactId = PactId . hashToText
 
 
 -- | Dynamic storage for loaded names and modules, and current namespace.

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -26,7 +26,6 @@ module Pact.Types.Runtime
    toPactId,
    Purity(..),PureNoDb,PureReadOnly,EnvNoDb(..),EnvReadOnly(..),mkNoDbEnv,mkReadOnlyEnv,
    StackFrame(..),sfName,sfLoc,sfApp,
-   PactExec(..),peStepCount,peYield,peExecuted,pePactId,peStep,peContinuation,
    RefState(..),rsLoaded,rsLoadedModules,rsNamespace,
    EvalState(..),evalRefs,evalCallStack,evalPactExec,evalGas,evalCapabilities,
    Eval(..),runEval,runEval',
@@ -38,7 +37,6 @@ module Pact.Types.Runtime
    NamespacePolicy(..), nsPolicy,
    permissiveNamespacePolicy,
    SPVSupport(..),noSPVSupport,
-   PactContinuation(..),
    module Pact.Types.Lang,
    module Pact.Types.Util,
    module Pact.Types.Persistence,
@@ -65,7 +63,6 @@ import Pact.Types.ChainMeta
 import Pact.Types.Gas
 import Pact.Types.Lang
 import Pact.Types.Orphans ()
-import Pact.Types.PactValue
 import Pact.Types.Persistence
 import Pact.Types.Pretty
 import Pact.Types.Util
@@ -157,27 +154,6 @@ data RefStore = RefStore {
 makeLenses ''RefStore
 instance Default RefStore where def = RefStore HM.empty
 
-data PactContinuation = PactContinuation
-  { _pcDef :: Def Ref
-  , _pcArgs :: [PactValue]
-  } deriving (Eq,Show)
-
--- | Result of evaluation of a 'defpact'.
-data PactExec = PactExec
-  { -- | Count of steps in pact (discovered when code is executed)
-    _peStepCount :: Int
-    -- | Yield value if invoked
-  , _peYield :: !(Maybe (ObjectMap PactValue))
-    -- | Whether step was executed (in private cases, it can be skipped)
-  , _peExecuted :: Bool
-    -- | Step that was executed or skipped
-  , _peStep :: Int
-    -- | Pact id. On a new pact invocation, is copied from tx id.
-  , _pePactId :: PactId
-    -- | Strict (in arguments) application of pact, for future step invocations.
-  , _peContinuation :: PactContinuation
-  } deriving (Eq,Show)
-makeLenses ''PactExec
 
 -- | Indicates level of db access offered in current Eval monad.
 data Purity =

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -136,14 +136,22 @@ instance AsString KeyPredBuiltins where
 keyPredBuiltins :: M.Map Name KeyPredBuiltins
 keyPredBuiltins = M.fromList $ map ((`Name` def) . asString &&& id) [minBound .. maxBound]
 
--- | Environment setup for pact execution.
+-- | Environment setup for pact execution, from ContMsg request.
 data PactStep = PactStep {
+      -- | intended step to execute
       _psStep :: !Int
+      -- | rollback
     , _psRollback :: !Bool
+      -- | pact id
     , _psPactId :: !PactId
+      -- | resume value. Note that this is only set in Repl tests and in private use cases;
+      -- in all other cases resume value comes out of PactExec.
     , _psResume :: !(Maybe (ObjectMap (Term Name)))
 } deriving (Eq,Show)
 makeLenses ''PactStep
+
+instance Pretty PactStep where
+  pretty = viaShow
 
 
 

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -70,7 +70,7 @@ module Pact.Types.Term
    tDef,tMeta,tFields,tFunTypes,tHash,tInfo,tGuard,
    tListType,tList,tLiteral,tModuleBody,tModuleDef,tModule,tUse,
    tNativeDocs,tNativeFun,tNativeName,tNativeExamples,tNativeTopLevelOnly,tObject,tSchemaName,
-   tTableName,tTableType,tVar,
+   tTableName,tTableType,tVar,tStep,
    ToTerm(..),
    toTermList,toTObject,toTObjectMap,toTList,toTListV,
    typeof,typeof',guardTypeOf,
@@ -342,6 +342,10 @@ type Ref = Ref' (Term Name)
 instance Pretty d => Pretty (Ref' d) where
   pretty (Direct tm) = pretty tm
   pretty (Ref tm)    = pretty tm
+
+instance HasInfo n => HasInfo (Ref' n) where
+  getInfo (Direct d) = getInfo d
+  getInfo (Ref r) = getInfo r
 
 -- | Gas compute cost unit.
 newtype Gas = Gas Int64

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -64,12 +64,13 @@ module Pact.Types.Term
    ObjectMap(..),objectMapToListWith,
    Object(..),oObject,oObjectType,oInfo,oKeyOrder,
    FieldKey(..),
+   Step(..),sEntity,sExec,sRollback,sInfo,
    Term(..),
    tApp,tBindBody,tBindPairs,tBindType,tConstArg,tConstVal,
    tDef,tMeta,tFields,tFunTypes,tHash,tInfo,tGuard,
    tListType,tList,tLiteral,tModuleBody,tModuleDef,tModule,tUse,
    tNativeDocs,tNativeFun,tNativeName,tNativeExamples,tNativeTopLevelOnly,tObject,tSchemaName,
-   tStepEntity,tStepExec,tStepRollback,tTableName,tTableType,tVar,
+   tTableName,tTableType,tVar,
    ToTerm(..),
    toTermList,toTObject,toTObjectMap,toTList,toTListV,
    typeof,typeof',guardTypeOf,
@@ -198,9 +199,8 @@ newtype KeySetName = KeySetName Text
 
 instance Pretty KeySetName where pretty (KeySetName s) = "'" <> pretty s
 
-newtype PactId = PactId Hash
-    deriving (Eq,Ord,Show,Pretty,AsString,FromJSON,ToJSON,Generic,NFData)
-instance ToTerm PactId where toTerm (PactId p) = (tLit . LString) (hashToText p)
+newtype PactId = PactId Text
+    deriving (Eq,Ord,Show,Pretty,AsString,IsString,FromJSON,ToJSON,Generic,NFData,ToTerm)
 
 data PactGuard = PactGuard
   { _pgPactId :: !PactId
@@ -779,6 +779,34 @@ instance (ToJSON n, FromJSON n) => FromJSON (Object n) where
   parseJSON = withObject "Object" $ \o ->
     Object <$> o .: "obj" <*> o .: "type" <*> o .:? "keyorder" <*> o .: "i"
 
+
+
+data Step n = Step
+  { _sEntity :: !(Maybe n)
+  , _sExec :: !n
+  , _sRollback :: !(Maybe n)
+  , _sInfo :: !Info
+  } deriving (Eq,Show,Generic,Functor,Foldable,Traversable)
+instance NFData n => NFData (Step n)
+instance ToJSON n => ToJSON (Step n) where toJSON = lensyToJSON 2
+instance FromJSON n => FromJSON (Step n) where parseJSON = lensyParseJSON 2
+instance HasInfo (Step n) where getInfo = _sInfo
+instance Pretty n => Pretty (Step n) where
+  pretty = \case
+    Step mEntity exec Nothing _i -> parensSep $
+      [ "step"
+      ] ++ maybe [] (\entity -> [pretty entity]) mEntity ++
+      [ pretty exec
+      ]
+    Step mEntity exec (Just rollback) _i -> parensSep $
+      [ "step-with-rollback"
+      ] ++ maybe [] (\entity -> [pretty entity]) mEntity ++
+      [ pretty exec
+      , pretty rollback
+      ]
+
+
+
 -- | Pact evaluable term.
 data Term n =
     TModule {
@@ -849,9 +877,7 @@ data Term n =
     , _tInfo :: Info
     } |
     TStep {
-      _tStepEntity :: !(Maybe (Term n))
-    , _tStepExec :: !(Term n)
-    , _tStepRollback :: !(Maybe (Term n))
+      _tStep :: Step (Term n)
     , _tInfo :: !Info
     } |
     TTable {
@@ -863,6 +889,7 @@ data Term n =
     , _tInfo :: !Info
     }
     deriving (Functor,Foldable,Traversable,Generic)
+
 
 deriving instance Show n => Show (Term n)
 deriving instance Eq n => Eq (Term n)
@@ -921,17 +948,7 @@ instance Pretty n => Pretty (Term n) where
     TLiteral l _ -> annotate Val $ pretty l
     TGuard k _ -> pretty k
     TUse u _ -> pretty u
-    TStep mEntity exec Nothing _i -> parensSep $
-      [ "step"
-      ] ++ maybe [] (\entity -> [pretty entity]) mEntity ++
-      [ pretty exec
-      ]
-    TStep mEntity exec (Just rollback) _i -> parensSep $
-      [ "step-with-rollback"
-      ] ++ maybe [] (\entity -> [pretty entity]) mEntity ++
-      [ pretty exec
-      , pretty rollback
-      ]
+    TStep s _i -> pretty s
     TSchema{..} -> parensSep
       [ "defschema"
       , pretty _tSchemaName
@@ -963,7 +980,7 @@ instance Monad Term where
     TLiteral l i >>= _ = TLiteral l i
     TGuard k i >>= _ = TGuard k i
     TUse u i >>= _ = TUse u i
-    TStep ent e r i >>= f = TStep (fmap (>>= f) ent) (e >>= f) (fmap (>>= f) r) i
+    TStep (Step ent e r si) i >>= f = TStep (Step (fmap (>>= f) ent) (e >>= f) (fmap (>>= f) r) si) i
     TSchema {..} >>= f = TSchema _tSchemaName _tModule _tMeta (fmap (fmap (>>= f)) _tFields) _tInfo
     TTable {..} >>= f = TTable _tTableName _tModule _tHash (fmap (>>= f) _tTableType) _tMeta _tInfo
 
@@ -987,7 +1004,7 @@ termCodec = Codec enc dec
       TLiteral l i -> ob [literal .= l, inf i]
       TGuard k i -> ob [guard' .= k, inf i]
       TUse u _i -> toJSON u
-      TStep ent e r i -> ob [entity .= ent, exec .= e, rollback .= r, inf i]
+      TStep s _i -> toJSON s
       TSchema sn smod smeta sfs i ->
         ob [ schemaName .= sn, modName .= smod, meta .= smeta, fields .= sfs, inf i ]
       TTable tn tmod th tty tmeta i ->
@@ -1012,7 +1029,7 @@ termCodec = Codec enc dec
         <|> wo "Literal" (\o -> TLiteral <$> o .: literal <*> inf' o)
         <|> wo "Guard" (\o -> TGuard <$> o .: guard' <*> inf' o)
         <|> parseWithInfo TUse
-        <|> wo "Step" (\o -> TStep <$> o .: entity <*> o .: exec <*> o .: rollback <*> inf' o)
+        <|> parseWithInfo TStep
         <|> wo "Schema"
             (\o -> TSchema <$>  o .: schemaName <*> o .: modName <*> o .: meta <*> o .: fields <*> inf' o )
         <|> wo "Table"
@@ -1041,9 +1058,6 @@ termCodec = Codec enc dec
     pairs = "pairs"
     literal = "lit"
     guard' = "guard"
-    entity = "ent"
-    exec = "exec"
-    rollback = "rb"
     schemaName = "name"
     fields = "fields"
     tblName = "name"
@@ -1170,6 +1184,7 @@ makeLenses ''ModuleName
 makePrisms ''DefType
 makeLenses ''Object
 makeLenses ''BindPair
+makeLenses ''Step
 
 deriveEq1 ''Term
 deriveEq1 ''BindPair
@@ -1182,6 +1197,7 @@ deriveEq1 ''Module
 deriveEq1 ''Governance
 deriveEq1 ''ObjectMap
 deriveEq1 ''Object
+deriveEq1 ''Step
 
 deriveShow1 ''Term
 deriveShow1 ''BindPair
@@ -1194,6 +1210,7 @@ deriveShow1 ''Def
 deriveShow1 ''ModuleDef
 deriveShow1 ''Module
 deriveShow1 ''Governance
+deriveShow1 ''Step
 
 -- | Demonstrate Term/Bound JSON marshalling with nested bound and free vars.
 _roundtripJSON :: String

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -51,7 +51,7 @@ import qualified Data.Set as S
 import Control.Monad.State
 import Data.Foldable
 
-import Pact.Types.Lang hiding (App,Object)
+import Pact.Types.Lang hiding (App,Object,Step)
 import Pact.Types.Pretty
 import Pact.Types.Native
 

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -232,7 +232,7 @@ testPactRollback mgr = before_ flushDb $ after_ flushDb $ do
       testRollbackErr mgr
 
   context "when trying to rollback a step without a rollback function" $
-    it "outputs that no rollback function exists for step and deletes pact from state" $
+    it "outputs a rollback failure and doesn't change the pact's state" $
       testNoRollbackFunc mgr
 
 

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -10,6 +10,7 @@ import Data.Aeson
 import qualified Network.HTTP.Client as HTTP
 import Data.Default (def)
 import Data.Decimal
+import Control.Monad.Reader
 
 import Pact.ApiReq
 import Pact.Types.API
@@ -21,12 +22,21 @@ import qualified Data.Text as T
 
 ----- UTILS ------
 
-shouldMatch :: HM.HashMap RequestKey ApiResult -> [ApiResultCheck] -> Expectation
-shouldMatch results checks = mapM_ match checks
-  where match ApiResultCheck{..} = do
+shouldMatch' :: HasCallStack => ApiResultCheck -> HM.HashMap RequestKey ApiResult -> Expectation
+shouldMatch' ApiResultCheck{..} results = do
           let apiRes = HM.lookup _arcReqKey results
           checkResult _arcIsFailure _arcExpect apiRes
 
+succeedsWith :: HasCallStack => Command Text -> Maybe Value ->
+                ReaderT (HM.HashMap RequestKey ApiResult) IO ()
+succeedsWith cmd r = ask >>= liftIO . shouldMatch' (makeCheck cmd False r)
+
+failsWith :: HasCallStack => Command Text -> Maybe Value ->
+             ReaderT (HM.HashMap RequestKey ApiResult) IO ()
+failsWith cmd r = ask >>= liftIO . shouldMatch' (makeCheck cmd True r)
+
+runResults :: r -> ReaderT r m a -> m a
+runResults rs act = runReaderT act rs
 
 makeExecCmd :: SomeKeyPair -> String -> IO (Command Text)
 makeExecCmd keyPairs code =
@@ -46,8 +56,8 @@ getPactId cmd = toPactId hsh
 pactIdNotFoundMsg :: Command Text -> Maybe Value
 pactIdNotFoundMsg cmd = (Just . String) escaped
   where txtPact = asString (getPactId cmd)
-        escaped = "applyContinuation: pact ID not found: PactId "
-                  <> "\"" <> txtPact <> "\""
+        escaped = ": Failure: resumePact: pact completed: " <> txtPact
+
 
 
 ---- TESTS -----
@@ -71,11 +81,10 @@ testNestedPacts mgr = before_ flushDb $ after_ flushDb $
     nestedExecPactCmd <- makeExecCmdWith ("(nestedPact.tester)" ++ " (nestedPact.tester)")
     allResults <- runAll mgr [moduleCmd, nestedExecPactCmd]
 
-    let allChecks = [makeCheck moduleCmd False Nothing,
-                     makeCheck nestedExecPactCmd True
-                      (Just "(defpact tester ()   (step \"st...: Failure: Nested pact execution, aborting")]
-
-    allResults `shouldMatch` allChecks
+    runResults allResults $ do
+      moduleCmd `succeedsWith`  Nothing
+      nestedExecPactCmd `failsWith`
+        (Just "(nestedPact.tester): Failure: Multiple or nested pact exec found")
 
 
 -- CONTINUATIONS TESTS
@@ -116,7 +125,7 @@ testCorrectNextStep :: HTTP.Manager -> Expectation
 testCorrectNextStep mgr = do
   let moduleName = "testCorrectNextStep"
   adminKeys <- genKeysEth
-  
+
   let makeExecCmdWith = makeExecCmd adminKeys
   moduleCmd       <- makeExecCmdWith (T.unpack (threeStepPactCode moduleName))
   executePactCmd  <- makeExecCmdWith ("(" ++ moduleName ++ ".tester)")
@@ -126,21 +135,20 @@ testCorrectNextStep mgr = do
   checkStateCmd   <- makeContCmdWith 1 "test4"
   allResults      <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd, checkStateCmd]
 
-  let moduleCheck       = makeCheck moduleCmd False Nothing
-      executePactCheck  = makeCheck executePactCmd False $ Just "step 0"
-      contNextStepCheck = makeCheck contNextStepCmd False $ Just "step 1"
-      checkStateCheck   = makeCheck checkStateCmd True
-                          (Just "Invalid continuation step value: Received 1 but expected 2")
-      allChecks         = [moduleCheck, executePactCheck, contNextStepCheck, checkStateCheck]
+  runResults allResults $ do
+    moduleCmd `succeedsWith`  Nothing
+    executePactCmd `succeedsWith` Just "step 0"
+    contNextStepCmd `succeedsWith` Just "step 1"
+    checkStateCmd `failsWith`
+      (Just ": Failure: resumePactExec: exec step mismatch with context: (1, 1)")
 
-  allResults `shouldMatch` allChecks
 
 
 testIncorrectNextStep :: HTTP.Manager -> Expectation
 testIncorrectNextStep mgr = do
   let moduleName = "testIncorrectNextStep"
   adminKeys <- genKeys
-  
+
   let makeExecCmdWith = makeExecCmd adminKeys
   moduleCmd         <- makeExecCmdWith (T.unpack (threeStepPactCode moduleName))
   executePactCmd    <- makeExecCmdWith ("(" ++ moduleName ++ ".tester)")
@@ -150,21 +158,19 @@ testIncorrectNextStep mgr = do
   checkStateCmd     <- makeContCmdWith 1 "test4"
   allResults        <- runAll mgr [moduleCmd, executePactCmd, incorrectStepCmd, checkStateCmd]
 
-  let moduleCheck        = makeCheck moduleCmd False Nothing
-      executePactCheck   = makeCheck executePactCmd False $ Just "step 0"
-      incorrectStepCheck = makeCheck incorrectStepCmd True
-                           (Just "Invalid continuation step value: Received 2 but expected 1")
-      checkStateCheck    = makeCheck checkStateCmd False $ Just "step 1"
-      allChecks          = [moduleCheck, executePactCheck, incorrectStepCheck, checkStateCheck]
-
-  allResults `shouldMatch` allChecks
+  runResults allResults $ do
+    moduleCmd `succeedsWith`  Nothing
+    executePactCmd `succeedsWith` Just "step 0"
+    incorrectStepCmd `failsWith`
+      (Just ": Failure: resumePactExec: exec step mismatch with context: (2, 0)")
+    checkStateCmd `succeedsWith` Just "step 1"
 
 
 testLastStep :: HTTP.Manager -> Expectation
 testLastStep mgr = do
   let moduleName = "testLastStep"
   adminKeys <- genKeys
-  
+
   let makeExecCmdWith = makeExecCmd adminKeys
   moduleCmd        <- makeExecCmdWith (T.unpack (threeStepPactCode moduleName))
   executePactCmd   <- makeExecCmdWith ("(" ++ moduleName ++ ".tester)")
@@ -176,24 +182,21 @@ testLastStep mgr = do
   allResults       <- runAll mgr [moduleCmd, executePactCmd, contNextStep1Cmd,
                               contNextStep2Cmd, checkStateCmd]
 
+  runResults allResults $ do
+    moduleCmd `succeedsWith`  Nothing
+    executePactCmd `succeedsWith` Just "step 0"
+    contNextStep1Cmd `succeedsWith` Just "step 1"
+    contNextStep2Cmd `succeedsWith` Just "step 2"
+    checkStateCmd `failsWith`
+      pactIdNotFoundMsg executePactCmd
 
-  let moduleCheck        = makeCheck moduleCmd False Nothing
-      executePactCheck   = makeCheck executePactCmd False $ Just "step 0"
-      contNextStep1Check = makeCheck contNextStep1Cmd False $ Just "step 1"
-      contNextStep2Check = makeCheck contNextStep2Cmd False $ Just "step 2"
-      checkStateCheck    = makeCheck checkStateCmd True $
-                           pactIdNotFoundMsg executePactCmd
-      allChecks          = [moduleCheck, executePactCheck, contNextStep1Check,
-                            contNextStep2Check, checkStateCheck]
-
-  allResults `shouldMatch` allChecks
 
 
 testErrStep :: HTTP.Manager -> Expectation
 testErrStep mgr = do
   let moduleName = "testErrStep"
   adminKeys <- genKeys
-  
+
   let makeExecCmdWith = makeExecCmd adminKeys
   moduleCmd        <- makeExecCmdWith (T.unpack (errorStepPactCode moduleName))
   executePactCmd   <- makeExecCmdWith ("(" ++ moduleName ++ ".tester)")
@@ -203,14 +206,12 @@ testErrStep mgr = do
   checkStateCmd    <- makeContCmdWith 2 "test4"
   allResults       <- runAll mgr [moduleCmd, executePactCmd, contErrStepCmd, checkStateCmd]
 
-  let moduleCheck        = makeCheck moduleCmd False Nothing
-      executePactCheck   = makeCheck executePactCmd False $ Just "step 0"
-      contErrStepCheck   = makeCheck contErrStepCmd True Nothing
-      checkStateCheck    = makeCheck checkStateCmd True
-                           (Just "Invalid continuation step value: Received 2 but expected 1")
-      allChecks          = [moduleCheck, executePactCheck, contErrStepCheck, checkStateCheck]
-
-  allResults `shouldMatch` allChecks
+  runResults allResults $ do
+    moduleCmd `succeedsWith`  Nothing
+    executePactCmd `succeedsWith` Just "step 0"
+    contErrStepCmd `failsWith`  Nothing
+    checkStateCmd `failsWith`
+      (Just ": Failure: resumePactExec: exec step mismatch with context: (2, 0)")
 
 
 
@@ -252,16 +253,13 @@ testCorrectRollbackStep mgr = do
   allResults      <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd,
                              rollbackStepCmd, checkStateCmd]
 
-  let moduleCheck       = makeCheck moduleCmd False Nothing
-      executePactCheck  = makeCheck executePactCmd False $ Just "step 0"
-      contNextStepCheck = makeCheck contNextStepCmd False $ Just "step 1"
-      rollbackStepCheck = makeCheck rollbackStepCmd False $ Just "rollback 1"
-      checkStateCheck   = makeCheck checkStateCmd True $
-                          pactIdNotFoundMsg executePactCmd
-      allChecks         = [moduleCheck, executePactCheck, contNextStepCheck,
-                           rollbackStepCheck, checkStateCheck]
-
-  allResults `shouldMatch` allChecks
+  runResults allResults $ do
+    moduleCmd `succeedsWith`  Nothing
+    executePactCmd `succeedsWith` Just "step 0"
+    contNextStepCmd `succeedsWith` Just "step 1"
+    rollbackStepCmd `succeedsWith` Just "rollback 1"
+    checkStateCmd `failsWith`
+      pactIdNotFoundMsg executePactCmd
 
 
 testIncorrectRollbackStep :: HTTP.Manager -> Expectation
@@ -281,16 +279,13 @@ testIncorrectRollbackStep mgr = do
   allResults      <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd,
                              incorrectRbCmd, checkStateCmd]
 
-  let moduleCheck       = makeCheck moduleCmd False Nothing
-      executePactCheck  = makeCheck executePactCmd False $ Just "step 0"
-      contNextStepCheck = makeCheck contNextStepCmd False $ Just "step 1"
-      incorrectRbCheck  = makeCheck incorrectRbCmd True
-                          (Just "Invalid rollback step value: Received 2 but expected 1")
-      checkStateCheck   = makeCheck checkStateCmd False $ Just "step 2"
-      allChecks         = [moduleCheck, executePactCheck, contNextStepCheck,
-                           incorrectRbCheck, checkStateCheck]
-
-  allResults `shouldMatch` allChecks
+  runResults allResults $ do
+    moduleCmd `succeedsWith`  Nothing
+    executePactCmd `succeedsWith` Just "step 0"
+    contNextStepCmd `succeedsWith` Just "step 1"
+    incorrectRbCmd `failsWith`
+      (Just ": Failure: resumePactExec: rollback step mismatch with context: (2, 1)")
+    checkStateCmd `succeedsWith` Just "step 2"
 
 
 testRollbackErr :: HTTP.Manager -> Expectation
@@ -310,15 +305,12 @@ testRollbackErr mgr = do
   allResults       <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd,
                               rollbackErrCmd, checkStateCmd]
 
-  let moduleCheck        = makeCheck moduleCmd False Nothing
-      executePactCheck   = makeCheck executePactCmd False $ Just "step 0"
-      contNextStepCheck  = makeCheck contNextStepCmd False $ Just "step 1"
-      rollbackErrCheck   = makeCheck rollbackErrCmd True Nothing
-      checkStateCheck    = makeCheck checkStateCmd False $ Just "step 2"
-      allChecks          = [moduleCheck, executePactCheck, contNextStepCheck,
-                            rollbackErrCheck, checkStateCheck]
-
-  allResults `shouldMatch` allChecks
+  runResults allResults $ do
+    moduleCmd `succeedsWith`  Nothing
+    executePactCmd `succeedsWith` Just "step 0"
+    contNextStepCmd `succeedsWith` Just "step 1"
+    rollbackErrCmd `failsWith`  Nothing
+    checkStateCmd `succeedsWith` Just "step 2"
 
 
 testNoRollbackFunc :: HTTP.Manager -> Expectation
@@ -338,16 +330,12 @@ testNoRollbackFunc mgr = do
   allResults       <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd,
                               noRollbackCmd, checkStateCmd]
 
-  let moduleCheck        = makeCheck moduleCmd False Nothing
-      executePactCheck   = makeCheck executePactCmd False $ Just "step 0"
-      contNextStepCheck  = makeCheck contNextStepCmd False $ Just "step 1"
-      noRollbackCheck    = makeCheck noRollbackCmd False $ Just "No rollback on step 1" -- not a failure
-      checkStateCheck    = makeCheck checkStateCmd True $
-                           pactIdNotFoundMsg executePactCmd
-      allChecks          = [moduleCheck, executePactCheck, contNextStepCheck,
-                            noRollbackCheck, checkStateCheck]
-
-  allResults `shouldMatch` allChecks
+  runResults allResults $ do
+    moduleCmd `succeedsWith`  Nothing
+    executePactCmd `succeedsWith` Just "step 0"
+    contNextStepCmd `succeedsWith` Just "step 1"
+    noRollbackCmd `failsWith` Just "(step \"step 1\")   : Failure: Rollback requested but none in step"
+    checkStateCmd `succeedsWith` Just "step 2"
 
 
 
@@ -371,7 +359,7 @@ testValidYield :: HTTP.Manager -> Expectation
 testValidYield mgr = do
   let moduleName = "testValidYield"
   adminKeys <- genKeys
-  
+
   let makeExecCmdWith = makeExecCmd adminKeys
   moduleCmd          <- makeExecCmdWith (T.unpack (pactWithYield moduleName))
   executePactCmd     <- makeExecCmdWith ("(" ++ moduleName ++ ".tester \"testing\")")
@@ -384,16 +372,13 @@ testValidYield mgr = do
   allResults         <- runAll mgr [moduleCmd, executePactCmd, resumeAndYieldCmd,
                                 resumeOnlyCmd, checkStateCmd]
 
-  let moduleCheck         = makeCheck moduleCmd False Nothing
-      executePactCheck    = makeCheck executePactCmd False $ Just "testing->Step0"
-      resumeAndYieldCheck = makeCheck resumeAndYieldCmd False $ Just "testing->Step0->Step1"
-      resumeOnlyCheck     = makeCheck resumeOnlyCmd False $ Just "testing->Step0->Step1->Step2"
-      checkStateCheck     = makeCheck checkStateCmd True $
-                            pactIdNotFoundMsg executePactCmd
-      allChecks           = [moduleCheck, executePactCheck, resumeAndYieldCheck,
-                             resumeOnlyCheck, checkStateCheck]
-
-  allResults `shouldMatch` allChecks
+  runResults allResults $ do
+    moduleCmd `succeedsWith`  Nothing
+    executePactCmd `succeedsWith` Just "testing->Step0"
+    resumeAndYieldCmd `succeedsWith` Just "testing->Step0->Step1"
+    resumeOnlyCmd `succeedsWith` Just "testing->Step0->Step1->Step2"
+    checkStateCmd `failsWith`
+      pactIdNotFoundMsg executePactCmd
 
 
 testNoYield :: HTTP.Manager -> Expectation
@@ -412,16 +397,13 @@ testNoYield mgr = do
   allResults     <- runAll mgr [moduleCmd, executePactCmd, noYieldStepCmd,
                            resumeErrCmd, checkStateCmd]
 
-  let moduleCheck      = makeCheck moduleCmd False Nothing
-      executePactCheck = makeCheck executePactCmd False $ Just "testing->Step0"
-      noYieldStepCheck = makeCheck noYieldStepCmd False $ Just "step 1 has no yield"
-      resumeErrCheck   = makeCheck resumeErrCmd True Nothing
-      checkStateCheck  = makeCheck checkStateCmd True
-                         (Just "Invalid continuation step value: Received 1 but expected 2")
-      allChecks        = [moduleCheck, executePactCheck, noYieldStepCheck,
-                         resumeErrCheck, checkStateCheck]
-
-  allResults `shouldMatch` allChecks
+  runResults allResults $ do
+    moduleCmd `succeedsWith`  Nothing
+    executePactCmd `succeedsWith` Just "testing->Step0"
+    noYieldStepCmd `succeedsWith` Just "step 1 has no yield"
+    resumeErrCmd `failsWith`  Nothing
+    checkStateCmd `failsWith`
+      (Just ": Failure: resumePactExec: exec step mismatch with context: (1, 1)")
 
 
 testResetYield :: HTTP.Manager -> Expectation
@@ -440,16 +422,13 @@ testResetYield mgr = do
   allResults       <- runAll mgr [moduleCmd, executePactCmd, yieldSameKeyCmd,
                               resumeStepCmd, checkStateCmd]
 
-  let moduleCheck       = makeCheck moduleCmd False Nothing
-      executePactCheck  = makeCheck executePactCmd False $ Just "step 0"
-      yieldSameKeyCheck = makeCheck yieldSameKeyCmd False $ Just "step 1"
-      resumeStepCheck   = makeCheck resumeStepCmd False $ Just "step 1"
-      checkStateCheck   = makeCheck checkStateCmd True $
-                          pactIdNotFoundMsg executePactCmd
-      allChecks         = [moduleCheck, executePactCheck, yieldSameKeyCheck,
-                           resumeStepCheck, checkStateCheck]
-
-  allResults `shouldMatch` allChecks
+  runResults allResults $ do
+    moduleCmd `succeedsWith`  Nothing
+    executePactCmd `succeedsWith` Just "step 0"
+    yieldSameKeyCmd `succeedsWith` Just "step 1"
+    resumeStepCmd `succeedsWith` Just "step 1"
+    checkStateCmd `failsWith`
+      pactIdNotFoundMsg executePactCmd
 
 
 
@@ -479,8 +458,9 @@ testTwoPartyEscrow mgr = before_ flushDb $ after_ flushDb $ do
       testValidEscrowFinish mgr
 
 
-twoPartyEscrow :: [Command T.Text] -> [ApiResultCheck] -> HTTP.Manager -> Expectation
-twoPartyEscrow testCmds testChecks mgr = do
+twoPartyEscrow :: [Command T.Text] -> HTTP.Manager ->
+                  ReaderT (HM.HashMap RequestKey ApiResult) IO () -> Expectation
+twoPartyEscrow testCmds mgr act = do
   let setupPath = testDir ++ "cont-scripts/setup-"
 
   (_, sysModuleCmd)  <- mkApiReq (setupPath ++ "01-system.yaml")
@@ -494,18 +474,16 @@ twoPartyEscrow testCmds testChecks mgr = do
                 : resetTimeCmd : runEscrowCmd : balanceCmd : testCmds
   allResults <- runAll mgr allCmds
 
-  let sysModuleCheck      = makeCheck sysModuleCmd False $ Just "system module loaded"
-      acctModuleCheck     = makeCheck acctModuleCmd False $ Just "TableCreated"
-      testModuleCheck     = makeCheck testModuleCmd False $ Just "test module loaded"
-      createAcctCheck     = makeCheck createAcctCmd False Nothing -- Alice should be funded with $100
-      resetTimeCheck      = makeCheck resetTimeCmd False Nothing
-      runEscrowCheck      = makeCheck runEscrowCmd False Nothing
-      balanceCheck        = makeCheck balanceCmd False $ decValue 98.00
-      allChecks           = sysModuleCheck : acctModuleCheck : testModuleCheck
-                            : createAcctCheck : resetTimeCheck : runEscrowCheck
-                            : balanceCheck : testChecks
+  runResults allResults $ do
+    sysModuleCmd `succeedsWith` Just "system module loaded"
+    acctModuleCmd `succeedsWith` Just "TableCreated"
+    testModuleCmd `succeedsWith` Just "test module loaded"
+    createAcctCmd `succeedsWith`  Nothing -- Alice should be funded with $100
+    resetTimeCmd `succeedsWith`  Nothing
+    runEscrowCmd `succeedsWith`  Nothing
+    balanceCmd `succeedsWith` decValue 98.00
+    act
 
-  allResults `shouldMatch` allChecks
 
 decValue :: Decimal -> Maybe Value
 decValue = Just . toJSON . PLiteral . LDecimal
@@ -521,11 +499,10 @@ testDebtorPreTimeoutCancel mgr = do
   let cancelMsg = T.concat ["(enforce-one         \"Cancel c...: Failure:",
                             " Tx Failed: Cancel can only be effected by",
                             " creditor, or debitor after timeout"]
-      tryCancelCheck        = makeCheck tryCancelCmd True $ Just $ String cancelMsg
-      checkStillEscrowCheck = makeCheck checkStillEscrowCmd False $ decValue 98.00
-      allChecks             = [tryCancelCheck, checkStillEscrowCheck]
+  twoPartyEscrow allCmds mgr $ do
+    tryCancelCmd `failsWith` Just (String cancelMsg)
+    checkStillEscrowCmd `succeedsWith` decValue 98.00
 
-  twoPartyEscrow allCmds allChecks mgr
 
 testDebtorPostTimeoutCancel :: HTTP.Manager -> Expectation
 testDebtorPostTimeoutCancel mgr = do
@@ -536,12 +513,11 @@ testDebtorPostTimeoutCancel mgr = do
   (_, checkStillEscrowCmd) <- mkApiReq (testPath ++ "03-balance.yaml")
   let allCmds = [setTimeCmd, tryCancelCmd, checkStillEscrowCmd]
 
-  let setTimeCheck = makeCheck setTimeCmd False Nothing
-      tryCancelCheck = makeCheck tryCancelCmd False Nothing
-      checkStillEscrowCheck = makeCheck checkStillEscrowCmd False $ decValue 100.00
-      allChecks = [setTimeCheck, tryCancelCheck, checkStillEscrowCheck]
+  twoPartyEscrow allCmds mgr $ do
+    setTimeCmd `succeedsWith`  Nothing
+    tryCancelCmd `succeedsWith`  Nothing
+    checkStillEscrowCmd `succeedsWith` decValue 100.00
 
-  twoPartyEscrow allCmds allChecks mgr
 
 testCreditorCancel :: HTTP.Manager -> Expectation
 testCreditorCancel mgr = do
@@ -552,12 +528,11 @@ testCreditorCancel mgr = do
   (_, checkStillEscrowCmd) <- mkApiReq (testPath ++ "03-balance.yaml")
   let allCmds = [resetTimeCmd, credCancelCmd, checkStillEscrowCmd]
 
-  let resetTimeCheck = makeCheck resetTimeCmd False Nothing
-      credCancelCheck = makeCheck credCancelCmd False Nothing
-      checkStillEscrowCheck = makeCheck checkStillEscrowCmd False $ decValue 100.00
-      allChecks = [resetTimeCheck, credCancelCheck, checkStillEscrowCheck]
+  twoPartyEscrow allCmds mgr $ do
+    resetTimeCmd `succeedsWith`  Nothing
+    credCancelCmd `succeedsWith`  Nothing
+    checkStillEscrowCmd `succeedsWith` decValue 100.00
 
-  twoPartyEscrow allCmds allChecks mgr
 
 testFinishAlone :: HTTP.Manager -> Expectation
 testFinishAlone mgr = do
@@ -568,23 +543,22 @@ testFinishAlone mgr = do
   (_, tryDebAloneCmd)  <- mkApiReq (testPathDeb ++ "01-cont.yaml")
   let allCmds = [tryCredAloneCmd, tryDebAloneCmd]
 
-  let tryCredAloneCheck = makeCheck tryCredAloneCmd True
+  twoPartyEscrow allCmds mgr $ do
+    tryCredAloneCmd `failsWith`
                           (Just "(enforce-guard g): Failure: Tx Failed: Keyset failure (keys-all)")
-      tryDebAloneCheck  = makeCheck tryDebAloneCmd True
+    tryDebAloneCmd `failsWith`
                           (Just "(enforce-guard g): Failure: Tx Failed: Keyset failure (keys-all)")
-      allChecks         = [tryCredAloneCheck, tryDebAloneCheck]
 
-  twoPartyEscrow allCmds allChecks mgr
 
 testPriceNegUp :: HTTP.Manager -> Expectation
 testPriceNegUp mgr = do
   let testPath = testDir ++ "cont-scripts/fail-both-price-up-"
 
   (_, tryNegUpCmd) <- mkApiReq (testPath ++ "01-cont.yaml")
-  let tryNegUpCheck = makeCheck tryNegUpCmd True
+  twoPartyEscrow [tryNegUpCmd] mgr $ do
+    tryNegUpCmd `failsWith`
                       (Just "(enforce (>= escrow-amount pri...: Failure: Tx Failed: Price cannot negotiate up")
 
-  twoPartyEscrow [tryNegUpCmd] [tryNegUpCheck] mgr
 
 testValidEscrowFinish :: HTTP.Manager -> Expectation
 testValidEscrowFinish mgr = do
@@ -595,10 +569,8 @@ testValidEscrowFinish mgr = do
   (_, debBalanceCmd)  <- mkApiReq (testPath ++ "03-deb-balance.yaml")
   let allCmds = [tryNegDownCmd, credBalanceCmd, debBalanceCmd]
 
-  let tryNegDownCheck  = makeCheck tryNegDownCmd False
+  twoPartyEscrow allCmds mgr $ do
+    tryNegDownCmd `succeedsWith`
                          (Just "Escrow completed with 1.75 paid and 0.25 refunded")
-      credBalanceCheck = makeCheck credBalanceCmd False $ decValue 1.75
-      debBalanceCheck  = makeCheck debBalanceCmd False $ decValue 98.25
-      allChecks        = [tryNegDownCheck, credBalanceCheck, debBalanceCheck]
-
-  twoPartyEscrow allCmds allChecks mgr
+    credBalanceCmd `succeedsWith` decValue 1.75
+    debBalanceCmd `succeedsWith` decValue 98.25

--- a/tests/Utils/TestRunner.hs
+++ b/tests/Utils/TestRunner.hs
@@ -164,7 +164,7 @@ formatPubKeyForCmd kp = toB16JSON $ formatPublicKey kp
 makeCheck :: Command T.Text -> Bool -> Maybe Value -> ApiResultCheck
 makeCheck c@Command{..} isFailure expect = ApiResultCheck (cmdToRequestKey c) isFailure expect
 
-checkResult :: Bool -> Maybe Value -> Maybe ApiResult -> Expectation
+checkResult :: HasCallStack => Bool -> Maybe Value -> Maybe ApiResult -> Expectation
 checkResult isFailure expect result =
   case result of
     Nothing -> expectationFailure $ show result ++ " should be Just ApiResult"
@@ -175,21 +175,21 @@ checkResult isFailure expect result =
         _ -> expectationFailure $ show cmdRes ++ " should be Object"
 
 
-fieldShouldBe :: (T.Text,HM.HashMap T.Text Value) -> Maybe Value -> Expectation
+fieldShouldBe :: HasCallStack => (T.Text,HM.HashMap T.Text Value) -> Maybe Value -> Expectation
 fieldShouldBe (k,m) b = do
   let a = HM.lookup k m
   unless (a == b) $
     expectationFailure $
     "Expected " ++ show b ++ ", found " ++ show a ++ " for field " ++ show k ++ " in " ++ show m
 
-checkIfSuccess :: Object -> Maybe Value -> Expectation
+checkIfSuccess :: HasCallStack => Object -> Maybe Value -> Expectation
 checkIfSuccess h Nothing =
   ("status",h) `fieldShouldBe` (Just . String . T.pack) "success"
 checkIfSuccess h (Just expect) = do
   ("status", h) `fieldShouldBe` (Just . String . T.pack) "success"
   ("data", h) `fieldShouldBe` Just (toJSON expect)
 
-checkIfFailure :: Object -> Maybe Value -> Expectation
+checkIfFailure :: HasCallStack => Object -> Maybe Value -> Expectation
 checkIfFailure h Nothing =
   ("status", h) `fieldShouldBe` (Just . String . T.pack) "failure"
 checkIfFailure h (Just expect) = do

--- a/tests/pact/yield.repl
+++ b/tests/pact/yield.repl
@@ -29,13 +29,20 @@
 (expect "step 1 executes" "stu->A->B" (continue-pact 1))
 
 ;; test 1 skips A
+(pact-state true)
+(tester "stu")
 (env-entity "A")
 (continue-pact 1)
 (expect "step 1 skips A" false (at "executed" (pact-state)))
 
 ;; test rollback
-(expect "step 1 rollback executes" "rollback-a" (continue-pact 0 true))
+(pact-state true)
+(tester "stu")
+(expect "step 0 rollback executes" "rollback-a" (continue-pact 0 true))
+
 ;; test no rollback for B
+(pact-state true)
+(tester "stu")
 (env-entity "B")
 (continue-pact 0 true)
 (expect "step 0 rollback skips B" false (at "executed" (pact-state)))


### PR DESCRIPTION
Thus completes the march to put all pact state in the backend.
- Defpact logic is now housed in `Pact.Eval.resumePact` and `Pact.Eval.applyPact`, not in PactService.
- DB rollbacks now affect pact state (mainly affects repl scripts like `accounts.repl`)
- `PactContinuationSpec` has been overhauled for better callstack reporting and individualized assertions. @LindaOrtega please note comment on line 344 or so.