### PR TITLE
'block-time' as pact time, plus native schemas

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -31,13 +31,13 @@ pact> (bind { "a": 1, "b": 2 } { "a" := a-value } a-value)
 
 ### chain-data {#chain-data}
 
- *&rarr;*&nbsp;`object:<{o}>`
+ *&rarr;*&nbsp;`object:{public-chain-data}`
 
 
 Get transaction public metadata. Returns an object with 'chain-id', 'block-height', 'block-time', 'sender', 'gas-limit', 'gas-price', and 'gas-fee' fields.
 ```lisp
 pact> (chain-data)
-{"block-height": 0,"block-time": 0,"chain-id": "","gas-limit": 0,"gas-price": 0,"sender": ""}
+{"block-height": 0,"block-time": "1970-01-01T00:00:00Z","chain-id": "","gas-limit": 0,"gas-price": 0,"sender": ""}
 ```
 
 
@@ -329,6 +329,19 @@ pact> (pact-version)
 ```
 
 Top level only: this function will fail if used in module code.
+
+
+### public-chain-data {#public-chain-data}
+
+Schema type for data returned from 'chain-data'.
+
+Fields:
+&nbsp;&nbsp;`chain-id:string`
+&nbsp;&nbsp;`block-height:integer`
+&nbsp;&nbsp;`block-time:time`
+&nbsp;&nbsp;`sender:string`
+&nbsp;&nbsp;`gas-limit:integer`
+&nbsp;&nbsp;`gas-price:decimal`
 
 
 ### read-decimal {#read-decimal}

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -19,6 +19,7 @@ module Pact.Native.Internal
   ,bindReduce
   ,enforceGuard
   ,defNative,defGasRNative,defRNative
+  ,defSchema
   ,setTopLevelOnly
   ,foldDefs
   ,funType,funType'
@@ -117,6 +118,15 @@ defGasRNative name fun = defNative name (reduced fun)
 defRNative :: NativeDefName -> RNativeFun e -> FunTypes (Term Name) -> [Example] -> Text -> NativeDef
 defRNative name fun = defNative name (reduced fun)
     where reduced f fi as = preGas fi as >>= \(g,as') -> (g,) <$> f fi as'
+
+
+defSchema :: NativeDefName -> Text -> [(FieldKey, Type (Term Name))] -> NativeDef
+defSchema n doc fields =
+  (n,
+   TSchema (TypeName $ asString n) (ModuleName "" Nothing) (Meta (Just doc) [])
+   (map (\(fr,ty) -> Arg (asString fr) ty def) fields)
+   def)
+
 
 foldDefs :: Monad m => [m a] -> m [a]
 foldDefs = foldM (\r d -> d >>= \d' -> return (d':r)) []

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -994,11 +994,12 @@ toUserType t = case t of
   _ -> die (_tInfo t) $ "toUserType: expected user type: " ++ show t
   where
     derefUT (Ref r) = toUserType' (fmap Left r :: Term (Either Ref n))
-    derefUT Direct {} = die (_tInfo t) $ "toUserType: unexpected direct ref: " ++ show t
+    derefUT (Direct d) = toUserType' (fmap Right d)
+    -- derefUT Direct {} = die (_tInfo t) $ "toUserType: unexpected direct ref: " ++ show t
 
 toUserType' :: Show n => Term (Either Ref n) -> TC UserType
 toUserType' TSchema {..} = Schema _tSchemaName _tModule <$> mapM (traverse toUserType) _tFields <*> pure _tInfo
-toUserType' t = die (_tInfo t) $ "toUserType: expected user type: " ++ show t
+toUserType' t = die (_tInfo t) $ "toUserType': expected user type: " ++ show t
 
 bindArgs :: Info -> [a] -> Int -> TC a
 bindArgs i args b =

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -991,11 +991,10 @@ trackNode ty i = trackAST node >> return node
 toUserType :: forall n . Show n => Term (Either Ref n) -> TC UserType
 toUserType t = case t of
   (TVar (Left r) _) -> derefUT r
-  _ -> die (_tInfo t) $ "toUserType: expected user type: " ++ show t
+  _ -> die (_tInfo t) $ "toUserType: expected var of user type ref: " ++ show t
   where
     derefUT (Ref r) = toUserType' (fmap Left r :: Term (Either Ref n))
     derefUT (Direct d) = toUserType' (fmap Right d)
-    -- derefUT Direct {} = die (_tInfo t) $ "toUserType: unexpected direct ref: " ++ show t
 
 toUserType' :: Show n => Term (Either Ref n) -> TC UserType
 toUserType' TSchema {..} = Schema _tSchemaName _tModule <$> mapM (traverse toUserType) _tFields <*> pure _tInfo

--- a/src/Pact/Types/Persistence.hs
+++ b/src/Pact/Types/Persistence.hs
@@ -78,6 +78,7 @@ instance Pretty PersistDirect where
 
 toPersistDirect :: Term Name -> Either Text PersistDirect
 toPersistDirect (TNative n _ _ _ _ _ _) = pure $ PDNative n
+toPersistDirect (TSchema n (ModuleName "" Nothing) _ _ _) = pure $ PDNative (NativeDefName (asString n))
 toPersistDirect t = case toPactValue t of
   Right v -> pure $ PDValue v
   Left e -> Left e

--- a/src/Pact/Types/Pretty.hs
+++ b/src/Pact/Types/Pretty.hs
@@ -11,6 +11,7 @@ module Pact.Types.Pretty
   , Pretty(..)
   , RenderColor(..)
   , SomeDoc(..)
+  , SpecialPretty(..)
   , abbrev
   , abbrevStr
   , align
@@ -242,3 +243,13 @@ newtype SomeDoc = SomeDoc Doc
 
 instance Pretty SomeDoc where
   pretty (SomeDoc doc) = doc
+
+
+-- | Type to allow for special-casing rendering of a type
+data SpecialPretty n
+  = SPSpecial Text
+  | SPNormal n
+
+instance Pretty n => Pretty (SpecialPretty n) where
+  pretty (SPSpecial t) = pretty t
+  pretty (SPNormal n) = pretty n

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -76,6 +76,7 @@ module Pact.Types.Term
    ToTerm(..),
    toTermList,toTObject,toTObjectMap,toTList,toTListV,
    typeof,typeof',guardTypeOf,
+   prettyTypeTerm,
    pattern TLitString,pattern TLitInteger,pattern TLitBool,
    tLit,tStr,termEq,canEq,
    Gas(..)
@@ -948,7 +949,7 @@ instance Pretty n => Pretty (Term n) where
       <> line <> fillSep (pretty <$> T.words _tNativeDocs)
       <> line
       <> line <> annotate Header "Type:"
-      <> line <> align (vsep (pretty <$> toList _tFunTypes))
+      <> line <> align (vsep (prettyFunType <$> toList _tFunTypes))
       <> examples
       ) where examples = case _tNativeExamples of
                 [] -> mempty
@@ -981,9 +982,17 @@ instance Pretty n => Pretty (Term n) where
       ]
     TTable{..} -> parensSep
       [ "deftable"
-      , pretty _tTableName <> ":" <> pretty _tTableType
+      , pretty _tTableName <> ":" <> pretty (fmap prettyTypeTerm _tTableType)
       , pretty _tMeta
       ]
+
+    where
+      prettyFunType (FunType as r) = pretty (FunType (map (fmap prettyTypeTerm) as) (prettyTypeTerm <$> r))
+
+prettyTypeTerm :: Term n -> SpecialPretty (Term n)
+prettyTypeTerm TSchema{..} = SPSpecial ("{" <> asString _tSchemaName <> "}")
+prettyTypeTerm t = SPNormal t
+
 
 instance Applicative Term where
     pure = return

--- a/tests/pact/pubdata.repl
+++ b/tests/pact/pubdata.repl
@@ -1,7 +1,7 @@
 ;; Chain public metadata should initialize with defaults
 (expect "chain data chain id initializes with \"\"" "" (at "chain-id" (chain-data)))
 (expect "chain data block height initializes with 0" 0 (at "block-height" (chain-data)))
-(expect "chain data block time id initializes with 0" 0 (at "block-time" (chain-data)))
+(expect "chain data block time id initializes with time value" (time "1970-01-01T00:00:00Z") (at "block-time" (chain-data)))
 (expect "chain data sender initializes with \"\"" "" (at "sender" (chain-data)))
 (expect "chain data gas limit initializes with 0" 0 (at "gas-limit" (chain-data)))
 (expect "chain data gas price initializes with 0.0" 0.0 (at "gas-price" (chain-data)))
@@ -27,3 +27,12 @@
 
 ;; Show failure on duplicate keys
 (expect-failure "chain data should not accept duplicate updates" (env-chain-data { "chain-id": "Testnet00/1", "chain-id:": "Testnet00/2" }))
+
+;; test time
+(expect "time update succeeds"
+        "Updated public metadata"
+        (env-chain-data
+         { "block-time": (time "2019-01-01T00:00:00Z") }))
+(expect "time value correct"
+        (time "2019-01-01T00:00:00Z")
+        (at "block-time" (chain-data)))

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -163,7 +163,13 @@
                   (yield y)))
             (resume {'a:= z} (yield {'b: z}))))
     (step (resume {'b:= q} q))
-  )
+    )
+
+  (defun tc-chain-data ()
+    (+ (at "block-height" (chain-data)) 1))
+
+  (defun tc-chain-data-2:object{public-chain-data} ()
+    (chain-data))
 
 )
 
@@ -183,6 +189,10 @@
 (expect-failure "bad update" (fails-update "Mary" "@mary123"))
 (expect "int list OK" [2 3 4] (addToAll 1 [1 2 3]))
 (expect-failure "bad int list" (addToAll 1 [1 2 3 "hi"]))
+
+(expect "native user type exercise works"
+        (tc-chain-data)
+        (+ (at "block-height" (tc-chain-data-2)) 1))
 
 (typecheck 'tctest)
 


### PR DESCRIPTION
What began as a small change (have `chain-data` return pact `time` for `'block-time` field) got involved when I realized it would be nice if `chain-data` were typesafe. Thus, native schemas.