### PR TITLE
Bug Fix: '=' only compares alike terms

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -904,7 +904,7 @@ true
 *x*&nbsp;`<a[integer,string,time,decimal,bool,[<l>],object:<{o}>,keyset]>` *y*&nbsp;`<a[integer,string,time,decimal,bool,[<l>],object:<{o}>,keyset]>` *&rarr;*&nbsp;`bool`
 
 
-True if X equals Y.
+Compare alike terms for equality. Returns true if X equals Y.
 ```lisp
 pact> (= [1 2 3] [1 2 3])
 true

--- a/src/Pact/Native/Ops.hs
+++ b/src/Pact/Native/Ops.hs
@@ -155,7 +155,9 @@ lteDef = defCmp "<=" (cmp (`elem` [LT,EQ]))
 eqDef :: NativeDef
 eqDef = defRNative "=" (eq id) eqTy
   ["(= [1 2 3] [1 2 3])", "(= 'foo \"foo\")", "(= { 'a: 2 } { 'a: 2})"]
-  "Compare alike terms for equality. Returns true if X equals Y."
+  "Compare alike terms for equality, returning TRUE if X is equal to Y. \
+  \Equality comparisons will fail immediately on type mismatch, or if types \
+  \are not value types."
 
 neqDef :: NativeDef
 neqDef = defRNative "!=" (eq not) eqTy

--- a/src/Pact/Native/Ops.hs
+++ b/src/Pact/Native/Ops.hs
@@ -155,7 +155,7 @@ lteDef = defCmp "<=" (cmp (`elem` [LT,EQ]))
 eqDef :: NativeDef
 eqDef = defRNative "=" (eq id) eqTy
   ["(= [1 2 3] [1 2 3])", "(= 'foo \"foo\")", "(= { 'a: 2 } { 'a: 2})"]
-  "True if X equals Y."
+  "Compare alike terms for equality. Returns true if X equals Y."
 
 neqDef :: NativeDef
 neqDef = defRNative "!=" (eq not) eqTy
@@ -275,8 +275,13 @@ liftNot i as = argsError' i as
 
 
 eq :: (Bool -> Bool) -> RNativeFun e
-eq f _ [a,b] = return $ toTerm $ f (a `termEq` b)
-eq _ i as = argsError i as
+eq f i as = case as of
+  [a,b] -> if a `canEq` b
+    then return $ toTerm $ f (a `termEq` b)
+    else evalError' i
+         $ "cannot compare incompatible types: "
+         <> pretty (typeof' a) <> ", " <> pretty (typeof' b)
+  _ -> argsError i as
 {-# INLINE eq #-}
 
 unaryTy :: Type n -> Type n -> FunTypes n

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -75,7 +75,7 @@ module Pact.Types.Term
    toTermList,toTObject,toTObjectMap,toTList,toTListV,
    typeof,typeof',guardTypeOf,
    pattern TLitString,pattern TLitInteger,pattern TLitBool,
-   tLit,tStr,termEq,
+   tLit,tStr,termEq,canEq,
    Gas(..)
    ) where
 
@@ -1165,6 +1165,18 @@ tLit = (`TLiteral` def)
 -- | Convenience for OverloadedStrings annoyances
 tStr :: Text -> Term n
 tStr = toTerm
+
+-- | Equality dictionary for term-level equality
+--
+canEq :: Term n -> Term n -> Bool
+canEq t u = case (t,u) of
+  ((TList _ _ _), (TList _ _ _)) -> True
+  ((TObject _ _),  (TObject _ _)) -> True
+  ((TLiteral _ _), (TLiteral _ _)) -> True
+  ((TTable _ _ _ _ _ _), (TTable _ _ _ _ _ _)) -> True
+  ((TSchema _ _ _ _ _), (TSchema _ _ _ _ _)) -> True
+  ((TGuard _ _), (TGuard _ _)) -> True
+  _ -> False
 
 -- | Support pact `=` for value-level terms
 termEq :: Eq n => Term n -> Term n -> Bool

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -1169,14 +1169,13 @@ tStr = toTerm
 -- | Equality dictionary for term-level equality
 --
 canEq :: Term n -> Term n -> Bool
-canEq t u = case (t,u) of
-  ((TList _ _ _), (TList _ _ _)) -> True
-  ((TObject _ _),  (TObject _ _)) -> True
-  ((TLiteral _ _), (TLiteral _ _)) -> True
-  ((TTable _ _ _ _ _ _), (TTable _ _ _ _ _ _)) -> True
-  ((TSchema _ _ _ _ _), (TSchema _ _ _ _ _)) -> True
-  ((TGuard _ _), (TGuard _ _)) -> True
-  _ -> False
+canEq TList{} TList{} = True
+canEq TObject{} TObject{} = True
+canEq TLiteral{} TLiteral{} = True
+canEq TTable{} TTable{} = True
+canEq TSchema{} TSchema{} = True
+canEq TGuard{} TGuard{} = True
+canEq _ _ = False
 
 -- | Support pact `=` for value-level terms
 termEq :: Eq n => Term n -> Term n -> Bool


### PR DESCRIPTION
Addresses #524. 

Output is now: 

```
pact> (= 1 [1,2])
<interactive>:0:0: cannot compare incompatible types: integer, [<a>]
 at <interactive>:0:0: (= 1 [1 2])
pact> 
```