### PR TITLE
fix describe table output and meta pretty instance

### DIFF
--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -139,7 +139,7 @@ descTable :: RNativeFun e
 descTable _ [TTable {..}] = return $ toTObject TyAny def [
   ("name",tStr $ asString _tTableName),
   ("module", tStr $ asString _tModule),
-  ("type", toTerm $ pack $ show _tTableType)]
+  ("type", toTerm $ pack $ showPretty _tTableType)]
 descTable i as = argsError i as
 
 descKeySet :: RNativeFun e

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -135,7 +135,7 @@ data Meta = Meta
   } deriving (Eq, Show, Generic)
 
 instance Pretty Meta where
-  pretty (Meta (Just doc) model) = pretty doc <> line <> prettyModel model
+  pretty (Meta (Just doc) model) = dquotes (pretty doc) <> line <> prettyModel model
   pretty (Meta Nothing    model) = prettyModel model
 
 instance NFData Meta


### PR DESCRIPTION
Fixes #535 

now output is:

```
pact> (describe-table accounts.accounts)
{"module": "accounts"
,"name": "accounts"
,"type": "(defschema account "Row type for accounts table."  [balance:decimal, amount:decimal, ccy:string, rowguard:guard, date:time, data:object:*])"}```
