### PR TITLE
WIP: Exposing user types for chain-data and env-chain-data

### DIFF
--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -66,6 +66,7 @@ import Pact.PersistPactDb
 import Pact.Types.Logger
 import Pact.Types.Pretty
 import Pact.Repl.Types
+import Pact.Native (chainDataSchemaDef)
 import Pact.Native.Capabilities (evalCap)
 import Pact.Gas.Table
 import Pact.Types.PactValue
@@ -551,10 +552,15 @@ testCapability i as = argsError' i as
 -- environment items only.
 envChainDataDef :: NativeDef
 envChainDataDef = defZRNative "env-chain-data" envChainData
-    (funType tTyString [("new-data", tTyObject TyAny)])
+    (funType tTyString [("new-data", objectType)])
     ["(env-chain-data { \"chain-id\": \"TestNet00/2\", \"block-height\": 20 })"]
-    "Update existing entries 'chain-data' with NEW-DATA, replacing those items only."
+    "Update existing entries of 'chain-data' with NEW-DATA, replacing those items only."
   where
+    objectType = TySchema
+      TyObject
+      (TyUser $ snd chainDataSchemaDef)
+      AnySubschema
+
     envChainData :: RNativeFun LibState
     envChainData i as = case as of
       [TObject (Object (ObjectMap ks) _ _ _) _] -> do

--- a/src/Pact/Types/Type.hs
+++ b/src/Pact/Types/Type.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
@@ -285,6 +286,10 @@ instance NFData v => NFData (Type v)
 instance (Pretty o) => Pretty (Type o) where
   pretty ty = case ty of
     TyVar n        -> pretty n
+    --
+    -- TODO: this produces a defschema form, whereas we would like to display
+    -- key-value pairs:
+    --
     TyUser v       -> pretty v
     TyFun f        -> pretty f
     TySchema s t p -> pretty s <> colon <> prettyList (showPartial p) <> pretty t


### PR DESCRIPTION
I started working on #487 but I could use a little help:

- [ ] what to name this schema (just to start, I picked `chain-schema`)
- [ ] which module/namespace to put it in (`TSchema` requires this)
- [ ] how to handle pretty printing of these object types

For this latter point of pretty printing, the current pact behavior is to display the following:

```
pact> chain-data
native `chain-data`
  
  Get transaction public metadata. Returns an object with 'chain-id',
  'block-height', 'block-time', 'sender', 'gas-limit', 'gas-price', and
  'gas-fee' fields.
  
  Type:
   -> object:(defschema
  chain-schema
  "The schema for objects returned from 'chain-data'"
  
  [ chain-id:string
  , block-height:integer
  , block-time:integer
  , sender:string
  , gas-limit:integer
  , gas-price:decimal ])
  
  Examples:
  > (chain-data)
```

As you can see, this `(defschema ...)` production is showing up where we would like to see key-value pairs for our object type. This occurs because the instance `instance (Pretty o) => Pretty (Type o)` handles `TyUser t` by pretty-printing the term `t`. I assume that we have codepaths that are relying on the current pretty-printing for `TSchema` terms so I can't change that. The next idea that comes to mind is to have an instance more specific than `instance (Pretty o) => Pretty (Type o)` -- namely for `Type (Term n)` so that we could pattern-match on `TyUser (TSchema ...)` and display the key-value pairs in this case. I haven't interacted too much with the pretty printing code in Pact so I can use a hand here. Thoughts?

/cc @emilypi @joelburget @slpopejoy 