### PR TITLE
CommandResult and Servant API overhaul

### DIFF
--- a/examples/accounts/scripts/run.sh
+++ b/examples/accounts/scripts/run.sh
@@ -9,22 +9,22 @@ JSON="Content-Type: application/json"
 echo ""; echo "Step 1"; echo ""
 pact -a examples/accounts/scripts/01-system.yaml | curl -H "$JSON" -d @- http://localhost:8080/api/v1/send
 sleep 1; echo ""
-curl -H "$JSON" -d '{"requestKeys":["LkaXHRpZyHd4HocYHO8v4d4rW8pITSE1ODLiraseRNo"]}' -X POST http://localhost:8080/api/v1/poll
+curl -H "$JSON" -d '{"requestKeys":["zaqnRQ0RYzxTccjtYoBvQsDo5K9mxr4TEF-HIYTi5Jo"]}' -X POST http://localhost:8080/api/v1/poll
 
 echo ""; echo "Step 2"; echo ""
 pact -a examples/accounts/scripts/02-accounts.yaml | curl -H "$JSON" -d @- http://localhost:8080/api/v1/send
 sleep 1; echo ""
-curl -H "$JSON" -d '{"requestKeys":["bctSHEz4N5Y1XQaic6eOoBmjty88HMMGfAdQLPuIGMw"]}' -X POST http://localhost:8080/api/v1/poll
+curl -H "$JSON" -d '{"requestKeys":["gx60LXLVcNlSQ4XkJUgqwqdZZ-RyaPymVVpWMspAf-Y"]}' -X POST http://localhost:8080/api/v1/poll
 
 echo ""; echo "Step 3"; echo ""
 pact -a examples/accounts/scripts/03-create.yaml | curl -H "$JSON" -d @- http://localhost:8080/api/v1/send
 sleep 1; echo ""
-curl -H "$JSON" -d '{"requestKeys":["N5xTwxAJTq6mu0aSzjny5p1FsXWiD0cpFI_QwofaVDg"]}' -X POST http://localhost:8080/api/v1/poll
+curl -H "$JSON" -d '{"requestKeys":["CgjWWeA3MBmf3GIyop2CPU7ndhPuxnXFtcGm7-STMUo"]}' -X POST http://localhost:8080/api/v1/poll
 
 echo ""; echo "Step 4"; echo ""
 pact -a examples/accounts/scripts/04-alice.yaml | curl -H "$JSON" -d @- http://localhost:8080/api/v1/send
 sleep 1; echo ""
-curl -H "$JSON" -d '{"requestKeys":["wZaF1caS607x1aAZyp-ld0P14qd0ytLcwpJPiTamtno"]}' -X POST http://localhost:8080/api/v1/poll
+curl -H "$JSON" -d '{"requestKeys":["r5L96DVwNKANAedHArQoJc9oxF3hf_EftopCsoaCuuY"]}' -X POST http://localhost:8080/api/v1/poll
 
 echo ""; echo "Step 5"; echo ""
 pact -l -a examples/accounts/scripts/05-bob.yaml | curl -H "$JSON" -d @- http://localhost:8080/api/v1/local

--- a/src-ghc/Pact/Server/ApiServer.hs
+++ b/src-ghc/Pact/Server/ApiServer.hs
@@ -25,7 +25,6 @@ module Pact.Server.ApiServer
 
 import Prelude hiding (log)
 
-import Control.Arrow (second)
 import Control.Lens
 import Control.Concurrent
 import Control.Monad.Reader
@@ -149,7 +148,7 @@ checkHistoryForResult rks = do
   liftIO $ readMVar m
 
 pollResultToReponse :: HM.HashMap RequestKey (CommandResult [TxLog Value]) -> PollResponses
-pollResultToReponse m = PollResponses $ HM.fromList $ map (second fullToHashLogCr) $ HM.toList m
+pollResultToReponse m = PollResponses $ HM.map fullToHashLogCr m
 
 fullToHashLogCr :: CommandResult [TxLog Value] -> CommandResult Hash
 fullToHashLogCr full = set crLogs hashedLogs full

--- a/src-ghc/Pact/Server/ApiServer.hs
+++ b/src-ghc/Pact/Server/ApiServer.hs
@@ -154,7 +154,8 @@ pollResultToReponse :: HM.HashMap RequestKey CommandResult -> PollResponses
 pollResultToReponse m = PollResponses $ HM.fromList $ map (second crToAr) $ HM.toList m
 
 crToAr :: CommandResult -> ApiResult
-crToAr CommandResult {..} = ApiResult (toJSON _crResult) _crTxId Nothing
+crToAr (CommandResult _ txId (Left pe) _) = ApiResult (toJSON . CommandError $ pe) txId Nothing
+crToAr (CommandResult _ txId (Right pv) _) = ApiResult (toJSON . CommandSuccess $ pv) txId Nothing
 
 log :: (MonadReader ApiEnv m, MonadIO m) => String -> m ()
 log s = view aiLog >>= \f -> liftIO (f $ "[api]: " ++ s)

--- a/src-ghc/Pact/Server/ApiServer.hs
+++ b/src-ghc/Pact/Server/ApiServer.hs
@@ -154,8 +154,7 @@ pollResultToReponse :: HM.HashMap RequestKey CommandResult -> PollResponses
 pollResultToReponse m = PollResponses $ HM.fromList $ map (second crToAr) $ HM.toList m
 
 crToAr :: CommandResult -> ApiResult
-crToAr (CommandResult _ txId (Left pe) _) = ApiResult (toJSON . CommandError $ pe) txId Nothing
-crToAr (CommandResult _ txId (Right pv) _) = ApiResult (toJSON . CommandSuccess $ pv) txId Nothing
+crToAr (CommandResult _ txId res _) = ApiResult (toJSON res) txId Nothing
 
 log :: (MonadReader ApiEnv m, MonadIO m) => String -> m ()
 log s = view aiLog >>= \f -> liftIO (f $ "[api]: " ++ s)

--- a/src-ghc/Pact/Server/History/Persistence.hs
+++ b/src-ghc/Pact/Server/History/Persistence.hs
@@ -35,6 +35,7 @@ import Pact.Types.Runtime
 import Pact.Types.SQLite
 
 import Pact.Server.History.Types
+import Pact.Types.PactValue (PactValue)
 
 hashToField :: Hash -> SType
 hashToField h = SText $ Utf8 $ BSL.toStrict $ A.encode h
@@ -44,7 +45,7 @@ hashFromField h = case A.eitherDecodeStrict' h of
   Left err -> error $ "hashFromField: unable to decode Hash from database! " ++ show err ++ " => " ++ show h
   Right v -> v
 
-crToField :: A.Value -> SType
+crToField :: Either PactError PactValue -> SType
 crToField r = SText $ Utf8 $ BSL.toStrict $ A.encode r
 
 crFromField :: RequestKey -> Maybe TxId -> ByteString -> Gas -> CommandResult

--- a/src-ghc/Pact/Server/History/Persistence.hs
+++ b/src-ghc/Pact/Server/History/Persistence.hs
@@ -27,6 +27,7 @@ import qualified Data.HashSet as HashSet
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Maybe
+import Data.Aeson (Value)
 
 import Database.SQLite3.Direct
 
@@ -44,13 +45,11 @@ hashFromField h = case A.eitherDecodeStrict' h of
   Left err -> error $ "hashFromField: unable to decode Hash from database! " ++ show err ++ " => " ++ show h
   Right v -> v
 
-crToField :: PactResult -> SType
-crToField r = SText $ Utf8 $ BSL.toStrict $ A.encode r
+crToField :: CommandResult [TxLog Value] -> SType
+crToField r = SText $ Utf8 $ BSL.toStrict $ A.encode $ A.toJSON r
 
-crFromField :: RequestKey -> Maybe TxId -> ByteString -> Gas -> CommandResult
-crFromField rk tid cr gas = CommandResult rk tid v gas
-  where
-    v = case A.eitherDecodeStrict' cr of
+crFromField :: ByteString -> CommandResult [TxLog Value]
+crFromField cr = case A.eitherDecodeStrict' cr of
       Left err -> error $ "crFromField: unable to decode CommandResult from database! " ++ show err ++ "\n" ++ show cr
       Right v' -> v'
 
@@ -110,16 +109,16 @@ sqlInsertHistoryRow =
     \, 'gas'\
     \) VALUES (?,?,?,?,?,?)"
 
-insertRow :: Statement -> (Command ByteString, CommandResult) -> IO ()
-insertRow s (Command{..},CommandResult {..}) =
+insertRow :: Statement -> (Command ByteString, CommandResult [TxLog Value]) -> IO ()
+insertRow s (Command{..},cr@CommandResult {..}) =
     execs s [hashToField (toUntypedHash _cmdHash)
             ,SInt $ fromIntegral (fromMaybe (-1) _crTxId)
             ,SText $ Utf8 _cmdPayload
-            ,crToField _crResult
+            ,crToField cr
             ,userSigsToField _cmdSigs
             ,gasToField _crGas]
 
-insertCompletedCommand :: DbEnv -> [(Command ByteString, CommandResult)] -> IO ()
+insertCompletedCommand :: DbEnv -> [(Command ByteString, CommandResult [TxLog Value])] -> IO ()
 insertCompletedCommand DbEnv{..} v = do
   let sortCmds (_,cr1) (_,cr2) = compare (_crTxId cr1) (_crTxId cr2)
   eitherToError "start insert transaction" <$> exec _conn "BEGIN TRANSACTION"
@@ -142,7 +141,7 @@ sqlSelectCompletedCommands :: Utf8
 sqlSelectCompletedCommands =
   "SELECT result,txid FROM 'main'.'pactCommands' WHERE hash=:hash LIMIT 1"
 
-selectCompletedCommands :: DbEnv -> HashSet RequestKey -> IO (HashMap RequestKey CommandResult)
+selectCompletedCommands :: DbEnv -> HashSet RequestKey -> IO (HashMap RequestKey (CommandResult [TxLog Value]))
 selectCompletedCommands e v = foldM f HashMap.empty v
   where
     f m rk = do
@@ -150,8 +149,8 @@ selectCompletedCommands e v = foldM f HashMap.empty v
       if null rs
       then return m
       else case head rs of
-          [SText (Utf8 cr),SInt tid, SInt g] ->
-            return $ HashMap.insert rk (crFromField rk (if tid < 0 then Nothing else Just (fromIntegral tid)) cr (Gas g)) m
+          [SText (Utf8 cr),SInt _, SInt _] ->
+            return $ HashMap.insert rk (crFromField cr) m
           r -> dbError $ "Invalid result from query: " ++ show r
 
 sqlSelectAllCommands :: Utf8

--- a/src-ghc/Pact/Server/History/Persistence.hs
+++ b/src-ghc/Pact/Server/History/Persistence.hs
@@ -35,7 +35,6 @@ import Pact.Types.Runtime
 import Pact.Types.SQLite
 
 import Pact.Server.History.Types
-import Pact.Types.PactValue (PactValue)
 
 hashToField :: Hash -> SType
 hashToField h = SText $ Utf8 $ BSL.toStrict $ A.encode h
@@ -45,7 +44,7 @@ hashFromField h = case A.eitherDecodeStrict' h of
   Left err -> error $ "hashFromField: unable to decode Hash from database! " ++ show err ++ " => " ++ show h
   Right v -> v
 
-crToField :: Either PactError PactValue -> SType
+crToField :: PactResult -> SType
 crToField r = SText $ Utf8 $ BSL.toStrict $ A.encode r
 
 crFromField :: RequestKey -> Maybe TxId -> ByteString -> Gas -> CommandResult

--- a/src-ghc/Pact/Server/History/Service.hs
+++ b/src-ghc/Pact/Server/History/Service.hs
@@ -243,7 +243,7 @@ _go :: HistoryService ()
 _go = do
   addNewKeys [Command "" [] initialHash]
   let rq = RequestKey pactInitialHash
-      res = Left $ PactError TxFailure def def . viaShow $ ("some error message" :: String)
+      res = PactResult $ Left $ PactError TxFailure def def . viaShow $ ("some error message" :: String)
   updateExistingKeys (HashMap.fromList [(rq, CommandResult rq Nothing res (Gas 0))])
   mv <- liftIO $ newEmptyMVar
   queryForResults (HashSet.singleton rq, mv)

--- a/src-ghc/Pact/Server/History/Service.hs
+++ b/src-ghc/Pact/Server/History/Service.hs
@@ -18,7 +18,6 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.RWS.Strict
 import Control.Concurrent.MVar
 import System.Directory
-import Data.Aeson (Value(Null))
 
 import Data.ByteString (ByteString)
 import Data.HashSet (HashSet)
@@ -26,6 +25,7 @@ import qualified Data.HashSet as HashSet
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Maybe (fromJust)
+import Data.Default
 
 import Pact.Types.Command
 import Pact.Types.Hash
@@ -33,6 +33,9 @@ import Pact.Types.Server
 import Pact.Types.Term
 import Pact.Server.History.Types
 import Pact.Server.History.Persistence as DB
+import Pact.Types.Runtime (PactError(..),PactErrorType(..))
+import Pact.Types.Pretty (viaShow)
+
 
 initHistoryEnv
   :: HistoryChannel
@@ -240,7 +243,8 @@ _go :: HistoryService ()
 _go = do
   addNewKeys [Command "" [] initialHash]
   let rq = RequestKey pactInitialHash
-  updateExistingKeys (HashMap.fromList [(rq, CommandResult rq Nothing Null (Gas 0))])
+      res = Left $ PactError TxFailure def def . viaShow $ ("some error message" :: String)
+  updateExistingKeys (HashMap.fromList [(rq, CommandResult rq Nothing res (Gas 0))])
   mv <- liftIO $ newEmptyMVar
   queryForResults (HashSet.singleton rq, mv)
   v <- liftIO $ takeMVar mv

--- a/src-ghc/Pact/Server/History/Service.hs
+++ b/src-ghc/Pact/Server/History/Service.hs
@@ -26,7 +26,6 @@ import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Maybe (fromJust)
 import Data.Default
-import Data.Aeson (Value)
 
 import Pact.Types.Command
 import Pact.Types.Hash
@@ -36,7 +35,6 @@ import Pact.Server.History.Types
 import Pact.Server.History.Persistence as DB
 import Pact.Types.Runtime (PactError(..),PactErrorType(..))
 import Pact.Types.Pretty (viaShow)
-import Pact.Types.Persistence (TxLog)
 
 
 initHistoryEnv
@@ -135,7 +133,7 @@ addNewKeys cmds = do
             debug $ "Some (" ++ show (HashMap.size asHM - HashMap.size newCmdsHM) ++ ") new command(s) had a previously seen hash/requestKey"
 
 
-updateExistingKeys :: HashMap RequestKey (CommandResult [TxLog Value])-> HistoryService ()
+updateExistingKeys :: HashMap RequestKey (CommandResult Hash)-> HistoryService ()
 updateExistingKeys updates = do
   alertListeners updates
   pers <- use persistence
@@ -150,19 +148,19 @@ updateExistingKeys updates = do
                             , dbConn = dbConn }
   debug $ "Updated " ++ show (HashMap.size updates) ++ " command(s)"
 
-updateInMemKey :: (RequestKey, CommandResult [TxLog Value]) ->
-                  HashMap RequestKey (Command ByteString, Maybe (CommandResult [TxLog Value])) ->
-                  HashMap RequestKey (Command ByteString, Maybe (CommandResult [TxLog Value]))
+updateInMemKey :: (RequestKey, CommandResult Hash) ->
+                  HashMap RequestKey (Command ByteString, Maybe (CommandResult Hash)) ->
+                  HashMap RequestKey (Command ByteString, Maybe (CommandResult Hash))
 updateInMemKey (k,v) m = HashMap.adjust (\(cmd, _) -> (cmd, Just v)) k m
 
 pairResultWithCmd :: HashMap RequestKey (Command ByteString) ->
-                     (RequestKey, (CommandResult [TxLog Value])) ->
-                     (Command ByteString, CommandResult [TxLog Value])
+                     (RequestKey, (CommandResult Hash)) ->
+                     (Command ByteString, CommandResult Hash)
 pairResultWithCmd m (rk, cmdr) = case HashMap.lookup rk m of
   Nothing -> error $ "Fatal error: the results for a RequestKey came in, but we can't find the original command\n" ++ show rk ++ "\n#----#\n" ++ show m
   Just cmd -> (cmd, cmdr)
 
-alertListeners :: HashMap RequestKey (CommandResult [TxLog Value]) -> HistoryService ()
+alertListeners :: HashMap RequestKey (CommandResult Hash) -> HistoryService ()
 alertListeners m = do
   listeners <- use registeredListeners
   triggered <- return $! HashMap.filterWithKey (\k _ -> HashMap.member k m) listeners
@@ -172,7 +170,7 @@ alertListeners m = do
     -- use registeredListeners >>= debug . ("Active Listeners: " ++) . show . HashMap.keysSet
     debug $ "Serviced " ++ show (sum res) ++ " listener(s)"
 
-alertListener :: HashMap RequestKey (CommandResult [TxLog Value]) -> (RequestKey, [MVar ListenerResult]) -> HistoryService Int
+alertListener :: HashMap RequestKey (CommandResult Hash) -> (RequestKey, [MVar ListenerResult]) -> HistoryService Int
 alertListener res (k,mvs) = do
   commandRes <- return $! res HashMap.! k
   -- debug $ "Servicing Listener for: " ++ show k
@@ -199,7 +197,7 @@ queryForResults (srks, mRes) = do
         debug $ "Querying for " ++ show (HashSet.size srks) ++ " keys, found " ++ show (HashMap.size found)
 
 -- This is here to try to get GHC to check the fast part first
-checkForIndividualResultInMem :: HashSet RequestKey -> RequestKey -> (Command ByteString, Maybe (CommandResult [TxLog Value])) -> Bool
+checkForIndividualResultInMem :: HashSet RequestKey -> RequestKey -> (Command ByteString, Maybe (CommandResult Hash)) -> Bool
 checkForIndividualResultInMem _ _ (_,Nothing) = False
 checkForIndividualResultInMem s k (_,Just _) = HashSet.member k s
 

--- a/src-ghc/Pact/Server/History/Types.hs
+++ b/src-ghc/Pact/Server/History/Types.hs
@@ -22,6 +22,8 @@ import Database.SQLite3.Direct
 
 import Pact.Types.Command
 import Pact.Types.Server
+import Pact.Types.Persistence (TxLog)
+import Data.Aeson (Value)
 
 data HistoryEnv = HistoryEnv
   { _historyChannel :: !HistoryChannel
@@ -42,7 +44,7 @@ data DbEnv = DbEnv
 
 data PersistenceSystem =
   InMemory
-    { inMemResults :: !(HashMap RequestKey (Command ByteString, Maybe CommandResult))} |
+    { inMemResults :: !(HashMap RequestKey (Command ByteString, Maybe (CommandResult [TxLog Value])))} |
   OnDisk
     { incompleteRequestKeys :: !(HashMap RequestKey (Command ByteString))
     , dbConn :: !DbEnv}

--- a/src-ghc/Pact/Server/History/Types.hs
+++ b/src-ghc/Pact/Server/History/Types.hs
@@ -22,8 +22,7 @@ import Database.SQLite3.Direct
 
 import Pact.Types.Command
 import Pact.Types.Server
-import Pact.Types.Persistence (TxLog)
-import Data.Aeson (Value)
+import Pact.Types.Hash
 
 data HistoryEnv = HistoryEnv
   { _historyChannel :: !HistoryChannel
@@ -44,7 +43,7 @@ data DbEnv = DbEnv
 
 data PersistenceSystem =
   InMemory
-    { inMemResults :: !(HashMap RequestKey (Command ByteString, Maybe (CommandResult [TxLog Value])))} |
+    { inMemResults :: !(HashMap RequestKey (Command ByteString, Maybe (CommandResult Hash)))} |
   OnDisk
     { incompleteRequestKeys :: !(HashMap RequestKey (Command ByteString))
     , dbConn :: !DbEnv}

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -34,6 +34,7 @@ import Pact.Types.Persistence
 import Pact.Types.RPC
 import Pact.Types.Runtime hiding (PublicKey)
 import Pact.Types.Server
+import Pact.Types.Pretty (viaShow)
 
 
 initPactService :: CommandConfig -> Loggers -> IO (CommandExecInterface PublicMeta ParsedCode)
@@ -67,8 +68,8 @@ applyCmd :: Logger -> Maybe EntityName -> PactDbEnv p ->
             ProcessedCommand PublicMeta ParsedCode -> IO CommandResult
 applyCmd _ _ _ _ _ _ _ cmd (ProcFail s) =
   -- Linda TODO
-  return $ jsonResult Nothing (cmdToRequestKey cmd) (Gas 0) $ s
-  --CommandError $ PactError TxFailure def def . viaShow $ s
+  return $ jsonResult Nothing (cmdToRequestKey cmd) (Gas 0) $
+  CommandError $ PactError TxFailure def def . viaShow $ s
 applyCmd logger conf dbv gasModel bh bt exMode _ (ProcSucc cmd) = do
   let pubMeta = _pMeta $ _cmdPayload cmd
       (ParsedDecimal gasPrice) = _pmGasPrice pubMeta
@@ -85,8 +86,7 @@ applyCmd logger conf dbv gasModel bh bt exMode _ (ProcSucc cmd) = do
       logLog logger "ERROR" $ "tx failure for requestKey: " ++ show (cmdToRequestKey cmd) ++ ": " ++ show e
       -- Linda TODO
       return $ jsonResult Nothing (cmdToRequestKey cmd) (Gas 0) $
-               CommandError "Command execution failed" (Just $ show e)
-               --CommandError $ PactError EvalError def def . viaShow $ e
+               CommandError $ PactError EvalError def def . viaShow $ e
 
 jsonResult :: ToJSON a => Maybe TxId -> RequestKey -> Gas -> a -> CommandResult
 jsonResult tx cmd gas a = CommandResult cmd tx (toJSON a) gas

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -88,7 +88,7 @@ applyCmd logger conf dbv gasModel bh bt exMode _ (ProcSucc cmd) = do
                Left e
 
 jsonResult :: Maybe TxId -> RequestKey -> Gas -> Either PactError PactValue -> CommandResult
-jsonResult tx cmd gas a = CommandResult cmd tx a gas
+jsonResult tx cmd gas a = CommandResult cmd tx (PactResult a) gas
 
 
 runPayload :: Command (Payload PublicMeta ParsedCode) -> CommandM p CommandResult

--- a/src-ghc/Pact/Server/Server.hs
+++ b/src-ghc/Pact/Server/Server.hs
@@ -72,8 +72,8 @@ usage =
 serve :: FilePath -> IO ()
 serve configFile = do
   (runServer, asyncCmd, asyncHist) <- setupServer configFile
-  link asyncCmd   -- Must be individually killed with uninterruptibleCancel
-  link asyncHist  -- Must be individually killed with uninterruptibleCancel
+  link asyncCmd
+  link asyncHist
   runServer
 
 setupServer :: FilePath -> IO (IO (), Async (), Async ())

--- a/src-ghc/Pact/Server/Server.hs
+++ b/src-ghc/Pact/Server/Server.hs
@@ -127,7 +127,5 @@ startCmdThread cmdConfig inChan histChan (ReplayFromDisk rp) debugFn = do
       LocalCmd cmd mv -> do
         CommandResult {..} <- liftIO $ _ceiApplyCmd Local cmd
         -- Linda TODO
-        let toRes (Left pe) = toJSON (CommandError pe)
-            toRes (Right pv) = toJSON (CommandSuccess pv)
-            resp = CommandResponse _crReqKey _crTxId (toRes _crResult) _crGas Nothing Nothing Nothing
+        let resp = CommandResponse _crReqKey _crTxId (toJSON _crResult) _crGas Nothing Nothing Nothing
         liftIO $ putMVar mv resp

--- a/src-ghc/Pact/Server/Server.hs
+++ b/src-ghc/Pact/Server/Server.hs
@@ -14,11 +14,10 @@
 
 module Pact.Server.Server
   ( serve
-  , setupServer
   ) where
 
 import Control.Concurrent
-import Control.Concurrent.Async (async, link, Async(..))
+import Control.Concurrent.Async (async, link)
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Exception
@@ -71,13 +70,6 @@ usage =
 
 serve :: FilePath -> IO ()
 serve configFile = do
-  (runServer, asyncCmd, asyncHist) <- setupServer configFile
-  link asyncCmd
-  link asyncHist
-  runServer
-
-setupServer :: FilePath -> IO (IO (), Async (), Async ())
-setupServer configFile = do
   Config {..} <- Y.decodeFileEither configFile >>= \case
     Left e -> do
       putStrLn usage
@@ -93,10 +85,16 @@ setupServer configFile = do
           _gasRate
 
   let histConf = initHistoryEnv histC inC _persistDir debugFn replayFromDisk'
+
+  -- Must be individually killed with uninterruptibleCancel if parent thread not killed.
   asyncCmd <- async (startCmdThread cmdConfig inC histC replayFromDisk' debugFn)
+  -- Must be individually killed with uninterruptibleCancel if parent thread not killed.
   asyncHist <- async (runHistoryService histConf Nothing)
   let runServer = runApiServer histC inC debugFn (fromIntegral _port) _logDir
-  return (runServer,asyncCmd, asyncHist)
+
+  link asyncCmd
+  link asyncHist
+  runServer
 
 initFastLogger :: IO (String -> IO ())
 initFastLogger = do
@@ -125,5 +123,5 @@ startCmdThread cmdConfig inChan histChan (ReplayFromDisk rp) debugFn = do
           liftIO $ _ceiApplyCmd Transactional cmd
         liftIO $ writeHistory histChan $ Update $ HashMap.fromList $ (\cmdr@CommandResult{..} -> (_crReqKey, cmdr)) <$> resps
       LocalCmd cmd mv -> do
-        resp@CommandResult{..} <- liftIO $ _ceiApplyCmd Local cmd
+        resp <- liftIO $ _ceiApplyCmd Local cmd
         liftIO $ putMVar mv resp

--- a/src-ghc/Pact/Server/Server.hs
+++ b/src-ghc/Pact/Server/Server.hs
@@ -126,4 +126,6 @@ startCmdThread cmdConfig inChan histChan (ReplayFromDisk rp) debugFn = do
         liftIO $ writeHistory histChan $ Update $ HashMap.fromList $ (\cmdr@CommandResult{..} -> (_crReqKey, cmdr)) <$> resps
       LocalCmd cmd mv -> do
         CommandResult {..} <- liftIO $ _ceiApplyCmd Local cmd
-        liftIO $ putMVar mv _crResult
+        -- Linda TODO
+        let resp = CommandResponse _crReqKey _crTxId _crResult _crGas Nothing Nothing Nothing
+        liftIO $ putMVar mv resp

--- a/src-ghc/Pact/Server/Server.hs
+++ b/src-ghc/Pact/Server/Server.hs
@@ -127,5 +127,7 @@ startCmdThread cmdConfig inChan histChan (ReplayFromDisk rp) debugFn = do
       LocalCmd cmd mv -> do
         CommandResult {..} <- liftIO $ _ceiApplyCmd Local cmd
         -- Linda TODO
-        let resp = CommandResponse _crReqKey _crTxId _crResult _crGas Nothing Nothing Nothing
+        let toRes (Left pe) = toJSON (CommandError pe)
+            toRes (Right pv) = toJSON (CommandSuccess pv)
+            resp = CommandResponse _crReqKey _crTxId (toRes _crResult) _crGas Nothing Nothing Nothing
         liftIO $ putMVar mv resp

--- a/src-ghc/Pact/Server/Server.hs
+++ b/src-ghc/Pact/Server/Server.hs
@@ -125,7 +125,5 @@ startCmdThread cmdConfig inChan histChan (ReplayFromDisk rp) debugFn = do
           liftIO $ _ceiApplyCmd Transactional cmd
         liftIO $ writeHistory histChan $ Update $ HashMap.fromList $ (\cmdr@CommandResult{..} -> (_crReqKey, cmdr)) <$> resps
       LocalCmd cmd mv -> do
-        CommandResult {..} <- liftIO $ _ceiApplyCmd Local cmd
-        -- Linda TODO
-        let resp = CommandResponse _crReqKey _crTxId (toJSON _crResult) _crGas Nothing Nothing Nothing
+        resp@CommandResult{..} <- liftIO $ _ceiApplyCmd Local cmd
         liftIO $ putMVar mv resp

--- a/src-ghc/Pact/Types/Server.hs
+++ b/src-ghc/Pact/Types/Server.hs
@@ -152,6 +152,6 @@ data History =
 data Inbound =
   TxCmds { iCmds :: [Command ByteString] } |
   LocalCmd { iCmd :: Command ByteString,
-             iLocalResult :: MVar (CommandResponse Hash)
+             iLocalResult :: MVar CommandResult
            }
   deriving (Eq)

--- a/src-ghc/Pact/Types/Server.hs
+++ b/src-ghc/Pact/Types/Server.hs
@@ -48,7 +48,6 @@ import Data.String
 import Data.ByteString (ByteString)
 import qualified Data.Set as S
 import Data.Text.Encoding
-import Data.Aeson
 import Data.HashSet (HashSet)
 import Data.HashMap.Strict (HashMap)
 import Data.Int
@@ -153,6 +152,6 @@ data History =
 data Inbound =
   TxCmds { iCmds :: [Command ByteString] } |
   LocalCmd { iCmd :: Command ByteString,
-             iLocalResult :: MVar Value
+             iLocalResult :: MVar (CommandResponse Hash)
            }
   deriving (Eq)

--- a/src-ghc/Pact/Types/Server.hs
+++ b/src-ghc/Pact/Types/Server.hs
@@ -51,7 +51,6 @@ import Data.Text.Encoding
 import Data.HashSet (HashSet)
 import Data.HashMap.Strict (HashMap)
 import Data.Int
-import Data.Aeson (Value)
 
 import Prelude
 
@@ -130,11 +129,11 @@ newtype ExistenceResult = ExistenceResult
   } deriving (Show, Eq)
 
 newtype PossiblyIncompleteResults = PossiblyIncompleteResults
-  { possiblyIncompleteResults :: HashMap RequestKey (CommandResult [TxLog Value])
+  { possiblyIncompleteResults :: HashMap RequestKey (CommandResult Hash)
   } deriving (Show, Eq)
 
 data ListenerResult =
-  ListenerResult (CommandResult [TxLog Value]) |
+  ListenerResult (CommandResult Hash) |
   GCed String
   deriving (Show, Eq)
 
@@ -142,7 +141,7 @@ data History =
   AddNew
     { hNewKeys :: ![Command ByteString]} |
   Update
-    { hUpdateRks :: !(HashMap RequestKey (CommandResult [TxLog Value])) } |
+    { hUpdateRks :: !(HashMap RequestKey (CommandResult Hash)) } |
   QueryForResults
     { hQueryForResults :: !(HashSet RequestKey, MVar PossiblyIncompleteResults) } |
   RegisterListener
@@ -153,6 +152,6 @@ data History =
 data Inbound =
   TxCmds { iCmds :: [Command ByteString] } |
   LocalCmd { iCmd :: Command ByteString,
-             iLocalResult :: MVar (CommandResult [TxLog Value])
+             iLocalResult :: MVar (CommandResult Hash)
            }
   deriving (Eq)

--- a/src-ghc/Pact/Types/Server.hs
+++ b/src-ghc/Pact/Types/Server.hs
@@ -51,6 +51,7 @@ import Data.Text.Encoding
 import Data.HashSet (HashSet)
 import Data.HashMap.Strict (HashMap)
 import Data.Int
+import Data.Aeson (Value)
 
 import Prelude
 
@@ -129,11 +130,11 @@ newtype ExistenceResult = ExistenceResult
   } deriving (Show, Eq)
 
 newtype PossiblyIncompleteResults = PossiblyIncompleteResults
-  { possiblyIncompleteResults :: HashMap RequestKey CommandResult
+  { possiblyIncompleteResults :: HashMap RequestKey (CommandResult [TxLog Value])
   } deriving (Show, Eq)
 
 data ListenerResult =
-  ListenerResult CommandResult |
+  ListenerResult (CommandResult [TxLog Value]) |
   GCed String
   deriving (Show, Eq)
 
@@ -141,7 +142,7 @@ data History =
   AddNew
     { hNewKeys :: ![Command ByteString]} |
   Update
-    { hUpdateRks :: !(HashMap RequestKey CommandResult) } |
+    { hUpdateRks :: !(HashMap RequestKey (CommandResult [TxLog Value])) } |
   QueryForResults
     { hQueryForResults :: !(HashSet RequestKey, MVar PossiblyIncompleteResults) } |
   RegisterListener
@@ -152,6 +153,6 @@ data History =
 data Inbound =
   TxCmds { iCmds :: [Command ByteString] } |
   LocalCmd { iCmd :: Command ByteString,
-             iLocalResult :: MVar CommandResult
+             iLocalResult :: MVar (CommandResult [TxLog Value])
            }
   deriving (Eq)

--- a/src/Pact/Server/API.hs
+++ b/src/Pact/Server/API.hs
@@ -10,13 +10,13 @@ module Pact.Server.API
   , pactServerAPI
   ) where
 
-import Data.Aeson
 import Data.Proxy
 import Servant.API
 import qualified Pact.Analyze.Remote.Types as Analyze
 import Pact.Types.API
 import Pact.Types.Command
 import Data.Text (Text)
+import Pact.Types.Hash (Hash)
 
 type ApiV1API =
   (    "send" :> ReqBody '[JSON] SubmitBatch :>
@@ -26,7 +26,7 @@ type ApiV1API =
   :<|> "listen" :> ReqBody '[JSON] ListenerRequest :>
     Post '[JSON] ApiResult
   :<|> "local" :> ReqBody '[JSON] (Command Text) :>
-    Post '[JSON] (CommandSuccess Value)
+    Post '[JSON] (CommandResponse Hash)
   )
 
 type PactServerAPI =

--- a/src/Pact/Server/API.hs
+++ b/src/Pact/Server/API.hs
@@ -16,7 +16,6 @@ import qualified Pact.Analyze.Remote.Types as Analyze
 import Pact.Types.API
 import Pact.Types.Command
 import Data.Text (Text)
-import Pact.Types.Hash (Hash)
 
 type ApiV1API =
   (    "send" :> ReqBody '[JSON] SubmitBatch :>
@@ -24,9 +23,9 @@ type ApiV1API =
   :<|> "poll" :> ReqBody '[JSON] Poll :>
     Post '[JSON] PollResponses
   :<|> "listen" :> ReqBody '[JSON] ListenerRequest :>
-    Post '[JSON] ApiResult
+    Post '[JSON] CommandResult
   :<|> "local" :> ReqBody '[JSON] (Command Text) :>
-    Post '[JSON] (CommandResponse Hash)
+    Post '[JSON] CommandResult
   )
 
 type PactServerAPI =

--- a/src/Pact/Server/API.hs
+++ b/src/Pact/Server/API.hs
@@ -16,6 +16,7 @@ import qualified Pact.Analyze.Remote.Types as Analyze
 import Pact.Types.API
 import Pact.Types.Command
 import Data.Text (Text)
+import Pact.Types.Hash (Hash)
 
 type ApiV1API =
   (    "send" :> ReqBody '[JSON] SubmitBatch :>
@@ -23,9 +24,9 @@ type ApiV1API =
   :<|> "poll" :> ReqBody '[JSON] Poll :>
     Post '[JSON] PollResponses
   :<|> "listen" :> ReqBody '[JSON] ListenerRequest :>
-    Post '[JSON] CommandResult
+    Post '[JSON] (CommandResult Hash)
   :<|> "local" :> ReqBody '[JSON] (Command Text) :>
-    Post '[JSON] CommandResult
+    Post '[JSON] (CommandResult Hash)
   )
 
 type PactServerAPI =

--- a/src/Pact/Server/Client.hs
+++ b/src/Pact/Server/Client.hs
@@ -13,7 +13,6 @@ module Pact.Server.Client
   , pactServerApiClient
   ) where
 
-import Data.Aeson
 import Data.Proxy
 import Servant.API
 import Servant.Client.Core
@@ -21,6 +20,7 @@ import qualified Pact.Analyze.Remote.Types as Analyze
 import Pact.Types.API
 import Pact.Types.Command
 import Data.Text (Text)
+import Pact.Types.Hash (Hash)
 
 import Pact.Server.API
 
@@ -28,7 +28,7 @@ data PactServerAPIClient m = PactServerAPIClient
   { send :: SubmitBatch -> m RequestKeys
   , poll :: Poll -> m PollResponses
   , listen :: ListenerRequest -> m ApiResult
-  , local :: Command Text -> m (CommandSuccess Value)
+  , local :: Command Text -> m (CommandResponse Hash)
   , verify :: Analyze.Request -> m Analyze.Response
   , version :: m Text
   }
@@ -38,4 +38,3 @@ pactServerApiClient = let
   (send :<|> poll :<|> listen :<|> local) :<|> verify :<|> version =
     clientIn pactServerAPI (Proxy :: Proxy m)
   in PactServerAPIClient{ send, poll, listen, local, verify, version }
-

--- a/src/Pact/Server/Client.hs
+++ b/src/Pact/Server/Client.hs
@@ -20,14 +20,15 @@ import qualified Pact.Analyze.Remote.Types as Analyze
 import Pact.Types.API
 import Pact.Types.Command
 import Data.Text (Text)
+import Pact.Types.Hash (Hash)
 
 import Pact.Server.API
 
 data PactServerAPIClient m = PactServerAPIClient
   { send :: SubmitBatch -> m RequestKeys
   , poll :: Poll -> m PollResponses
-  , listen :: ListenerRequest -> m CommandResult
-  , local :: Command Text -> m CommandResult
+  , listen :: ListenerRequest -> m (CommandResult Hash)
+  , local :: Command Text -> m (CommandResult Hash)
   , verify :: Analyze.Request -> m Analyze.Response
   , version :: m Text
   }

--- a/src/Pact/Server/Client.hs
+++ b/src/Pact/Server/Client.hs
@@ -20,15 +20,14 @@ import qualified Pact.Analyze.Remote.Types as Analyze
 import Pact.Types.API
 import Pact.Types.Command
 import Data.Text (Text)
-import Pact.Types.Hash (Hash)
 
 import Pact.Server.API
 
 data PactServerAPIClient m = PactServerAPIClient
   { send :: SubmitBatch -> m RequestKeys
   , poll :: Poll -> m PollResponses
-  , listen :: ListenerRequest -> m ApiResult
-  , local :: Command Text -> m (CommandResponse Hash)
+  , listen :: ListenerRequest -> m CommandResult
+  , local :: Command Text -> m CommandResult
   , verify :: Analyze.Request -> m Analyze.Response
   , version :: m Text
   }

--- a/src/Pact/Types/API.hs
+++ b/src/Pact/Types/API.hs
@@ -22,7 +22,6 @@ module Pact.Types.API
   , Poll(..)
   , PollResponses(..)
   , ListenerRequest(..)
-  , ApiResult(..), arMetaData, arResult, arTxId
   ) where
 
 import Data.Aeson hiding (Success)
@@ -64,17 +63,8 @@ instance ToJSON Poll where
 instance FromJSON Poll where
   parseJSON = lensyParseJSON 2
 
-data ApiResult = ApiResult {
-  _arResult :: !Value,
-  _arTxId :: !(Maybe TxId),
-  _arMetaData :: !(Maybe Value)
-  } deriving (Eq,Show,Generic)
-makeLenses ''ApiResult
-instance FromJSON ApiResult where parseJSON = lensyParseJSON 3
-instance ToJSON ApiResult where toJSON = lensyToJSON 3
-
 -- | What you get back from a Poll
-newtype PollResponses = PollResponses (HM.HashMap RequestKey ApiResult)
+newtype PollResponses = PollResponses (HM.HashMap RequestKey CommandResult)
   deriving (Eq, Show)
 instance ToJSON PollResponses where
   toJSON (PollResponses m) = object $ map (requestKeyToB16Text *** toJSON) $ HM.toList m

--- a/src/Pact/Types/API.hs
+++ b/src/Pact/Types/API.hs
@@ -64,7 +64,7 @@ instance FromJSON Poll where
   parseJSON = lensyParseJSON 2
 
 -- | What you get back from a Poll
-newtype PollResponses = PollResponses (HM.HashMap RequestKey CommandResult)
+newtype PollResponses = PollResponses (HM.HashMap RequestKey (CommandResult Hash))
   deriving (Eq, Show)
 instance ToJSON PollResponses where
   toJSON (PollResponses m) = object $ map (requestKeyToB16Text *** toJSON) $ HM.toList m

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -35,7 +35,6 @@ module Pact.Types.Command
   , ParsedCode(..),pcCode,pcExps
   , Signer(..),siScheme, siPubKey, siAddress
   , UserSig(..),usSig
-  , CommandResponse(..)
   , PactResult(..)
   , CommandResult(..),crReqKey,crTxId,crResult,crGas
   , CommandExecInterface(..),ceiApplyCmd,ceiApplyPPCmd
@@ -257,20 +256,6 @@ instance ToJSON UserSig where
 instance FromJSON UserSig where
   parseJSON = withObject "UserSig" $ \o -> do
     UserSig <$> o .: "sig"
-
-
-data CommandResponse l = CommandResponse
-  { _crReqKey' :: RequestKey
-  , _crTxId' :: Maybe TxId
-  , _crResult' :: Value --Either PactError PactValue
-  , _crGas' :: Gas
-  , _crLogs' :: Maybe l                  -- this would be [TxLog Value] in pact -s
-  , _crContinuation' :: Maybe PactExec
-  , _crMeta' :: Maybe Value
-  } deriving (Generic)
-instance (ToJSON l) => ToJSON (CommandResponse l) where toJSON = lensyToJSON 3
-instance (FromJSON l) => FromJSON (CommandResponse l) where parseJSON = lensyParseJSON 3
-
 
 
 newtype PactResult = PactResult (Either PactError PactValue)

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -273,15 +273,22 @@ instance FromJSON PactResult where
                             (Right <$> o .: "data"))
   parseJSON p = fail $ "Invalid PactResult " ++ show p
 
-data CommandResult l = CommandResult
-  { _crReqKey :: !RequestKey              -- Request Key of command (the hash of the command payload)
-  , _crTxId :: !(Maybe TxId)              -- Transaction id of this CommandResult
-  , _crResult :: !PactResult              -- Result of evaluating the command, either a PactError or the output
-                                          --   of the last pact expression as a PactValue
-  , _crGas :: !Gas                        -- Gas consummed by command
-  , _crLogs :: !(Maybe l)                 -- Level of logging (i.e. full TxLog vs hashed logs)
-  , _crContinuation :: !(Maybe PactExec)  -- Output of a Continuation if one occurred in the command.
-  , _crMetaData :: !(Maybe Value)         -- Platform-specific data
+-- | API result of attempting to execute a pact command, parametrized over level of logging type
+data CommandResult l = CommandResult {
+  -- | Request Key of command (the hash of the command payload)
+    _crReqKey :: !RequestKey
+  -- | Transaction id of this CommandResult
+  , _crTxId :: !(Maybe TxId)
+  -- | Pact execution result, either a PactError or the last pact expression output as a PactValue
+  , _crResult :: !PactResult
+  -- | Gas consummed by command                                         
+  , _crGas :: !Gas
+  -- | Level of logging (i.e. full TxLog vs hashed logs)
+  , _crLogs :: !(Maybe l)
+  -- | Output of a Continuation if one occurred in the command.
+  , _crContinuation :: !(Maybe PactExec)
+  -- | Platform-specific data
+  , _crMetaData :: !(Maybe Value)
   } deriving (Eq,Show,Generic)
 instance (ToJSON l) => ToJSON (CommandResult l) where toJSON = lensyToJSON 3
 instance (FromJSON l) => FromJSON (CommandResult l) where parseJSON = lensyParseJSON 3

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -35,8 +35,6 @@ module Pact.Types.Command
   , ParsedCode(..),pcCode,pcExps
   , Signer(..),siScheme, siPubKey, siAddress
   , UserSig(..),usSig
-  , CommandError(..),ceData
-  , CommandSuccess(..),csData
   , CommandResponse(..)
   , PactResult(..)
   , CommandResult(..),crReqKey,crTxId,crResult,crGas
@@ -261,31 +259,6 @@ instance FromJSON UserSig where
     UserSig <$> o .: "sig"
 
 
--- Linda TODO
-newtype CommandError = CommandError { _ceData :: PactError }
-  deriving (Show)
-instance ToJSON CommandError where
-    toJSON (CommandError m) =
-        object $ [ "status" .= ("failure" :: String)
-                 , "data" .= m ]
-
-instance FromJSON CommandError where
-    parseJSON = withObject "CommandError" $ \o ->
-        CommandError <$> o .: "data"
-
-
-newtype CommandSuccess = CommandSuccess { _csData :: PactValue }
-  deriving (Eq, Show)
-
-instance ToJSON CommandSuccess where
-    toJSON (CommandSuccess a) =
-        object [ "status" .= ("success" :: String)
-               , "data" .= a ]
-
-instance FromJSON CommandSuccess where
-    parseJSON = withObject "CommandSuccess" $ \o ->
-        CommandSuccess <$> o .: "data"
-
 data CommandResponse l = CommandResponse
   { _crReqKey' :: RequestKey
   , _crTxId' :: Maybe TxId
@@ -359,8 +332,6 @@ makeLenses ''ExecutionMode
 makeLenses ''Command
 makeLenses ''ParsedCode
 makeLenses ''Payload
-makeLenses ''CommandError
-makeLenses ''CommandSuccess
 makeLenses ''CommandResult
 makePrisms ''ProcessedCommand
 makePrisms ''ExecutionMode

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -37,6 +37,7 @@ module Pact.Types.Command
   , UserSig(..),usSig
   , CommandError(..),ceMsg,ceDetail
   , CommandSuccess(..),csData
+  , CommandResponse(..)
   , CommandResult(..),crReqKey,crTxId,crResult,crGas
   , CommandExecInterface(..),ceiApplyCmd,ceiApplyPPCmd
   , ApplyCmd, ApplyPPCmd
@@ -258,7 +259,7 @@ instance FromJSON UserSig where
     UserSig <$> o .: "sig"
 
 
-
+-- Linda TODO
 data CommandError = CommandError {
       _ceMsg :: String
     , _ceDetail :: Maybe String
@@ -280,6 +281,22 @@ instance (ToJSON a) => ToJSON (CommandSuccess a) where
 instance (FromJSON a) => FromJSON (CommandSuccess a) where
     parseJSON = withObject "CommandSuccess" $ \o ->
         CommandSuccess <$> o .: "data"
+
+data CommandResponse l = CommandResponse
+  { _crReqKey' :: RequestKey
+  , _crTxId' :: Maybe TxId
+  , _crResult' :: Value --Either PactError PactValue
+  , _crGas' :: Gas
+  , _crLogs' :: Maybe l                  -- this would be [TxLog Value] in pact -s
+  , _crContinuation' :: Maybe PactExec
+  , _crMeta' :: Maybe Value
+  } deriving (Generic)
+instance (ToJSON l) => ToJSON (CommandResponse l) where toJSON = lensyToJSON 3
+instance (FromJSON l) => FromJSON (CommandResponse l) where parseJSON = lensyParseJSON 3
+
+
+
+
 
 data CommandResult = CommandResult
   { _crReqKey :: RequestKey

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -266,20 +266,21 @@ instance ToJSON PactResult where
            , "data" .= s ]
   toJSON (PactResult (Left f)) =
     object [ "status" .= ("failure" :: String)
-           , "data" .= f ]
+           , "error" .= f ]
 instance FromJSON PactResult where
   parseJSON (A.Object o) = PactResult <$>
-                           ((Left <$> o .: "data") <|>
+                           ((Left <$> o .: "error") <|>
                             (Right <$> o .: "data"))
   parseJSON p = fail $ "Invalid PactResult " ++ show p
 
 data CommandResult l = CommandResult
-  { _crReqKey :: !RequestKey
-  , _crTxId :: !(Maybe TxId)
-  , _crResult :: !PactResult
-  , _crGas :: !Gas
+  { _crReqKey :: !RequestKey              -- Request Key of command (the hash of the command payload)
+  , _crTxId :: !(Maybe TxId)              -- Transaction id of this CommandResult
+  , _crResult :: !PactResult              -- Result of evaluating the command, either a PactError or the output
+                                          --   of the last pact expression as a PactValue
+  , _crGas :: !Gas                        -- Gas consummed by command
   , _crLogs :: !(Maybe l)                 -- Level of logging (i.e. full TxLog vs hashed logs)
-  , _crContinuation :: !(Maybe PactExec)
+  , _crContinuation :: !(Maybe PactExec)  -- Output of a Continuation if one occurred in the command.
   , _crMetaData :: !(Maybe Value)         -- Platform-specific data
   } deriving (Eq,Show,Generic)
 instance (ToJSON l) => ToJSON (CommandResult l) where toJSON = lensyToJSON 3

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -304,7 +304,7 @@ instance (FromJSON l) => FromJSON (CommandResponse l) where parseJSON = lensyPar
 data CommandResult = CommandResult
   { _crReqKey :: RequestKey
   , _crTxId :: Maybe TxId
-  , _crResult :: Value
+  , _crResult :: Either PactError PactValue
   , _crGas :: Gas
   } deriving (Eq,Show)
 

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -35,7 +35,7 @@ module Pact.Types.Command
   , ParsedCode(..),pcCode,pcExps
   , Signer(..),siScheme, siPubKey, siAddress
   , UserSig(..),usSig
-  , CommandError(..),ceMsg,ceDetail
+  , CommandError(..),ceData
   , CommandSuccess(..),csData
   , CommandResponse(..)
   , CommandResult(..),crReqKey,crTxId,crResult,crGas
@@ -261,15 +261,11 @@ instance FromJSON UserSig where
 
 
 -- Linda TODO
-data CommandError = CommandError {
-      _ceMsg :: String
-    , _ceDetail :: Maybe String
-}
+newtype CommandError = CommandError { _ceData :: PactError }
 instance ToJSON CommandError where
-    toJSON (CommandError m d) =
+    toJSON (CommandError m) =
         object $ [ "status" .= ("failure" :: String)
-                 , "error" .= m ] ++
-        maybe [] ((:[]) . ("detail" .=)) d
+                 , "data" .= m ]
 
 newtype CommandSuccess = CommandSuccess { _csData :: PactValue }
   deriving (Eq, Show)

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -262,10 +262,16 @@ instance FromJSON UserSig where
 
 -- Linda TODO
 newtype CommandError = CommandError { _ceData :: PactError }
+  deriving (Show)
 instance ToJSON CommandError where
     toJSON (CommandError m) =
         object $ [ "status" .= ("failure" :: String)
                  , "data" .= m ]
+
+instance FromJSON CommandError where
+    parseJSON = withObject "CommandError" $ \o ->
+        CommandError <$> o .: "data"
+
 
 newtype CommandSuccess = CommandSuccess { _csData :: PactValue }
   deriving (Eq, Show)

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -65,6 +65,7 @@ import Prelude
 import Pact.Types.Runtime hiding (PublicKey)
 import Pact.Types.Orphans ()
 import Pact.Types.RPC
+import Pact.Types.PactValue (PactValue(..))
 
 
 #if !defined(ghcjs_HOST_OS)
@@ -270,15 +271,15 @@ instance ToJSON CommandError where
                  , "error" .= m ] ++
         maybe [] ((:[]) . ("detail" .=)) d
 
-newtype CommandSuccess a = CommandSuccess { _csData :: a }
+newtype CommandSuccess = CommandSuccess { _csData :: PactValue }
   deriving (Eq, Show)
 
-instance (ToJSON a) => ToJSON (CommandSuccess a) where
+instance ToJSON CommandSuccess where
     toJSON (CommandSuccess a) =
         object [ "status" .= ("success" :: String)
                , "data" .= a ]
 
-instance (FromJSON a) => FromJSON (CommandSuccess a) where
+instance FromJSON CommandSuccess where
     parseJSON = withObject "CommandSuccess" $ \o ->
         CommandSuccess <$> o .: "data"
 

--- a/src/Pact/Types/Pretty.hs
+++ b/src/Pact/Types/Pretty.hs
@@ -55,7 +55,7 @@ module Pact.Types.Pretty
   ) where
 
 import           Bound.Var
-import           Data.Aeson           (Value(..),ToJSON(..),FromJSON(..))
+import           Data.Aeson           (Value(..))
 import qualified Data.ByteString.UTF8 as UTF8
 import           Data.Foldable        (toList)
 import qualified Data.HashMap.Strict  as HM
@@ -91,10 +91,8 @@ data Annot
 
 type Doc = PP.Doc Annot
 instance Eq Doc where
-  d1 == d2 = d1 == d2
-  d1 /= d2 = d1 /= d2
-instance ToJSON Doc where toJSON = toJSON
-instance FromJSON Doc where parseJSON = parseJSON
+  d1 == d2 = show d1 == show d2
+  d1 /= d2 = show d1 /= show d2
 
 -- | Pact's version of 'Pretty', with 'Annot' annotations.
 class Pretty a where

--- a/src/Pact/Types/Pretty.hs
+++ b/src/Pact/Types/Pretty.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
+
 module Pact.Types.Pretty
   ( (<+>)
   , Annot(..)
@@ -54,7 +55,7 @@ module Pact.Types.Pretty
   ) where
 
 import           Bound.Var
-import           Data.Aeson           (Value(..))
+import           Data.Aeson           (Value(..),ToJSON(..),FromJSON(..))
 import qualified Data.ByteString.UTF8 as UTF8
 import           Data.Foldable        (toList)
 import qualified Data.HashMap.Strict  as HM
@@ -89,6 +90,11 @@ data Annot
   | BadExample
 
 type Doc = PP.Doc Annot
+instance Eq Doc where
+  d1 == d2 = d1 == d2
+  d1 /= d2 = d1 /= d2
+instance ToJSON Doc where toJSON = toJSON
+instance FromJSON Doc where parseJSON = parseJSON
 
 -- | Pact's version of 'Pretty', with 'Annot' annotations.
 class Pretty a where

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -123,7 +123,6 @@ data PactError = PactError
   deriving (Eq,Generic)
 
 instance Exception PactError
--- Linda TODO
 instance ToJSON PactError where
   toJSON (PactError t i s d) =
     object [ "type" .= t, "info" .= i, "callStack" .= s, "doc" .= (show d)]

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -123,8 +123,17 @@ data PactError = PactError
   deriving (Eq,Generic)
 
 instance Exception PactError
-instance ToJSON PactError where toJSON = lensyToJSON 2
-instance FromJSON PactError where parseJSON = lensyParseJSON 2
+-- Linda TODO
+instance ToJSON PactError where
+  toJSON (PactError t i s d) =
+    object [ "type" .= t, "info" .= i, "callStack" .= s, "doc" .= (show d)]
+instance FromJSON PactError where
+  parseJSON = withObject "PactError" $ \o -> do
+    typ <- o .: "type"
+    info <- o .: "info"
+    callStack <- o .: "callStack"
+    doc <- o .: "doc"
+    pure $ PactError typ info callStack (prettyString doc)
 
 instance Show PactError where
     show (PactError t i _ s) = show i ++ ": Failure: " ++ maybe "" (++ ": ") msg ++ show s

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE DeriveGeneric #-}
 -- |
 -- Module      :  Pact.Types.Runtime
 -- Copyright   :  (C) 2016 Stuart Popejoy
@@ -58,6 +59,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.String
+import GHC.Generics
 
 import Pact.Types.ChainMeta
 import Pact.Types.Gas
@@ -92,7 +94,10 @@ data StackFrame = StackFrame {
       _sfName :: !Text
     , _sfLoc :: !Info
     , _sfApp :: Maybe (FunApp,[Text])
-    }
+    } deriving (Eq,Generic)
+instance ToJSON StackFrame where toJSON = lensyToJSON 3
+instance FromJSON StackFrame where parseJSON = lensyParseJSON 3
+
 instance Show StackFrame where
     show (StackFrame n i app) = renderInfo i ++ ": " ++ case app of
       Nothing -> unpack n
@@ -106,15 +111,20 @@ data PactErrorType
   | TxFailure
   | SyntaxError
   | GasError
-  deriving Show
+  deriving (Show,Eq,Generic)
+instance ToJSON PactErrorType
+instance FromJSON PactErrorType
 
 data PactError = PactError
   { peType :: PactErrorType
   , peInfo :: Info
   , peCallStack :: [StackFrame]
   , peDoc :: Doc }
+  deriving (Eq,Generic)
 
 instance Exception PactError
+instance ToJSON PactError where toJSON = lensyToJSON 2
+instance FromJSON PactError where parseJSON = lensyParseJSON 2
 
 instance Show PactError where
     show (PactError t i _ s) = show i ++ ": Failure: " ++ maybe "" (++ ": ") msg ++ show s

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -323,8 +323,9 @@ data FunApp = FunApp {
     , _faDefType :: !DefType
     , _faTypes :: !(FunTypes (Term Name))
     , _faDocs :: !(Maybe Text)
-    } deriving Show
-
+    } deriving (Show,Eq,Generic)
+instance ToJSON FunApp where toJSON = lensyToJSON 3
+instance FromJSON FunApp where parseJSON = lensyParseJSON 3
 instance HasInfo FunApp where getInfo = _faInfo
 
 -- | Variable type for an evaluable 'Term'.

--- a/tests/ClientSpec.hs
+++ b/tests/ClientSpec.hs
@@ -6,6 +6,7 @@
 module ClientSpec (spec) where
 
 import Data.Aeson
+import Data.Aeson.Types (parse)
 import Data.Default (def)
 import Test.Hspec
 import Utils.TestRunner
@@ -40,6 +41,11 @@ simpleServerCmd = do
   simpleKeys <- genKeys
   mkExec  "(+ 1 2)" Null def [simpleKeys] (Just "test1")
 
+simpleServerCmdWithPactErr :: IO (Command Text)
+simpleServerCmdWithPactErr = do
+  simpleKeys <- genKeys
+  mkExec  "(+ 1 2 3)" Null def [simpleKeys] (Just "test1")
+
 spec :: Spec
 spec = describe "Servant API client tests" $ do
   mgr <- runIO $ HTTP.newManager HTTP.defaultManagerSettings
@@ -58,6 +64,14 @@ spec = describe "Servant API client tests" $ do
     -- Linda TODO
     let cmdPactResult = (toJSON . CommandSuccess . PLiteral . LDecimal) 3 --Right . PLiteral . LDecimal $ 3
     (_crResult' <$> res) `shouldBe` (Right cmdPactResult)
+
+  it "correctly runs a simple command with pact error locally" $ do
+    cmd <- simpleServerCmdWithPactErr
+    res <- bracket $! do
+      r <- runClientM (local pactServerApiClient cmd) clientEnv
+      return r
+    (_crResult' <$> res) `shouldSatisfy` (failWith ArgsError)
+
   it "correctly runs a simple command publicly and listens to the result" $ do
     cmd <- simpleServerCmd
     let rk = cmdToRequestKey cmd
@@ -69,3 +83,22 @@ spec = describe "Servant API client tests" $ do
     res `shouldBe` (Right (RequestKeys [rk]))
     let cmdData = (toJSON . CommandSuccess . PLiteral . LDecimal) 3
     (_arResult <$> res') `shouldBe` (Right cmdData)
+
+  it "correctly runs a simple command with pact error publicly and listens to the result" $ do
+    cmd <- simpleServerCmdWithPactErr
+    let rk = cmdToRequestKey cmd
+    (res,res') <- bracket $! do
+      !res <- runClientM (send pactServerApiClient (SubmitBatch [cmd])) clientEnv
+      !res' <- runClientM (listen pactServerApiClient (ListenerRequest rk)) clientEnv
+      -- print (res,res')
+      return (res,res')
+    res `shouldBe` (Right (RequestKeys [rk]))
+    (_arResult <$> res') `shouldSatisfy` (failWith ArgsError)
+
+
+failWith :: PactErrorType -> Either ServantError Value -> Bool
+failWith errType res = case res of
+  Left _ -> False
+  Right res' -> case parse parseJSON res' of
+    Success (CommandError (PactError t _ _ _)) -> t == errType
+    _ -> False

--- a/tests/ClientSpec.hs
+++ b/tests/ClientSpec.hs
@@ -61,7 +61,7 @@ spec = describe "Servant API client tests" $ do
     res <- bracket $! do
       r <- runClientM (local pactServerApiClient cmd) clientEnv
       return r
-    let cmdPactResult = (toJSON . CommandSuccess . PLiteral . LDecimal) 3
+    let cmdPactResult = (toJSON . PactResult . Right . PLiteral . LDecimal) 3
     (_crResult' <$> res) `shouldBe` (Right cmdPactResult)
 
   it "correctly runs a simple command with pact error locally" $ do
@@ -80,7 +80,7 @@ spec = describe "Servant API client tests" $ do
       -- print (res,res')
       return (res,res')
     res `shouldBe` (Right (RequestKeys [rk]))
-    let cmdData = (toJSON . CommandSuccess . PLiteral . LDecimal) 3
+    let cmdData = (toJSON . PactResult . Right . PLiteral . LDecimal) 3
     (_arResult <$> res') `shouldBe` (Right cmdData)
 
   it "correctly runs a simple command with pact error publicly and listens to the result" $ do
@@ -99,5 +99,5 @@ failWith :: PactErrorType -> Either ServantError Value -> Bool
 failWith errType res = case res of
   Left _ -> False
   Right res' -> case parse parseJSON res' of
-    Success (CommandError (PactError t _ _ _)) -> t == errType
+    Success (PactResult (Left (PactError t _ _ _))) -> t == errType
     _ -> False

--- a/tests/ClientSpec.hs
+++ b/tests/ClientSpec.hs
@@ -18,6 +18,8 @@ import Pact.Types.Command
 import Data.Text (Text)
 import Pact.Server.Client
 import Servant.Client
+import Pact.Types.Runtime
+import Pact.Types.PactValue
 
 
 _testLogDir, _testConfigFilePath, _testPort, _serverPath :: String
@@ -54,7 +56,7 @@ spec = describe "Servant API client tests" $ do
       r <- runClientM (local pactServerApiClient cmd) clientEnv
       return r
     -- Linda TODO
-    let cmdPactResult = (toJSON . CommandSuccess . Number) 3 --Right . PLiteral . LDecimal $ 3
+    let cmdPactResult = (toJSON . CommandSuccess . PLiteral . LDecimal) 3 --Right . PLiteral . LDecimal $ 3
     (_crResult' <$> res) `shouldBe` (Right cmdPactResult)
   it "correctly runs a simple command publicly and listens to the result" $ do
     cmd <- simpleServerCmd
@@ -65,5 +67,5 @@ spec = describe "Servant API client tests" $ do
       -- print (res,res')
       return (res,res')
     res `shouldBe` (Right (RequestKeys [rk]))
-    let cmdData = (toJSON . CommandSuccess . Number) 3
+    let cmdData = (toJSON . CommandSuccess . PLiteral . LDecimal) 3
     (_arResult <$> res') `shouldBe` (Right cmdData)

--- a/tests/ClientSpec.hs
+++ b/tests/ClientSpec.hs
@@ -61,8 +61,7 @@ spec = describe "Servant API client tests" $ do
     res <- bracket $! do
       r <- runClientM (local pactServerApiClient cmd) clientEnv
       return r
-    -- Linda TODO
-    let cmdPactResult = (toJSON . CommandSuccess . PLiteral . LDecimal) 3 --Right . PLiteral . LDecimal $ 3
+    let cmdPactResult = (toJSON . CommandSuccess . PLiteral . LDecimal) 3
     (_crResult' <$> res) `shouldBe` (Right cmdPactResult)
 
   it "correctly runs a simple command with pact error locally" $ do

--- a/tests/ClientSpec.hs
+++ b/tests/ClientSpec.hs
@@ -19,6 +19,7 @@ import Data.Text (Text)
 import Pact.Server.Client
 import Servant.Client
 
+
 _testLogDir, _testConfigFilePath, _testPort, _serverPath :: String
 _testLogDir = testDir ++ "test-log/"
 _testConfigFilePath = testDir ++ "test-config.yaml"
@@ -52,8 +53,9 @@ spec = describe "Servant API client tests" $ do
     res <- bracket $! do
       r <- runClientM (local pactServerApiClient cmd) clientEnv
       return r
-    let cmdData = (CommandSuccess . Number) 3
-    res `shouldBe` (Right cmdData)
+    -- Linda TODO
+    let cmdPactResult = (toJSON . CommandSuccess . Number) 3 --Right . PLiteral . LDecimal $ 3
+    (_crResult' <$> res) `shouldBe` (Right cmdPactResult)
   it "correctly runs a simple command publicly and listens to the result" $ do
     cmd <- simpleServerCmd
     let rk = cmdToRequestKey cmd

--- a/tests/ClientSpec.hs
+++ b/tests/ClientSpec.hs
@@ -6,7 +6,6 @@
 module ClientSpec (spec) where
 
 import Data.Aeson
-import Data.Aeson.Types (parse)
 import Data.Default (def)
 import Test.Hspec
 import Utils.TestRunner
@@ -61,15 +60,15 @@ spec = describe "Servant API client tests" $ do
     res <- bracket $! do
       r <- runClientM (local pactServerApiClient cmd) clientEnv
       return r
-    let cmdPactResult = (toJSON . PactResult . Right . PLiteral . LDecimal) 3
-    (_crResult' <$> res) `shouldBe` (Right cmdPactResult)
+    let cmdPactResult = (PactResult . Right . PLiteral . LDecimal) 3
+    (_crResult <$> res) `shouldBe` (Right cmdPactResult)
 
   it "correctly runs a simple command with pact error locally" $ do
     cmd <- simpleServerCmdWithPactErr
     res <- bracket $! do
       r <- runClientM (local pactServerApiClient cmd) clientEnv
       return r
-    (_crResult' <$> res) `shouldSatisfy` (failWith ArgsError)
+    (_crResult <$> res) `shouldSatisfy` (failWith ArgsError)
 
   it "correctly runs a simple command publicly and listens to the result" $ do
     cmd <- simpleServerCmd
@@ -80,8 +79,8 @@ spec = describe "Servant API client tests" $ do
       -- print (res,res')
       return (res,res')
     res `shouldBe` (Right (RequestKeys [rk]))
-    let cmdData = (toJSON . PactResult . Right . PLiteral . LDecimal) 3
-    (_arResult <$> res') `shouldBe` (Right cmdData)
+    let cmdData = (PactResult . Right . PLiteral . LDecimal) 3
+    (_crResult <$> res') `shouldBe` (Right cmdData)
 
   it "correctly runs a simple command with pact error publicly and listens to the result" $ do
     cmd <- simpleServerCmdWithPactErr
@@ -92,12 +91,12 @@ spec = describe "Servant API client tests" $ do
       -- print (res,res')
       return (res,res')
     res `shouldBe` (Right (RequestKeys [rk]))
-    (_arResult <$> res') `shouldSatisfy` (failWith ArgsError)
+    (_crResult <$> res') `shouldSatisfy` (failWith ArgsError)
 
 
-failWith :: PactErrorType -> Either ServantError Value -> Bool
+failWith :: PactErrorType -> Either ServantError PactResult -> Bool
 failWith errType res = case res of
   Left _ -> False
-  Right res' -> case parse parseJSON res' of
-    Success (PactResult (Left (PactError t _ _ _))) -> t == errType
+  Right res' -> case res' of
+    (PactResult (Left (PactError t _ _ _))) -> t == errType
     _ -> False

--- a/tests/HistoryServiceSpec.hs
+++ b/tests/HistoryServiceSpec.hs
@@ -13,6 +13,7 @@ import qualified Data.HashSet as HashSet
 import System.Directory
 import Test.Hspec
 import Data.Default
+import Data.Aeson (Value)
 
 import Pact.Server.History.Persistence as DB
 import Pact.Server.History.Service
@@ -24,6 +25,7 @@ import Pact.Types.Term
 import Pact.Types.Runtime (PactError(..),PactErrorType(..))
 import Pact.Types.PactValue (PactValue)
 import Pact.Types.Pretty (viaShow)
+import Pact.Types.Persistence (TxLog)
 
 
 histFile :: FilePath
@@ -54,10 +56,10 @@ rq = RequestKey pactInitialHash
 res :: Either PactError PactValue
 res = Left $ PactError TxFailure def def . viaShow $ ("some error message" :: String)
 
-cr :: CommandResult
-cr = CommandResult rq Nothing (PactResult res) (Gas 0)
+cr :: CommandResult [TxLog Value]
+cr = CommandResult rq Nothing (PactResult res) (Gas 0) Nothing Nothing Nothing
 
-results :: HashMap.HashMap RequestKey CommandResult
+results :: HashMap.HashMap RequestKey (CommandResult [TxLog Value])
 results = HashMap.fromList [(rq, cr)]
 
 initHistory :: IO (HistoryEnv,HistoryState)

--- a/tests/HistoryServiceSpec.hs
+++ b/tests/HistoryServiceSpec.hs
@@ -55,7 +55,7 @@ res :: Either PactError PactValue
 res = Left $ PactError TxFailure def def . viaShow $ ("some error message" :: String)
 
 cr :: CommandResult
-cr = CommandResult rq Nothing res (Gas 0)
+cr = CommandResult rq Nothing (PactResult res) (Gas 0)
 
 results :: HashMap.HashMap RequestKey CommandResult
 results = HashMap.fromList [(rq, cr)]

--- a/tests/HistoryServiceSpec.hs
+++ b/tests/HistoryServiceSpec.hs
@@ -7,12 +7,12 @@ import Control.Concurrent.MVar
 import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans.RWS.Strict
-import Data.Aeson (Value(Null))
 import Data.ByteString (ByteString)
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.HashSet as HashSet
 import System.Directory
 import Test.Hspec
+import Data.Default
 
 import Pact.Server.History.Persistence as DB
 import Pact.Server.History.Service
@@ -21,6 +21,9 @@ import Pact.Types.Command
 import Pact.Types.Hash
 import Pact.Types.Server
 import Pact.Types.Term
+import Pact.Types.Runtime (PactError(..),PactErrorType(..))
+import Pact.Types.PactValue (PactValue)
+import Pact.Types.Pretty (viaShow)
 
 
 histFile :: FilePath
@@ -48,8 +51,11 @@ cmd = Command "" [] initialHash
 rq :: RequestKey
 rq = RequestKey pactInitialHash
 
+res :: Either PactError PactValue
+res = Left $ PactError TxFailure def def . viaShow $ ("some error message" :: String)
+
 cr :: CommandResult
-cr = CommandResult rq Nothing Null (Gas 0)
+cr = CommandResult rq Nothing res (Gas 0)
 
 results :: HashMap.HashMap RequestKey CommandResult
 results = HashMap.fromList [(rq, cr)]

--- a/tests/HistoryServiceSpec.hs
+++ b/tests/HistoryServiceSpec.hs
@@ -13,7 +13,6 @@ import qualified Data.HashSet as HashSet
 import System.Directory
 import Test.Hspec
 import Data.Default
-import Data.Aeson (Value)
 
 import Pact.Server.History.Persistence as DB
 import Pact.Server.History.Service
@@ -25,7 +24,6 @@ import Pact.Types.Term
 import Pact.Types.Runtime (PactError(..),PactErrorType(..))
 import Pact.Types.PactValue (PactValue)
 import Pact.Types.Pretty (viaShow)
-import Pact.Types.Persistence (TxLog)
 
 
 histFile :: FilePath
@@ -56,10 +54,10 @@ rq = RequestKey pactInitialHash
 res :: Either PactError PactValue
 res = Left $ PactError TxFailure def def . viaShow $ ("some error message" :: String)
 
-cr :: CommandResult [TxLog Value]
+cr :: CommandResult Hash
 cr = CommandResult rq Nothing (PactResult res) (Gas 0) Nothing Nothing Nothing
 
-results :: HashMap.HashMap RequestKey (CommandResult [TxLog Value])
+results :: HashMap.HashMap RequestKey (CommandResult Hash)
 results = HashMap.fromList [(rq, cr)]
 
 initHistory :: IO (HistoryEnv,HistoryState)

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -21,18 +21,18 @@ import qualified Data.Text as T
 
 ----- UTILS ------
 
-shouldMatch' :: HasCallStack => CommandResultCheck -> HM.HashMap RequestKey CommandResult -> Expectation
+shouldMatch' :: HasCallStack => CommandResultCheck -> HM.HashMap RequestKey (CommandResult Hash) -> Expectation
 shouldMatch' CommandResultCheck{..} results = do
           let apiRes = HM.lookup _crcReqKey results
           checkResult _crcExpect apiRes
 
 succeedsWith :: HasCallStack => Command Text -> Maybe PactValue ->
-                ReaderT (HM.HashMap RequestKey CommandResult) IO ()
+                ReaderT (HM.HashMap RequestKey (CommandResult Hash)) IO ()
 succeedsWith cmd r = ask >>= liftIO . shouldMatch'
                      (makeCheck cmd (ExpectResult . Right $ r))
 
 failsWith :: HasCallStack => Command Text -> Maybe String ->
-             ReaderT (HM.HashMap RequestKey CommandResult) IO ()
+             ReaderT (HM.HashMap RequestKey (CommandResult Hash)) IO ()
 failsWith cmd r = ask >>= liftIO . shouldMatch'
                   (makeCheck cmd (ExpectResult . Left $ r))
 
@@ -119,7 +119,7 @@ testPactContinuation mgr = before_ flushDb $ after_ flushDb $ do
     it "throws error and does not update pact's state" $
       testErrStep mgr
 
-testSimpleServerCmd :: HTTP.Manager -> IO (Maybe CommandResult)
+testSimpleServerCmd :: HTTP.Manager -> IO (Maybe (CommandResult Hash))
 testSimpleServerCmd mgr = do
   simpleKeys <- genKeys
   cmd <- mkExec  "(+ 1 2)" Null def
@@ -460,7 +460,7 @@ testTwoPartyEscrow mgr = before_ flushDb $ after_ flushDb $ do
 
 
 twoPartyEscrow :: [Command T.Text] -> HTTP.Manager ->
-                  ReaderT (HM.HashMap RequestKey CommandResult) IO () -> Expectation
+                  ReaderT (HM.HashMap RequestKey (CommandResult Hash)) IO () -> Expectation
 twoPartyEscrow testCmds mgr act = do
   let setupPath = testDir ++ "cont-scripts/setup-"
 

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -92,7 +92,7 @@ testNestedPacts mgr = before_ flushDb $ after_ flushDb $
 testPactContinuation :: HTTP.Manager -> Spec
 testPactContinuation mgr = before_ flushDb $ after_ flushDb $ do
   it "sends (+ 1 2) command to locally running dev server" $ do
-    let cmdData = (toJSON . CommandSuccess . Number) 3
+    let cmdData = (toJSON . CommandSuccess . PLiteral . LDecimal) 3
         expRes = Just $ ApiResult cmdData ((Just . TxId) 0) Nothing
     testSimpleServerCmd mgr `shouldReturn` expRes
 

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -13,7 +13,6 @@ import Data.Decimal
 import Control.Monad.Reader
 
 import Pact.ApiReq
-import Pact.Types.API
 import Pact.Types.Command
 import Pact.Types.Runtime
 import Pact.Types.PactValue
@@ -22,18 +21,20 @@ import qualified Data.Text as T
 
 ----- UTILS ------
 
-shouldMatch' :: HasCallStack => ApiResultCheck -> HM.HashMap RequestKey ApiResult -> Expectation
-shouldMatch' ApiResultCheck{..} results = do
-          let apiRes = HM.lookup _arcReqKey results
-          checkResult _arcIsFailure _arcExpect apiRes
+shouldMatch' :: HasCallStack => CommandResultCheck -> HM.HashMap RequestKey CommandResult -> Expectation
+shouldMatch' CommandResultCheck{..} results = do
+          let apiRes = HM.lookup _crcReqKey results
+          checkResult _crcExpect apiRes
 
-succeedsWith :: HasCallStack => Command Text -> Maybe Value ->
-                ReaderT (HM.HashMap RequestKey ApiResult) IO ()
-succeedsWith cmd r = ask >>= liftIO . shouldMatch' (makeCheck cmd False r)
+succeedsWith :: HasCallStack => Command Text -> Maybe PactValue ->
+                ReaderT (HM.HashMap RequestKey CommandResult) IO ()
+succeedsWith cmd r = ask >>= liftIO . shouldMatch'
+                     (makeCheck cmd (ExpectResult . Right $ r))
 
-failsWith :: HasCallStack => Command Text -> Maybe Value ->
-             ReaderT (HM.HashMap RequestKey ApiResult) IO ()
-failsWith cmd r = ask >>= liftIO . shouldMatch' (makeCheck cmd True r)
+failsWith :: HasCallStack => Command Text -> Maybe String ->
+             ReaderT (HM.HashMap RequestKey CommandResult) IO ()
+failsWith cmd r = ask >>= liftIO . shouldMatch'
+                  (makeCheck cmd (ExpectResult . Left $ r))
 
 runResults :: r -> ReaderT r m a -> m a
 runResults rs act = runReaderT act rs
@@ -47,23 +48,24 @@ makeContCmd :: SomeKeyPair -> Bool -> Value -> Command Text -> Int -> String -> 
 makeContCmd keyPairs isRollback cmdData pactExecCmd step nonce =
   mkCont (getPactId pactExecCmd) step isRollback cmdData def [keyPairs] (Just nonce)
 
+textVal :: Text -> Maybe PactValue
+textVal = Just . PLiteral . LString
 
 getPactId :: Command Text -> PactId
 getPactId cmd = toPactId hsh
   where hsh = (toUntypedHash . _cmdHash) cmd
 
 
-pactIdNotFoundMsg :: Command Text -> Maybe Value
-pactIdNotFoundMsg cmd = (Just . String) escaped
-  where txtPact = asString (getPactId cmd)
-        escaped = "resumePact: pact completed: " <> txtPact
+pactIdNotFoundMsg :: Command Text -> Maybe String
+pactIdNotFoundMsg cmd = Just msg
+  where txtPact = unpack (asString (getPactId cmd))
+        msg = "resumePact: pact completed: " <> txtPact
 
-stepMisMatchMsg :: Bool -> Int -> Int -> Maybe Value
-stepMisMatchMsg isRollback attemptStep currStep = (Just . String) msg
+stepMisMatchMsg :: Bool -> Int -> Int -> Maybe String
+stepMisMatchMsg isRollback attemptStep currStep = Just msg
   where typeOfStep = if isRollback then "rollback" else "exec"
         msg = "resumePactExec: " <> typeOfStep <> " step mismatch with context: ("
-              <> asString (show attemptStep) <> ", " <> asString (show currStep) <> ")"
-
+              <> show attemptStep <> ", " <> show currStep <> ")"
 
 ---- TESTS -----
 
@@ -96,9 +98,10 @@ testNestedPacts mgr = before_ flushDb $ after_ flushDb $
 testPactContinuation :: HTTP.Manager -> Spec
 testPactContinuation mgr = before_ flushDb $ after_ flushDb $ do
   it "sends (+ 1 2) command to locally running dev server" $ do
-    let cmdData = (toJSON . PactResult . Right . PLiteral . LDecimal) 3
-        expRes = Just $ ApiResult cmdData ((Just . TxId) 0) Nothing
-    testSimpleServerCmd mgr `shouldReturn` expRes
+    let cmdData = (PactResult . Right . PLiteral . LDecimal) 3
+        --expRes = Just $ CommandResult _ ((Just . TxId) 0) cmdData (Gas 0)
+    cr <- testSimpleServerCmd mgr
+    (_crResult <$> cr)`shouldBe` Just cmdData
 
   context "when provided with correct next step" $
     it "executes the next step and updates pact's state" $
@@ -116,7 +119,7 @@ testPactContinuation mgr = before_ flushDb $ after_ flushDb $ do
     it "throws error and does not update pact's state" $
       testErrStep mgr
 
-testSimpleServerCmd :: HTTP.Manager -> IO (Maybe ApiResult)
+testSimpleServerCmd :: HTTP.Manager -> IO (Maybe CommandResult)
 testSimpleServerCmd mgr = do
   simpleKeys <- genKeys
   cmd <- mkExec  "(+ 1 2)" Null def
@@ -140,8 +143,8 @@ testCorrectNextStep mgr = do
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
-    executePactCmd `succeedsWith` Just "step 0"
-    contNextStepCmd `succeedsWith` Just "step 1"
+    executePactCmd `succeedsWith` textVal "step 0"
+    contNextStepCmd `succeedsWith` textVal "step 1"
     checkStateCmd `failsWith` stepMisMatchMsg False 1 1
 
 
@@ -162,9 +165,9 @@ testIncorrectNextStep mgr = do
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
-    executePactCmd `succeedsWith` Just "step 0"
+    executePactCmd `succeedsWith` textVal "step 0"
     incorrectStepCmd `failsWith` stepMisMatchMsg False 2 0
-    checkStateCmd `succeedsWith` Just "step 1"
+    checkStateCmd `succeedsWith` textVal "step 1"
 
 
 testLastStep :: HTTP.Manager -> Expectation
@@ -185,9 +188,9 @@ testLastStep mgr = do
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
-    executePactCmd `succeedsWith` Just "step 0"
-    contNextStep1Cmd `succeedsWith` Just "step 1"
-    contNextStep2Cmd `succeedsWith` Just "step 2"
+    executePactCmd `succeedsWith` textVal "step 0"
+    contNextStep1Cmd `succeedsWith` textVal "step 1"
+    contNextStep2Cmd `succeedsWith` textVal "step 2"
     checkStateCmd `failsWith`
       pactIdNotFoundMsg executePactCmd
 
@@ -209,7 +212,7 @@ testErrStep mgr = do
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
-    executePactCmd `succeedsWith` Just "step 0"
+    executePactCmd `succeedsWith` textVal "step 0"
     contErrStepCmd `failsWith`  Nothing
     checkStateCmd `failsWith` stepMisMatchMsg False 2 0
 
@@ -255,9 +258,9 @@ testCorrectRollbackStep mgr = do
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
-    executePactCmd `succeedsWith` Just "step 0"
-    contNextStepCmd `succeedsWith` Just "step 1"
-    rollbackStepCmd `succeedsWith` Just "rollback 1"
+    executePactCmd `succeedsWith` textVal "step 0"
+    contNextStepCmd `succeedsWith` textVal "step 1"
+    rollbackStepCmd `succeedsWith` textVal "rollback 1"
     checkStateCmd `failsWith`
       pactIdNotFoundMsg executePactCmd
 
@@ -281,10 +284,10 @@ testIncorrectRollbackStep mgr = do
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
-    executePactCmd `succeedsWith` Just "step 0"
-    contNextStepCmd `succeedsWith` Just "step 1"
+    executePactCmd `succeedsWith` textVal "step 0"
+    contNextStepCmd `succeedsWith` textVal "step 1"
     incorrectRbCmd `failsWith` stepMisMatchMsg True 2 1
-    checkStateCmd `succeedsWith` Just "step 2"
+    checkStateCmd `succeedsWith` textVal "step 2"
 
 
 testRollbackErr :: HTTP.Manager -> Expectation
@@ -306,10 +309,10 @@ testRollbackErr mgr = do
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
-    executePactCmd `succeedsWith` Just "step 0"
-    contNextStepCmd `succeedsWith` Just "step 1"
+    executePactCmd `succeedsWith` textVal "step 0"
+    contNextStepCmd `succeedsWith` textVal "step 1"
     rollbackErrCmd `failsWith`  Nothing
-    checkStateCmd `succeedsWith` Just "step 2"
+    checkStateCmd `succeedsWith` textVal "step 2"
 
 
 testNoRollbackFunc :: HTTP.Manager -> Expectation
@@ -331,10 +334,10 @@ testNoRollbackFunc mgr = do
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
-    executePactCmd `succeedsWith` Just "step 0"
-    contNextStepCmd `succeedsWith` Just "step 1"
+    executePactCmd `succeedsWith` textVal "step 0"
+    contNextStepCmd `succeedsWith` textVal "step 1"
     noRollbackCmd `failsWith` Just "Rollback requested but none in step"
-    checkStateCmd `succeedsWith` Just "step 2"
+    checkStateCmd `succeedsWith` textVal "step 2"
 
 
 
@@ -373,9 +376,9 @@ testValidYield mgr = do
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
-    executePactCmd `succeedsWith` Just "testing->Step0"
-    resumeAndYieldCmd `succeedsWith` Just "testing->Step0->Step1"
-    resumeOnlyCmd `succeedsWith` Just "testing->Step0->Step1->Step2"
+    executePactCmd `succeedsWith` textVal "testing->Step0"
+    resumeAndYieldCmd `succeedsWith` textVal "testing->Step0->Step1"
+    resumeOnlyCmd `succeedsWith` textVal "testing->Step0->Step1->Step2"
     checkStateCmd `failsWith`
       pactIdNotFoundMsg executePactCmd
 
@@ -398,8 +401,8 @@ testNoYield mgr = do
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
-    executePactCmd `succeedsWith` Just "testing->Step0"
-    noYieldStepCmd `succeedsWith` Just "step 1 has no yield"
+    executePactCmd `succeedsWith` textVal "testing->Step0"
+    noYieldStepCmd `succeedsWith` textVal "step 1 has no yield"
     resumeErrCmd `failsWith`  Nothing
     checkStateCmd `failsWith` stepMisMatchMsg False 1 1
 
@@ -422,9 +425,9 @@ testResetYield mgr = do
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
-    executePactCmd `succeedsWith` Just "step 0"
-    yieldSameKeyCmd `succeedsWith` Just "step 1"
-    resumeStepCmd `succeedsWith` Just "step 1"
+    executePactCmd `succeedsWith` textVal "step 0"
+    yieldSameKeyCmd `succeedsWith` textVal "step 1"
+    resumeStepCmd `succeedsWith` textVal "step 1"
     checkStateCmd `failsWith`
       pactIdNotFoundMsg executePactCmd
 
@@ -457,7 +460,7 @@ testTwoPartyEscrow mgr = before_ flushDb $ after_ flushDb $ do
 
 
 twoPartyEscrow :: [Command T.Text] -> HTTP.Manager ->
-                  ReaderT (HM.HashMap RequestKey ApiResult) IO () -> Expectation
+                  ReaderT (HM.HashMap RequestKey CommandResult) IO () -> Expectation
 twoPartyEscrow testCmds mgr act = do
   let setupPath = testDir ++ "cont-scripts/setup-"
 
@@ -473,9 +476,9 @@ twoPartyEscrow testCmds mgr act = do
   allResults <- runAll mgr allCmds
 
   runResults allResults $ do
-    sysModuleCmd `succeedsWith` Just "system module loaded"
-    acctModuleCmd `succeedsWith` Just "TableCreated"
-    testModuleCmd `succeedsWith` Just "test module loaded"
+    sysModuleCmd `succeedsWith` textVal "system module loaded"
+    acctModuleCmd `succeedsWith` textVal "TableCreated"
+    testModuleCmd `succeedsWith` textVal "test module loaded"
     createAcctCmd `succeedsWith`  Nothing -- Alice should be funded with $100
     resetTimeCmd `succeedsWith`  Nothing
     runEscrowCmd `succeedsWith`  Nothing
@@ -483,8 +486,8 @@ twoPartyEscrow testCmds mgr act = do
     act
 
 
-decValue :: Decimal -> Maybe Value
-decValue = Just . toJSON . PLiteral . LDecimal
+decValue :: Decimal -> Maybe PactValue
+decValue = Just . PLiteral . LDecimal
 
 testDebtorPreTimeoutCancel :: HTTP.Manager -> Expectation
 testDebtorPreTimeoutCancel mgr = do
@@ -494,10 +497,10 @@ testDebtorPreTimeoutCancel mgr = do
   (_, checkStillEscrowCmd) <- mkApiReq (testPath ++ "02-balance.yaml")
   let allCmds = [tryCancelCmd, checkStillEscrowCmd]
 
-  let cancelMsg = T.concat ["Cancel can only be effected by",
-                            " creditor, or debitor after timeout"]
+  let cancelMsg = "Cancel can only be effected by" <>
+                  " creditor, or debitor after timeout"
   twoPartyEscrow allCmds mgr $ do
-    tryCancelCmd `failsWith` Just (String cancelMsg)
+    tryCancelCmd `failsWith` Just cancelMsg
     checkStillEscrowCmd `succeedsWith` decValue 98.00
 
 
@@ -565,6 +568,6 @@ testValidEscrowFinish mgr = do
 
   twoPartyEscrow allCmds mgr $ do
     tryNegDownCmd `succeedsWith`
-                         (Just "Escrow completed with 1.75 paid and 0.25 refunded")
+                         (textVal "Escrow completed with 1.75 paid and 0.25 refunded")
     credBalanceCmd `succeedsWith` decValue 1.75
     debBalanceCmd `succeedsWith` decValue 98.25

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -96,7 +96,7 @@ testNestedPacts mgr = before_ flushDb $ after_ flushDb $
 testPactContinuation :: HTTP.Manager -> Spec
 testPactContinuation mgr = before_ flushDb $ after_ flushDb $ do
   it "sends (+ 1 2) command to locally running dev server" $ do
-    let cmdData = (toJSON . CommandSuccess . PLiteral . LDecimal) 3
+    let cmdData = (toJSON . PactResult . Right . PLiteral . LDecimal) 3
         expRes = Just $ ApiResult cmdData ((Just . TxId) 0) Nothing
     testSimpleServerCmd mgr `shouldReturn` expRes
 

--- a/tests/Utils/TestRunner.hs
+++ b/tests/Utils/TestRunner.hs
@@ -24,7 +24,7 @@ module Utils.TestRunner
   , stopServer
   ) where
 
-import Pact.Server.Server (setupServer)
+import Pact.Server.Server (serve)
 import qualified Pact.Server.Client as C
 import Pact.Types.API
 import Pact.Types.Command
@@ -75,14 +75,11 @@ runAll mgr cmds = Exception.bracket
                stopServer
               (const (run mgr cmds))
 
-startServer :: FilePath -> IO (Async (), Async (), Async ())
+startServer :: FilePath -> IO (Async ())
 startServer configFile = do
-  (runServer, asyncCmd, asyncHist) <- setupServer configFile
-  asyncServer <- async runServer
-  link2 asyncServer asyncCmd
-  link2 asyncServer asyncHist
+  asyncServer <- async $ serve configFile
   waitUntilStarted 0
-  return (asyncServer, asyncCmd, asyncHist)
+  return asyncServer
 
 waitUntilStarted :: Int -> IO ()
 waitUntilStarted i | i > 10 = throwIO $ userError "waitUntilStarted: failing after 10 attempts"
@@ -97,12 +94,10 @@ waitUntilStarted i = do
       threadDelay 500
       waitUntilStarted (succ i)
 
-stopServer :: (Async (), Async (), Async ()) -> IO ()
-stopServer (asyncServer, asyncCmd, asyncHist) = do
-  uninterruptibleCancel asyncCmd
-  uninterruptibleCancel asyncHist
-  uninterruptibleCancel asyncServer
-  mapM_ checkFinished [asyncServer, asyncCmd, asyncHist]
+stopServer :: Async () -> IO ()
+stopServer asyncServer = do
+  cancel asyncServer
+  mapM_ checkFinished [asyncServer]
   where checkFinished asy = poll asy >>= \case
           Nothing -> Exception.evaluate $ error $
                     "Thread " ++ show (asyncThreadId asy) ++ " could not be cancelled."


### PR DESCRIPTION
Overhauls `CommandResult` and the Servant API per ["CommandResult proposal" #451 (comment)](https://github.com/kadena-io/pact/issues/451#issuecomment-479665427)