### PR TITLE
Fix trace output

### DIFF
--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -234,8 +234,10 @@ doOut ei mode a = case mode of
   _ -> return ()
   where
     plainOut = outStrLn HOut $ show $ pretty a
-    lineOut = do
-      outStrLn HErr $ renderInfo ei ++ ":Trace: " ++ show a
+    lineOut = outStrLn HErr $ renderInfo ei ++ ":Trace: " ++
+      case a of
+        TLiteral (LString t) _ -> Text.unpack t
+        _ -> show $ pretty a
 
 renderErr :: PactError -> Repl String
 renderErr a


### PR DESCRIPTION
Apparently trace output got messed up when we switched over to using `prettyprinter`.

Before:

![image](https://user-images.githubusercontent.com/5743/57953347-d3dae180-78bd-11e9-9240-7b44527906d5.png)

After:

![image](https://user-images.githubusercontent.com/5743/57953130-3f707f00-78bd-11e9-955a-05bead4ded2e.png)