### PR TITLE
Allow systable access in pure mode; reduce enforcements to pure-mode

### DIFF
--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -33,7 +33,7 @@ module Pact.Eval
     ,enforceKeySet,enforceKeySetName
     ,checkUserType
     ,deref
-    ,runPure,runReadOnly,Purity
+    ,runSysOnly,runReadOnly,Purity
     ,liftTerm,apply
     ,preGas
     ,acquireCapability,acquireModuleAdmin,enforceModuleAdmin
@@ -93,12 +93,11 @@ evalCommitTx i = do
 enforceKeySetName :: Info -> KeySetName -> Eval e ()
 enforceKeySetName mi mksn = do
   ks <- maybe (evalError mi $ "No such keyset: " <> pretty mksn) return =<< readRow mi KeySets mksn
-  runPure $ enforceKeySet mi (Just mksn) ks
+  runSysOnly $ enforceKeySet mi (Just mksn) ks
 {-# INLINE enforceKeySetName #-}
 
 -- | Enforce keyset against environment.
-enforceKeySet :: PureNoDb e => Info ->
-             Maybe KeySetName -> KeySet -> Eval e ()
+enforceKeySet :: PureSysOnly e => Info -> Maybe KeySetName -> KeySet -> Eval e ()
 enforceKeySet i ksn KeySet{..} = do
   sigs <- view eeMsgSigs
   let count = length _ksKeys
@@ -427,7 +426,7 @@ evaluateDefs info defs = do
                            & traverse . _3 %~ (SomeDoc . prettyList))
   let dresolve ds (d,dn,_) = HM.insert dn (Ref $ unify ds <$> d) ds
       unifiedDefs = foldl dresolve HM.empty sortedDefs
-  traverse (runPure . evalConsts) unifiedDefs
+  traverse (runSysOnly . evalConsts) unifiedDefs
 
 mkSomeDoc :: (Pretty a, Pretty b) => Either a b -> SomeDoc
 mkSomeDoc = either (SomeDoc . pretty) (SomeDoc . pretty)
@@ -546,7 +545,7 @@ unify :: HM.HashMap Text Ref -> Either Text Ref -> Ref
 unify _ (Right r) = r
 unify m (Left t) = m HM.! t
 
-evalConsts :: PureNoDb e => Ref -> Eval e Ref
+evalConsts :: PureSysOnly e => Ref -> Eval e Ref
 evalConsts rr@(Ref r) = case r of
   TConst {..} -> case _tConstVal of
     CVRaw raw -> do
@@ -845,14 +844,14 @@ checkUserType partial i (ObjectMap ps) (TyUser tu@TSchema {..}) = do
   return $ TySchema TyObject (TyUser tu) partial
 checkUserType _ i _ t = evalError i $ "Invalid reference in user type: " <> pretty t
 
-runPure :: Eval (EnvNoDb e) a -> Eval e a
-runPure action = ask >>= \env -> case _eePurity env of
-  PNoDb -> unsafeCoerce action -- yuck. would love safer coercion here
-  _ -> mkNoDbEnv env >>= runWithEnv action
+runSysOnly :: Eval (EnvSysOnly e) a -> Eval e a
+runSysOnly action = ask >>= \env -> case _eePurity env of
+  PSysOnly -> unsafeCoerce action -- yuck. would love safer coercion here
+  _ -> mkSysOnlyEnv env >>= runWithEnv action
 
 runReadOnly :: HasInfo i => i -> Eval (EnvReadOnly e) a -> Eval e a
 runReadOnly i action = ask >>= \env -> case _eePurity env of
-  PNoDb -> evalError' i "internal error: attempting db read in pure context"
+  PSysOnly -> evalError' i "internal error: attempting db read in sys-only context"
   PReadOnly -> unsafeCoerce action -- yuck. would love safer coercion here
   _ -> mkReadOnlyEnv env >>= runWithEnv action
 

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -93,12 +93,11 @@ evalCommitTx i = do
 enforceKeySetName :: Info -> KeySetName -> Eval e ()
 enforceKeySetName mi mksn = do
   ks <- maybe (evalError mi $ "No such keyset: " <> pretty mksn) return =<< readRow mi KeySets mksn
-  runReadOnly mi $ enforceKeySet mi (Just mksn) ks
+  runPure $ enforceKeySet mi (Just mksn) ks
 {-# INLINE enforceKeySetName #-}
 
 -- | Enforce keyset against environment.
--- Runs as "read only" as custom predicate might require module load.
-enforceKeySet :: PureReadOnly e => Info ->
+enforceKeySet :: PureNoDb e => Info ->
              Maybe KeySetName -> KeySet -> Eval e ()
 enforceKeySet i ksn KeySet{..} = do
   sigs <- view eeMsgSigs

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -117,7 +117,7 @@ enforceDef = defNative "enforce" enforce
   where
 
     enforce :: NativeFun e
-    enforce i as = runPure $ gasUnreduced i as $ mapM reduce as >>= enforce' i
+    enforce i as = runSysOnly $ gasUnreduced i as $ mapM reduce as >>= enforce' i
 
     enforce' :: RNativeFun e
     enforce' i [TLiteral (LBool b') _,TLitString msg]

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -161,7 +161,7 @@ enforceGuardDef dn =
 
 enforceGuard :: FunApp -> Guard -> Eval e ()
 enforceGuard i g = case g of
-  GKeySet k -> runReadOnly i $ enforceKeySet (_faInfo i) Nothing k
+  GKeySet k -> runPure $ enforceKeySet (_faInfo i) Nothing k
   GKeySetRef n -> enforceKeySetName (_faInfo i) n
   GPact PactGuard{..} -> do
     pid <- getPactId i
@@ -172,8 +172,8 @@ enforceGuard i g = case g of
     case m of
       MDModule Module{..} -> enforceModuleAdmin (_faInfo i) _mGovernance
       MDInterface{} -> evalError' i $ "ModuleGuard not allowed on interface: " <> pretty mg
-  GUser UserGuard{..} -> do
-    void $ runReadOnly (_faInfo i) $ evalByName _ugPredFun [TObject _ugData def] (_faInfo i)
+  GUser UserGuard{..} ->
+    void $ runPure $ evalByName _ugPredFun [TObject _ugData def] (_faInfo i)
 
 findCallingModule :: Eval e (Maybe ModuleName)
 findCallingModule = uses evalCallStack (firstOf (traverse . sfApp . _Just . _1 . faModule . _Just))

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -161,7 +161,7 @@ enforceGuardDef dn =
 
 enforceGuard :: FunApp -> Guard -> Eval e ()
 enforceGuard i g = case g of
-  GKeySet k -> runPure $ enforceKeySet (_faInfo i) Nothing k
+  GKeySet k -> runSysOnly $ enforceKeySet (_faInfo i) Nothing k
   GKeySetRef n -> enforceKeySetName (_faInfo i) n
   GPact PactGuard{..} -> do
     pid <- getPactId i
@@ -173,7 +173,7 @@ enforceGuard i g = case g of
       MDModule Module{..} -> enforceModuleAdmin (_faInfo i) _mGovernance
       MDInterface{} -> evalError' i $ "ModuleGuard not allowed on interface: " <> pretty mg
   GUser UserGuard{..} ->
-    void $ runPure $ evalByName _ugPredFun [TObject _ugData def] (_faInfo i)
+    void $ runSysOnly $ evalByName _ugPredFun [TObject _ugData def] (_faInfo i)
 
 findCallingModule :: Eval e (Maybe ModuleName)
 findCallingModule = uses evalCallStack (firstOf (traverse . sfApp . _Just . _1 . faModule . _Just))

--- a/src/Pact/Native/Keysets.hs
+++ b/src/Pact/Native/Keysets.hs
@@ -72,7 +72,7 @@ defineKeyset fi as = case as of
       case old of
         Nothing -> writeRow i Write KeySets ksn ks & success "Keyset defined"
         Just oldKs -> do
-          runPure $ enforceKeySet i (Just ksn) oldKs
+          runSysOnly $ enforceKeySet i (Just ksn) oldKs
           writeRow i Write KeySets ksn ks & success "Keyset defined"
 
 keyPred :: (Integer -> Integer -> Bool) -> RNativeFun e

--- a/src/Pact/Native/Keysets.hs
+++ b/src/Pact/Native/Keysets.hs
@@ -72,7 +72,7 @@ defineKeyset fi as = case as of
       case old of
         Nothing -> writeRow i Write KeySets ksn ks & success "Keyset defined"
         Just oldKs -> do
-          runReadOnly i $ enforceKeySet i (Just ksn) oldKs
+          runPure $ enforceKeySet i (Just ksn) oldKs
           writeRow i Write KeySets ksn ks & success "Keyset defined"
 
 keyPred :: (Integer -> Integer -> Bool) -> RNativeFun e

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -181,9 +181,9 @@ makeLenses ''PactExec
 
 -- | Indicates level of db access offered in current Eval monad.
 data Purity =
-  -- | Only access to systables.
+  -- | Read-only access to systables.
   PNoDb |
-  -- | Read-only access to module tables.
+  -- | Read-only access to systables and module tables.
   PReadOnly |
   -- | All database access allowed (normal).
   PImpure

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -12,6 +12,10 @@
   (defschema guards g:guard)
   (deftable guard-table:{guards})
 
+  (defschema int-row i:integer)
+  (deftable ints:{int-row})
+  (defschema ints-key k:string)
+
   (defschema yieldschema result:integer)
 
   (defschema guardschema key:string)
@@ -40,6 +44,14 @@
 
   (defun enforce-msg-keyset (key:object{guardschema})
     (enforce-keyset (read-keyset (at 'key key))))
+
+  ; a user guard which reads from the db, which we want to disallow.
+  (defun db-user-guard ()
+    (insert ints 'x {'i: 0})
+    (create-user-guard {'k: 'x} "read-zero-from-db"))
+  (defun read-zero-from-db (o:object{ints-key})
+    (let ((row (read ints (at 'k o))))
+      (enforce (= 0 (at 'i row)) "int wasn't zero")))
 
   (defpact test-pact-guards (id:string)
     (step (step1 id))
@@ -80,6 +92,7 @@
 )
 
 (create-table guard-table)
+(create-table ints)
 
 (commit-tx)
 
@@ -145,6 +158,8 @@
 (enforce-guard (keyset-ref-guard "k1"))
 (expect-failure "keyset ref guard k2"
                 (enforce-guard (keyset-ref-guard "k2")))
+
+(expect-failure "reading db from within user guard" (enforce-guard (db-user-guard)))
 
 (env-hash (hash "pact-guards-a-id")) ;; equivalent of pact-id
 (test-pact-guards "a")

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -45,11 +45,12 @@
   (defun enforce-msg-keyset (key:object{guardschema})
     (enforce-keyset (read-keyset (at 'key key))))
 
-  ; a user guard which reads from the db, which we want to disallow.
-  (defun db-user-guard ()
+  (defun create-bad-db-user-guard ()
+    @doc "Creates a user guard which tries to read from the DB, which is not allowed. This will fail when the guard is enforced."
+    ; this insert succeeds:
     (insert ints 'x {'i: 0})
-    (create-user-guard {'k: 'x} "read-zero-from-db"))
-  (defun read-zero-from-db (o:object{ints-key})
+    (create-user-guard {'k: 'x} "bad-user-guard-fun"))
+  (defun bad-user-guard-fun (o:object{ints-key})
     (let ((row (read ints (at 'k o))))
       (enforce (= 0 (at 'i row)) "int wasn't zero")))
 
@@ -159,7 +160,8 @@
 (expect-failure "keyset ref guard k2"
                 (enforce-guard (keyset-ref-guard "k2")))
 
-(expect-failure "reading db from within user guard" (enforce-guard (db-user-guard)))
+(let ((bad-db-user-guard (create-bad-db-user-guard)))
+  (expect-failure "reading db from within user guard" (enforce-guard bad-db-user-guard)))
 
 (env-hash (hash "pact-guards-a-id")) ;; equivalent of pact-id
 (test-pact-guards "a")

--- a/tests/pact/keysets.repl
+++ b/tests/pact/keysets.repl
@@ -21,7 +21,7 @@
   (defun test-impure-enforce ()
     (enforce (impure) "cannot impure enforce"))
 
-  (defun test-enforce-impure-keyset ()
+  (defun test-enforceks-in-enforce ()
     (enforce (enforce-keyset 'kall) "Fails with keyset"))
 
   (defun test-enforce-one ()
@@ -76,7 +76,7 @@
 
 (expect-failure "impure enforce should blow up" (test-impure-enforce))
 
-(expect-failure "keyset read in enforce is impure" (test-enforce-impure-keyset))
+(expect "permit enforce-keyset inside of enforce" true (test-enforceks-in-enforce))
 
 (expect "test enforce-one, keyset read in enforce-one ok" true (test-enforce-one))
 


### PR DESCRIPTION
Per a conversation with Stu.

Before this PR, "read-only" mode used to be necessary to read systables, and so was needed for keyset and guard enforcement. This mode also granted read-only access to user/module tables.

This change allows systable reads in "pure" mode. As a result we can reduce the access level necessary for enforcements. This is also key for user guard analysis -- user guards which can read from user tables turn out to be quite difficult to handle, and we don't currently know of any use cases which require this power.

This changeset will close #492 and #489.

edit: Also renamed "*NoDb" (aka pure) to "*SysOnly", now that this level _does_ read from the db. And changed `runPure` to `runSysOnly`