### PR TITLE
Add analysis for non-literal constants

### DIFF
--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -842,7 +842,7 @@ verifyModule modules moduleData = runExceptT $ do
     typecheckableRefs
 
   let constToProp :: ETerm -> Except VerificationFailure EProp
-      constToProp tm = case eTermToProp tm of
+      constToProp tm = case constantToProp tm of
         Right prop -> pure prop
         Left msg   -> throwError $ FailedConstTranslation msg
 

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -841,8 +841,8 @@ verifyModule modules moduleData = runExceptT $ do
     (HM.empty, HM.empty)
     typecheckableRefs
 
-  let valueToProp' :: ETerm -> Except VerificationFailure EProp
-      valueToProp' tm = case valueToProp tm of
+  let constToProp :: ETerm -> Except VerificationFailure EProp
+      constToProp tm = case eTermToProp tm of
         Right prop -> pure prop
         Left msg   -> throwError $ FailedConstTranslation msg
 
@@ -850,7 +850,7 @@ verifyModule modules moduleData = runExceptT $ do
         = withExceptT translateToVerificationFailure . translateNodeNoGraph
 
   consts' <- hoist generalize $
-    traverse (valueToProp' <=< translateNodeNoGraph') consts
+    traverse (constToProp <=< translateNodeNoGraph') consts
 
   (funChecks :: HM.HashMap Text ((Ref, CheckableType), Either ParseFailure [Located Check]))
     <- hoist generalize $

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -38,7 +38,7 @@ module Pact.Analyze.Types.Languages
 
   , toPact
   , fromPact
-  , eTermToProp
+  , constantToProp
   , sortLiteralObject
   , mkLiteralList
   , mkLiteralObject
@@ -75,7 +75,6 @@ module Pact.Analyze.Types.Languages
 
 import           Control.Lens                  (Prism', review, preview, prism')
 import           Control.Monad                 ((>=>))
-import           Data.Bifunctor                (first)
 import           Data.Maybe                    (fromMaybe)
 import           Data.String                   (IsString (..))
 import           Data.Text                     (Text)
@@ -1657,154 +1656,12 @@ instance Num (Term 'TyDecimal) where
   signum = inject .   DecUnaryArithOp Signum
   negate = inject .   DecUnaryArithOp Negate
 
-eTermToProp :: ETerm -> Either String EProp
-eTermToProp (Some ty t) = first appendTerm $ Some ty <$> termToProp t
-  where
-    appendTerm err = err ++ ": " ++ withSing ty (show t)
-
-termToProp :: Term a -> Either String (Prop a)
-termToProp = \case
-  CoreTerm coreTerm -> CoreProp <$>
-    case coreTerm of
-      Lit l ->
-        pure $ Lit l
-      Sym v ->
-        pure $ Sym v
-      Var vid nm ->
-        pure $ Var vid nm
-      Identity ty t ->
-        Identity ty <$> termToProp t
-      Constantly ty t1 t2 ->
-        Constantly ty <$> termToProp t1 <*> termToProp t2
-      Compose tyA tyB tyC a (Open v1 nm1 b) (Open v2 nm2 c) -> do
-        a' <- termToProp a
-        b' <- termToProp b
-        c' <- termToProp c
-        pure $ Compose tyA tyB tyC a' (Open v1 nm1 b') (Open v2 nm2 c')
-      StrConcat t1 t2 ->
-        StrConcat <$> termToProp t1 <*> termToProp t2
-      StrLength t ->
-        StrLength <$> termToProp t
-      StrToInt t ->
-        StrToInt <$> termToProp t
-      StrToIntBase t1 t2 ->
-        StrToIntBase <$> termToProp t1 <*> termToProp t2
-      StrContains t1 t2 ->
-        StrContains <$> termToProp t1 <*> termToProp t2
-      Numerical n ->
-        Numerical <$> numTermToProp n
-      IntAddTime t1 t2 ->
-        IntAddTime <$> termToProp t1 <*> termToProp t2
-      DecAddTime t1 t2 ->
-        DecAddTime <$> termToProp t1 <*> termToProp t2
-      Comparison ty op t1 t2 ->
-        Comparison ty op <$> termToProp t1 <*> termToProp t2
-      GuardEqNeq op t1 t2 ->
-        GuardEqNeq op <$> termToProp t1 <*> termToProp t2
-      ObjectEqNeq s1 s2 op t1 t2 ->
-        ObjectEqNeq s1 s2 op <$> termToProp t1 <*> termToProp t2
-      ObjAt s t1 t2 ->
-        ObjAt s <$> termToProp t1 <*> termToProp t2
-      ObjContains s t1 t2 ->
-        ObjContains s <$> termToProp t1 <*> termToProp t2
-      ObjDrop s t1 t2 ->
-        ObjDrop s <$> termToProp t1 <*> termToProp t2
-      ObjTake s t1 t2 ->
-        ObjTake s <$> termToProp t1 <*> termToProp t2
-      ObjMerge s1 s2 t1 t2 ->
-        ObjMerge s1 s2 <$> termToProp t1 <*> termToProp t2
-      LiteralObject s o ->
-        LiteralObject s <$> objTermToProp o
-      Logical op ts ->
-        Logical op <$> traverse termToProp ts
-      ListEqNeq ty op t1 t2 ->
-        ListEqNeq ty op <$> termToProp t1 <*> termToProp t2
-      ListAt ty t1 t2 ->
-        ListAt ty <$> termToProp t1 <*> termToProp t2
-      ListContains ty t1 t2 ->
-        ListContains ty <$> termToProp t1 <*> termToProp t2
-      ListLength ty t ->
-        ListLength ty <$> termToProp t
-      ListReverse ty t ->
-        ListReverse ty <$> termToProp t
-      ListSort ty t ->
-        ListSort ty <$> termToProp t
-      ListConcat ty t1 t2 ->
-        ListConcat ty <$> termToProp t1 <*> termToProp t2
-      ListDrop ty t1 t2 ->
-        ListDrop ty <$> termToProp t1 <*> termToProp t2
-      ListTake ty t1 t2 ->
-        ListTake ty <$> termToProp t1 <*> termToProp t2
-      MakeList ty t1 t2 ->
-        MakeList ty <$> termToProp t1 <*> termToProp t2
-      LiteralList ty ts ->
-        LiteralList ty <$> traverse termToProp ts
-      ListMap tyA tyB (Open v1 nm1 fBody) as -> do
-        fBody' <- termToProp fBody
-        as' <- termToProp as
-        pure $ ListMap tyA tyB (Open v1 nm1 fBody') as'
-      ListFilter ty (Open v1 nm1 fBody) as -> do
-        fBody' <- termToProp fBody
-        as' <- termToProp as
-        pure $ ListFilter ty (Open v1 nm1 fBody') as'
-      ListFold tyA tyB (Open v1 nm1 (Open v2 nm2 accBody)) zero bs -> do
-        accBody' <- termToProp accBody
-        zero' <- termToProp zero
-        bs' <- termToProp bs
-        pure $ ListFold tyA tyB (Open v1 nm1 (Open v2 nm2 accBody')) zero' bs'
-      AndQ ty (Open v1 nm1 body1) (Open v2 nm2 body2) t -> do
-        body1' <- termToProp body1
-        body2' <- termToProp body2
-        t' <- termToProp t
-        pure $ AndQ ty (Open v1 nm1 body1') (Open v2 nm2 body2') t'
-      OrQ ty (Open v1 nm1 body1) (Open v2 nm2 body2) t -> do
-        body1' <- termToProp body1
-        body2' <- termToProp body2
-        t' <- termToProp t
-        pure $ OrQ ty (Open v1 nm1 body1') (Open v2 nm2 body2') t'
-      Where s ty t1 (Open v nm body) t2 -> do
-        t1' <- termToProp t1
-        body' <- termToProp body
-        t2' <- termToProp t2
-        pure $ Where s ty t1' (Open v nm body') t2'
-      Typeof ty t ->
-        Typeof ty <$> termToProp t
-
-  _ -> Left "could not translate non-core term to prop"
-
-objTermToProp :: Object Term m -> Either String (Object Prop m)
-objTermToProp (Object hl) = Object <$> go hl
-  where
-    go :: HList (Column Term) m -> Either String (HList (Column Prop) m)
-    go SNil = pure SNil
-    go (SCons ty t rest) = do
-      t' <- colTermToProp t
-      rest' <- go rest
-      pure $ SCons ty t' rest'
-
-colTermToProp :: Column Term ty -> Either String (Column Prop ty)
-colTermToProp (Column ty t) = Column ty <$> termToProp t
-
-numTermToProp :: Numerical Term a -> Either String (Numerical Prop a)
-numTermToProp = \case
-  DecArithOp op t1 t2 ->
-    DecArithOp op <$> termToProp t1 <*> termToProp t2
-  IntArithOp op t1 t2 ->
-    IntArithOp op <$> termToProp t1 <*> termToProp t2
-  DecUnaryArithOp op t ->
-    DecUnaryArithOp op <$> termToProp t
-  IntUnaryArithOp op t ->
-    IntUnaryArithOp op <$> termToProp t
-  DecIntArithOp op t1 t2 ->
-    DecIntArithOp op <$> termToProp t1 <*> termToProp t2
-  IntDecArithOp op t1 t2 ->
-    IntDecArithOp op <$> termToProp t1 <*> termToProp t2
-  ModOp t1 t2 ->
-    ModOp <$> termToProp t1 <*> termToProp t2
-  RoundingLikeOp1 op t ->
-    RoundingLikeOp1 op <$> termToProp t
-  RoundingLikeOp2 op t1 t2 ->
-    RoundingLikeOp2 op <$> termToProp t1 <*> termToProp t2
+constantToProp :: ETerm -> Either String EProp
+constantToProp = \case
+  Some ty (CoreTerm (Lit l))
+    -> Right $ Some ty (CoreProp (Lit l))
+  Some ty t -> Left $
+    "encountered unexpected non-literal for constant: " ++ withSing ty (show t)
 
 -- Note [instances]:
 -- The following nine instances seem like they should be

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -816,7 +816,12 @@ toAST TSchema {..} = die _tInfo "User type in value position"
 
 toAST (TVar v i) = case v of -- value position only, TApp has its own resolver
   (Left (Ref r)) -> toAST (fmap Left r)
-  (Left Direct {}) -> die i "Native in value context"
+  (Left (Direct t)) ->
+    case t of
+      TLiteral {..} ->
+        trackPrim _tInfo (litToPrim _tLiteral) (PrimLit _tLiteral)
+      _ ->
+        die i $ "Native in value context: " ++ show t
   (Right t) -> return t
 
 toAST (TApp Term.App{..} _) = do

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -932,7 +932,7 @@ toAST (TObject Term.Object {..} _) = do
   ty <- TySchema TyObject <$> traverse toUserType _oObjectType <*> pure FullSchema
   Object <$> (trackNode ty =<< freshId _oInfo "object")
     <*> mapM toAST _oObject
-toAST TConst {..} = toAST (_cvRaw _tConstVal) -- TODO typecheck here
+toAST TConst {..} = toAST (_cvEval _tConstVal) -- TODO typecheck here
 toAST TGuard {..} = trackPrim _tInfo (TyGuard $ Just $ guardTypeOf _tGuard) (PrimGuard _tGuard)
 toAST TLiteral {..} = trackPrim _tInfo (litToPrim _tLiteral) (PrimLit _tLiteral)
 toAST TTable {..} = do

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -819,6 +819,7 @@ toAST (TVar v i) = case v of -- value position only, TApp has its own resolver
   (Left (Direct t)) ->
     case t of
       TLiteral {..} ->
+        -- Handle references to pre-evaluated constants:
         trackPrim _tInfo (litToPrim _tLiteral) (PrimLit _tLiteral)
       _ ->
         die i $ "Native in value context: " ++ show t


### PR DESCRIPTION
Before this point, we only analyzed literal constants. This causes issues like #502.

The problem in that issue is the presence of `(defconst EPOCH:time (time "1970-01-01T00:00:00Z"))`. On this PR, I just finished adding support for arbitrary "core terms", but this still does not allow us to use `time` (which can cause a tx to fail, and therefore lives in `Term`).

We need to figure out how we can support things like `time` as well.