### PR TITLE
Add subschema type for env-chain-data

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1403,10 +1403,10 @@ Continue previously-initiated pact identified STEP, optionally specifying ROLLBA
 
 ### env-chain-data {#env-chain-data}
 
-*new-data*&nbsp;`object:*` *&rarr;*&nbsp;`string`
+*new-data*&nbsp;`object:~{public-chain-data}` *&rarr;*&nbsp;`string`
 
 
-Update existing entries 'chain-data' with NEW-DATA, replacing those items only.
+Update existing entries of 'chain-data' with NEW-DATA, replacing those items only.
 ```lisp
 pact> (env-chain-data { "chain-id": "TestNet00/2", "block-height": 20 })
 "Updated public metadata"

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -553,10 +553,15 @@ testCapability i as = argsError' i as
 -- environment items only.
 envChainDataDef :: NativeDef
 envChainDataDef = defZRNative "env-chain-data" envChainData
-    (funType tTyString [("new-data", tTyObject TyAny)])
+    (funType tTyString [("new-data", objectType)])
     ["(env-chain-data { \"chain-id\": \"TestNet00/2\", \"block-height\": 20 })"]
-    "Update existing entries 'chain-data' with NEW-DATA, replacing those items only."
+    "Update existing entries of 'chain-data' with NEW-DATA, replacing those items only."
   where
+    objectType = TySchema
+      TyObject
+      (TyUser $ snd chainDataSchema)
+      AnySubschema
+
     envChainData :: RNativeFun LibState
     envChainData i as = case as of
       [TObject (Object (ObjectMap ks) _ _ _) _] -> do


### PR DESCRIPTION
Addendum to #575, adding a type to the argument for `env-chain-data`.

Unfortunately I don't think there is a way to test this at the moment, because `env-chain-data` can only be called from REPL (not module) code, and we only typecheck module code.

My one open question is whether the _existing_ type (from #575) on `chainDataDef` should be `TySchema TyObject (TyUser (snd chainDataSchema)) FullSchema` instead of just `TyUser (snd chainDataSchema)`? Similar this new argument type for `envChainDataDef`, `TySchema TyObject (TyUser (snd chainDataSchema)) AnySubschema`, but requiring the *full* schema. @slpopejoy?