### PR TITLE
Add second missing use of cvEval

### DIFF
--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -938,7 +938,7 @@ toAST (TObject Term.Object {..} _) = do
   ty <- TySchema TyObject <$> traverse toUserType _oObjectType <*> pure FullSchema
   Object <$> (trackNode ty =<< freshId _oInfo "object")
     <*> mapM toAST _oObject
-toAST TConst {..} = toAST (_cvEval _tConstVal) -- TODO typecheck here
+toAST TConst {..} = toAST $ constTerm _tConstVal -- TODO(stuart): typecheck here
 toAST TGuard {..} = trackPrim _tInfo (TyGuard $ Just $ guardTypeOf _tGuard) (PrimGuard _tGuard)
 toAST TLiteral {..} = trackPrim _tInfo (litToPrim _tLiteral) (PrimLit _tLiteral)
 toAST TTable {..} = do
@@ -1005,7 +1005,7 @@ mkTop t@TConst {..} = do
   debug $ "===== Const: " ++ abbrevStr (AbbrevNode <$> t)
   TopConst _tInfo (asString _tModule <> "." <> _aName _tConstArg) <$>
     traverse toUserType (_aType _tConstArg) <*>
-    toAST (_cvRaw _tConstVal) <*> pure (_mDocs _tMeta)
+    toAST (constTerm _tConstVal) <*> pure (_mDocs _tMeta)
 mkTop t@TTable {..} = do
   debug $ "===== Table: " ++ abbrevStr (AbbrevNode <$> t)
   TopTable _tInfo (asString _tModule <> "." <> asString _tTableName) <$>

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -55,7 +55,7 @@ module Pact.Types.Term
    Governance(..),
    ModuleName(..), mnName, mnNamespace,
    Name(..),parseName,
-   ConstVal(..),
+   ConstVal(..),constTerm,
    Use(..),
    App(..),appFun,appArgs,appInfo,
    Def(..),dDefBody,dDefName,dDefType,dMeta,dFunType,dInfo,dModule,
@@ -701,6 +701,10 @@ instance FromJSON n => FromJSON (ConstVal n) where
     (withObject "CVRaw"
      (\o -> CVRaw <$> o .: "raw") v)
 
+-- | A term from a 'ConstVal', preferring evaluated terms when available.
+constTerm :: ConstVal a -> a
+constTerm (CVRaw raw) = raw
+constTerm (CVEval _raw eval) = eval
 
 data Example
   = ExecExample !Text


### PR DESCRIPTION
We missed one other spot in the typechecker where we should have used `CVEval` (when possible). Now the "non-literal for constant" error is *actually* gone for CLI usage.

And for both of these spots in the typechecker, we should never directly use `_cvEval` -- this can cause `RecSelError`s because this field is only defined for one of `ConstVal`'s two constructors. I introduced a helper function to remedy this, which prefers evaluated terms if possible, and uses a raw term if that's all we have.

/cc @ggobugi27