### PR TITLE
swagger2 >= 2.3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -29,6 +29,12 @@ in
     overrides = self: super: with pkgs.haskell.lib;
       let guardGhcjs = p: if self.ghc.isGhcjs or false then null else p;
           whenGhcjs = f: p: if self.ghc.isGhcjs or false then (f p) else p;
+          callHackageDirect = {pkg, ver, sha256}@args:
+            let pkgver = "${pkg}-${ver}";
+            in self.callCabal2nix pkg (pkgs.fetchzip {
+                 url = "http://hackage.haskell.org/package/${pkgver}/${pkgver}.tar.gz";
+                 inherit sha256;
+               }) {};
        in {
             pact = doCoverage (addBuildDepend super.pact pkgs.z3);
             haskeline = guardGhcjs super.haskeline;
@@ -62,7 +68,6 @@ in
             servant-client = whenGhcjs dontCheck super.servant-client;
             servant-server = whenGhcjs dontCheck super.servant-server;
             servant-swagger = whenGhcjs dontCheck super.servant-swagger;
-            swagger2 = whenGhcjs dontCheck super.swagger2;
             unix-time = whenGhcjs dontCheck super.unix-time;
             wai-app-static = whenGhcjs dontCheck super.wai-app-static;
             wai-extra = whenGhcjs dontCheck super.wai-extra;
@@ -75,6 +80,12 @@ in
             }));
 
             algebraic-graphs = dontCheck super.algebraic-graphs;
+
+            swagger2 = whenGhcjs dontCheck (doJailbreak (callHackageDirect {
+              pkg = "swagger2";
+              ver = "2.3.1.1";
+              sha256 = "0rhxqdiymh462ya9h76qnv73v8hparwz8ibqqr1d06vg4zm7s86p";
+            }));
 
             # Prevent: "Setup: Encountered missing dependencies: doctest >=0.9"
             prettyprinter = dontCheck super.prettyprinter;

--- a/pact.cabal
+++ b/pact.cabal
@@ -186,7 +186,7 @@ library
                      , servant-client
                      , servant-client-core
                      , servant-swagger
-                     , swagger2 >= 2.2
+                     , swagger2 >= 2.3
 
   if impl(ghcjs)
     build-depends:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,14 @@
 # stack yaml for ghc builds
 
-resolver: lts-13.22
+resolver: lts-13.23
 
 packages:
   - '.'
 
 extra-deps:
   # --- Missing from Stackage --- #
-  - ed25519-donna-0.1.1@sha256:344c0bb83603ed896012f441e54b380314dc4910320577cd18a9071e34f24fe9,2358
-  - prettyprinter-convert-ansi-wl-pprint-1.1@sha256:ae908ee44422c38a696858f04928d4b2448df656c09e6b5f5b1be05d99669fb0,3022
+  - ed25519-donna-0.1.1
+  - prettyprinter-convert-ansi-wl-pprint-1.1
 
   # --- Forced Downgrades --- #
   - megaparsec-6.5.0


### PR DESCRIPTION
So that we can document `ObjectMap` as desired.