### PR TITLE
NonEmpty API Types

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -169,7 +169,7 @@ library
                      , safe >= 0.3.11 && < 0.4
                      , scientific >= 0.3.4.9 && < 0.4
                      , semigroups >= 0.18.2 && < 0.19
-                     , semigroupoids >= 5.3
+                     , semigroupoids >= 5.0
                      , stm >= 2.4.4.1 && < 2.6
                      , text >= 1.2.2.1 && < 1.3
                      -- kadena ghcjs compat fork

--- a/pact.cabal
+++ b/pact.cabal
@@ -169,6 +169,7 @@ library
                      , safe >= 0.3.11 && < 0.4
                      , scientific >= 0.3.4.9 && < 0.4
                      , semigroups >= 0.18.2 && < 0.19
+                     , semigroupoids >= 5.3
                      , stm >= 2.4.4.1 && < 2.6
                      , text >= 1.2.2.1 && < 1.3
                      -- kadena ghcjs compat fork

--- a/src/Pact/Types/API.hs
+++ b/src/Pact/Types/API.hs
@@ -1,12 +1,11 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-
+{-# LANGUAGE TemplateHaskell #-}
 
 -- |
 -- Module      :  Pact.Types.API
@@ -27,18 +26,18 @@ module Pact.Types.API
   ) where
 
 import Control.Applicative ((<|>))
-import Data.Aeson hiding (Success)
-import Control.Lens hiding ((.=))
-import GHC.Generics
-import qualified Data.HashMap.Strict as HM
 import Control.Arrow
+import Control.Lens hiding ((.=))
 import Control.Monad
+import Data.Aeson hiding (Success)
+import qualified Data.HashMap.Strict as HM
+import Data.List.NonEmpty (NonEmpty)
+import GHC.Generics
 
 import Pact.Types.Command
-import Pact.Types.Util
 import Pact.Types.Runtime
 
-newtype RequestKeys = RequestKeys { _rkRequestKeys :: [RequestKey] }
+newtype RequestKeys = RequestKeys { _rkRequestKeys :: NonEmpty RequestKey }
   deriving (Show, Eq, Ord, Generic)
 makeLenses ''RequestKeys
 
@@ -49,7 +48,7 @@ instance FromJSON RequestKeys where
 
 
 -- | Submit new commands for execution
-newtype SubmitBatch = SubmitBatch { _sbCmds :: [Command Text] }
+newtype SubmitBatch = SubmitBatch { _sbCmds :: NonEmpty (Command Text) }
   deriving (Eq,Generic,Show)
 makeLenses ''SubmitBatch
 
@@ -59,8 +58,9 @@ instance FromJSON SubmitBatch where
    parseJSON = lensyParseJSON 3
 
 -- | Poll for results by RequestKey
-newtype Poll = Poll { _pRequestKeys :: [RequestKey] }
+newtype Poll = Poll { _pRequestKeys :: NonEmpty RequestKey }
   deriving (Eq,Show,Generic)
+
 instance ToJSON Poll where
   toJSON = lensyToJSON 2
 instance FromJSON Poll where
@@ -69,6 +69,7 @@ instance FromJSON Poll where
 -- | What you get back from a Poll
 newtype PollResponses = PollResponses (HM.HashMap RequestKey (CommandResult Hash))
   deriving (Eq, Show, Generic)
+
 instance ToJSON PollResponses where
   toJSON (PollResponses m) = object $ map (requestKeyToB16Text *** toJSON) $ HM.toList m
 instance FromJSON PollResponses where
@@ -79,6 +80,7 @@ instance FromJSON PollResponses where
 -- | ListenerRequest for results by RequestKey
 newtype ListenerRequest = ListenerRequest RequestKey
   deriving (Eq,Show,Generic)
+
 instance ToJSON ListenerRequest where
   toJSON (ListenerRequest r) = object ["listen" .= r]
 instance FromJSON ListenerRequest where

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,6 @@
 # stack yaml for ghc builds
 
-resolver: lts-13.23
-
-packages:
-  - '.'
+resolver: lts-13.24
 
 extra-deps:
   # --- Missing from Stackage --- #

--- a/tests/Utils/TestRunner.hs
+++ b/tests/Utils/TestRunner.hs
@@ -35,21 +35,22 @@ import Pact.Types.Runtime (PactError(..))
 import Pact.Types.PactValue (PactValue(..))
 import Pact.Types.Hash
 
-import Control.Exception
-import Data.Aeson
-import Test.Hspec
-import qualified Data.Text as T
-import qualified Data.HashMap.Strict as HM
-import qualified Control.Exception as Exception
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
+import Control.Exception
 import Control.Monad
+import Data.Aeson
+import NeatInterpolation (text)
 import Network.HTTP.Client (Manager)
-import qualified Network.HTTP.Client as HTTP
 import Servant.Client
 import System.Directory
 import System.Timeout
-import NeatInterpolation (text)
+import Test.Hspec
+import qualified Control.Exception as Exception
+import qualified Data.HashMap.Strict as HM
+import qualified Data.List.NonEmpty as NEL
+import qualified Data.Text as T
+import qualified Network.HTTP.Client as HTTP
 
 testDir, _testLogDir, _testConfigFilePath, _testPort, _serverPath, _serverRootPath :: String
 testDir = "tests/"
@@ -114,7 +115,7 @@ stopServer asyncServer = do
 
 run :: Manager -> [Command T.Text] -> IO (HM.HashMap RequestKey (CommandResult Hash))
 run mgr cmds = do
-  sendResp <- doSend mgr $ SubmitBatch cmds
+  sendResp <- doSend mgr . SubmitBatch $ NEL.fromList cmds
   case sendResp of
     Left servantErr -> Exception.evaluate (error $ show servantErr)
     Right RequestKeys{..} -> do


### PR DESCRIPTION
This PR enforces the contents of `Poll`, `RequestKeys`, and `SubmitBatch` to be `NonEmpty`, thereby guaranteeing totality in functions that consume these types.