### PR TITLE
Render traces on one line.

### DIFF
--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -237,7 +237,7 @@ doOut ei mode a = case mode of
     lineOut = outStrLn HErr $ renderInfo ei ++ ":Trace: " ++
       case a of
         TLiteral (LString t) _ -> Text.unpack t
-        _ -> show $ pretty a
+        _ -> renderCompactString a
 
 renderErr :: PactError -> Repl String
 renderErr a


### PR DESCRIPTION
Hee Kyun reported that the following trace breaks Atom integration:

    {“last-tx-time”: “2019-05-08T18:10:00Z”
    ,“total-coins-earned”: 21.0
    ,“total-coins-returned”: 0.0}

We now render compact, eg:

    {“last-tx-time”: “2019-05-08T18:10:00Z”,“total-coins-earned”: 21.0,“total-coins-returned”: 0.0}

I verified this behavior by running
`pact -t examples/accounts/accounts.repl` and saw at least one large
object printed on a single line.