### PR TITLE
Avoid duplicate error messages from verification.

### DIFF
--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -469,7 +469,7 @@ verify i as = case as of
     let renderedLines = Check.renderVerifiedModule modResult
 #endif
     setop $ TcErrors $ Text.unpack <$> renderedLines
-    return (tStr $ mconcat renderedLines)
+    return $ tStr $ "Verification of " <> modName <> " failed"
 
   _ -> argsError i as
 


### PR DESCRIPTION
As reported by Emily, currently users see this:

    "coin.pact:212:10:Warning: Analysis doesn't support this construct yet"
    coin.pact:212:10:Warning: Analysis doesn't support this construct yet

This is due to (1) showing a message on `stderr` and (2) returning a
string result from the call to `verify`.

In this change we follow the lead of `typecheck` which shows a different
message in the two contexts.