### PR TITLE
Use `StrictData` in analysis.

### DIFF
--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE PatternSynonyms       #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE StrictData            #-}
 {-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE TypeApplications      #-}
 
@@ -144,8 +145,8 @@ data CheckFailureNoLoc
   deriving (Eq, Show)
 
 data CheckFailure = CheckFailure
-  { _checkFailureParsed :: !Info
-  , _checkFailure       :: !CheckFailureNoLoc
+  { _checkFailureParsed :: Info
+  , _checkFailure       :: CheckFailureNoLoc
   } deriving (Eq, Show)
 
 type CheckResult = Either CheckFailure CheckSuccess
@@ -167,11 +168,11 @@ hasVerificationError (ModuleChecks propChecks stepChecks invChecks _)
     in not (null errs)
 
 data CheckEnv = CheckEnv
-  { _tables     :: ![Table]
-  , _consts     :: !(HM.HashMap Text EProp)
-  , _propDefs   :: !(HM.HashMap Text (DefinedProperty (Exp Info)))
-  , _moduleData :: !(ModuleData Ref)
-  , _caps       :: ![Capability]
+  { _tables     :: [Table]
+  , _consts     :: HM.HashMap Text EProp
+  , _propDefs   :: HM.HashMap Text (DefinedProperty (Exp Info))
+  , _moduleData :: ModuleData Ref
+  , _caps       :: [Capability]
   }
 
 -- | Essential data used to check a function (where function could actually be
@@ -182,9 +183,9 @@ data CheckEnv = CheckEnv
 -- also use it for checking pact steps which are a different check type and
 -- borrow the name of their enclosing pact.
 data FunData = FunData
-  !Info         -- Location info (for error messages)
-  ![Named Node] -- Arguments
-  ![AST Node]   -- Body
+  Info         -- Location info (for error messages)
+  [Named Node] -- Arguments
+  [AST Node]   -- Body
 
 mkFunInfo :: Fun Node -> FunData
 mkFunInfo = \case
@@ -197,7 +198,7 @@ data VerificationFailure
   | TypeTranslationFailure Text (Pact.Type TC.UserType)
   | InvalidRefType -- TODO: make this error more informative
   | FailedConstTranslation String
-  | SchemalessTable !Info
+  | SchemalessTable Info
   deriving Show
 
 describeCheckSuccess :: CheckSuccess -> Text
@@ -575,12 +576,12 @@ moduleCapabilities md = do
 
 data PropertyScope
   = Everywhere
-  | Excluding !(Set Text)
-  | Including !(Set Text)
+  | Excluding (Set Text)
+  | Including (Set Text)
 
 data ModuleProperty = ModuleProperty
-  { _moduleProperty      :: !(Exp Info)
-  , _modulePropertyScope :: !PropertyScope
+  { _moduleProperty      :: Exp Info
+  , _modulePropertyScope :: PropertyScope
   }
 
 -- Does this (module-scoped) property apply to this function?
@@ -675,8 +676,8 @@ moduleTypecheckableRefs ModuleData{..} = foldl f noRefs (HM.toList _mdRefMap)
 
 -- | Module-level propery definitions and declarations
 data ModelDecl = ModelDecl
-  { _moduleDefProperties :: !(HM.HashMap Text (DefinedProperty (Exp Info)))
-  , _moduleProperties    :: ![ModuleProperty]
+  { _moduleDefProperties :: HM.HashMap Text (DefinedProperty (Exp Info))
+  , _moduleProperties    :: [ModuleProperty]
   }
 
 -- | Get the model defined in this module

--- a/src/Pact/Analyze/Errors.hs
+++ b/src/Pact/Analyze/Errors.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StrictData        #-}
 
 -- | Errors that can occur during symbolic analysis.
 module Pact.Analyze.Errors where
@@ -74,6 +75,6 @@ instance IsString AnalyzeFailureNoLoc where
   fromString = FailureMessage . T.pack
 
 data AnalyzeFailure = AnalyzeFailure
-  { _analyzeFailureParsed :: !Info
-  , _analyzeFailure       :: !AnalyzeFailureNoLoc
+  { _analyzeFailureParsed :: Info
+  , _analyzeFailure       :: AnalyzeFailureNoLoc
   }

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -10,12 +10,12 @@
 {-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE Rank2Types                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StrictData                 #-}
 {-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE ViewPatterns               #-}
-
-{-# LANGUAGE TupleSections              #-}
 
 -- | Translation from typechecked 'AST' to 'Term', while accumulating an
 -- execution graph to be used during symbolic analysis and model reporting.
@@ -69,8 +69,8 @@ import           Pact.Analyze.Util
 -- * Translation types
 
 data TranslateFailure = TranslateFailure
-  { _translateFailureInfo :: !Info
-  , _translateFailure     :: !TranslateFailureNoLoc
+  { _translateFailureInfo :: Info
+  , _translateFailure     :: TranslateFailureNoLoc
   } deriving Show
 
 data TranslateFailureNoLoc
@@ -244,7 +244,7 @@ data TranslateState
 
       -- Vars representing nondeterministic choice between two branches. These
       -- are used for continuing on or rolling back in evaluation of pacts.
-    , _tsStepChoices   :: ![VarId]
+    , _tsStepChoices   :: [VarId]
     }
 
 makeLenses ''TranslateFailure

--- a/src/Pact/Analyze/Types.hs
+++ b/src/Pact/Analyze/Types.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms       #-}
 {-# LANGUAGE Rank2Types            #-}
+{-# LANGUAGE StrictData            #-}
 {-# LANGUAGE TemplateHaskell       #-}
 
 -- | Toplevel module for types related to symbolic analysis of Pact programs.
@@ -74,9 +75,9 @@ genVarId :: (MonadState s m, HasVarId s) => m VarId
 genVarId = genId varId
 
 data Check
-  = PropertyHolds !(Prop 'TyBool) -- valid, assuming success
-  | Satisfiable   !(Prop 'TyBool) -- sat,   not assuming success
-  | Valid         !(Prop 'TyBool) -- valid, not assuming success
+  = PropertyHolds (Prop 'TyBool) -- valid, assuming success
+  | Satisfiable   (Prop 'TyBool) -- sat,   not assuming success
+  | Valid         (Prop 'TyBool) -- valid, not assuming success
 
 instance Show Check where
   showsPrec p c = showParen (p > 10) $ case c of

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE StrictData            #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
@@ -98,9 +99,9 @@ infix 1 ???
 
 data PactMetadata
   = PactMetadata
-    { _pmInPact  :: !(S Bool)
-    , _pmPactId  :: !(S Str)
-    , _pmEntity  :: !(S Str)
+    { _pmInPact  :: S Bool
+    , _pmPactId  :: S Str
+    , _pmEntity  :: S Str
     }
   deriving Show
 
@@ -143,32 +144,32 @@ mkRegistry = Registry $ mkFreeArray "registry"
 
 data TxMetadata
   = TxMetadata
-    { _tmKeySets  :: !(SFunArray Str Guard)
-    , _tmDecimals :: !(SFunArray Str Decimal)
-    , _tmIntegers :: !(SFunArray Str Integer)
+    { _tmKeySets  :: SFunArray Str Guard
+    , _tmDecimals :: SFunArray Str Decimal
+    , _tmIntegers :: SFunArray Str Integer
     -- TODO: strings
     }
   deriving Show
 
 data AnalyzeEnv
   = AnalyzeEnv
-    { _aeModuleName   :: !Pact.ModuleName
-    , _aePactMetadata :: !PactMetadata
-    , _aeRegistry     :: !Registry
-    , _aeTxMetadata   :: !TxMetadata
-    , _aeScope        :: !(Map VarId AVal) -- used as a stack
-    , _aeStepChoices  :: !(Map VarId (SBV Bool))
-    , _aeGuardPasses  :: !(SFunArray Guard Bool)
-    , _invariants     :: !(TableMap [Located (Invariant 'TyBool)])
-    , _aeColumnIds    :: !(TableMap (Map Text VarId))
-    , _aeModelTags    :: !(ModelTags 'Symbolic)
-    , _aeInfo         :: !Info
-    , _aeTrivialGuard :: !(S Guard)
-    , _aeEmptyGrants  :: !TokenGrants
+    { _aeModuleName   :: Pact.ModuleName
+    , _aePactMetadata :: PactMetadata
+    , _aeRegistry     :: Registry
+    , _aeTxMetadata   :: TxMetadata
+    , _aeScope        :: Map VarId AVal -- used as a stack
+    , _aeStepChoices  :: Map VarId (SBV Bool)
+    , _aeGuardPasses  :: SFunArray Guard Bool
+    , _invariants     :: TableMap [Located (Invariant 'TyBool)]
+    , _aeColumnIds    :: TableMap (Map Text VarId)
+    , _aeModelTags    :: ModelTags 'Symbolic
+    , _aeInfo         :: Info
+    , _aeTrivialGuard :: S Guard
+    , _aeEmptyGrants  :: TokenGrants
     -- ^ the default, blank slate of grants, where no token is granted.
-    , _aeActiveGrants :: !TokenGrants
+    , _aeActiveGrants :: TokenGrants
     -- ^ the current set of tokens that are granted, manipulated as a stack
-    , _aeTables       :: ![Table]
+    , _aeTables       :: [Table]
     } deriving Show
 
 mkAnalyzeEnv
@@ -281,8 +282,8 @@ data LatticeAnalyzeState a
     , _lasCellsWritten        :: TableMap (ColumnMap (SFunArray RowKey Bool))
     , _lasConstraints         :: S Bool
     , _lasPendingGrants       :: TokenGrants
-    , _lasYieldedInPrevious   :: !(Maybe ExistentialVal)
-    , _lasYieldedInCurrent    :: !(Maybe ExistentialVal)
+    , _lasYieldedInPrevious   :: Maybe ExistentialVal
+    , _lasYieldedInCurrent    :: Maybe ExistentialVal
     , _lasExtra               :: a
     }
   deriving (Generic, Show)
@@ -294,7 +295,7 @@ data GlobalAnalyzeState
   = GlobalAnalyzeState
     { _gasGuardProvenances :: Map TagId Provenance -- added as we accum guard info
     , _gasNextUninterpId   :: Integer
-    , _gasRollbacks        :: ![ETerm]
+    , _gasRollbacks        :: [ETerm]
     -- ^ the stack of rollbacks to perform on failure
     }
   deriving (Show)

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -1,20 +1,21 @@
-{-# LANGUAGE UndecidableInstances  #-} -- Pretty (Core tm a)
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PatternSynonyms       #-}
 {-# LANGUAGE Rank2Types            #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE ViewPatterns          #-}
-{-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE StrictData            #-}
 {-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-} -- Pretty (Core tm a)
+{-# LANGUAGE ViewPatterns          #-}
 
 -- | Type definitions for each of the languages we analyze, including the three
 -- main languages of programs ('Term'), invariants ('Invariant'), and

--- a/src/Pact/Analyze/Types/Shared.hs
+++ b/src/Pact/Analyze/Types/Shared.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE Rank2Types                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE StrictData                 #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
@@ -453,7 +454,7 @@ symRowKey = coerceS
 type TVal = (EType, AVal)
 
 data Column tm a where
-  Column :: IsTerm tm => !(SingTy a) -> !(tm a) -> Column tm a
+  Column :: IsTerm tm => SingTy a -> tm a -> Column tm a
 
 instance (Eq (SingTy a), Eq (tm a)) => Eq (Column tm a) where
   Column _ a == Column _ b = a == b
@@ -461,7 +462,7 @@ instance (Ord (SingTy a), Ord (tm a)) => Ord (Column tm a) where
   Column _ a `compare` Column _ b = a `compare` b
 
 data Object (tm :: Ty -> *) (m :: [(Symbol, Ty)])
-  = Object !(HList (Column tm) m)
+  = Object (HList (Column tm) m)
 
 pattern ObjectNil :: () => schema ~ '[] => Object tm schema
 pattern ObjectNil = Object SNil


### PR DESCRIPTION
.. Since we don't use laziness anywhere in analysis.

The original goal of this change was to just change our data types to
have strict fields. After removing all of our scattered strictness
annotations, and adding `StrictData`, I realized that we could go a bit
further and use `Strict`. Note that I didn't add this to all of our
analysis modules (I don't think laziness is slowing us down much so I
don't see much reason to), but it could be added to more later on.