### PR TITLE
Add `succeeds-when` / `fails-when` check forms.

### DIFF
--- a/docs/en/pact-properties.md
+++ b/docs/en/pact-properties.md
@@ -190,6 +190,31 @@ transaction is aborted. Because `properties` are only concerned with
 transactions that succeed, the necessary conditions to pass each `enforce` call
 are assumed.
 
+However, in some cases it's useful to assert when the function must succeed or
+abort. To write this kind of assertion, instead of `property`, you can use
+`succeeds-when` or `fails-when`, for example:
+
+
+```lisp
+(defun ensured-positive:bool (val:integer)
+  @model [
+    ; this succeeds exactly when val > 0, and fails exactly when val <= 0
+    (succeeds-when (> val 0))
+    (fails-when    (<= val 0))
+
+    ; however, it's valid to assert something weaker
+    (succeeds-when (> val 1000))
+    (fails-when    (< val -1000))
+    ]
+  (enforce (> val 0)))
+```
+
+With this model, we're guaranteed that no transaction will ever run on the
+blockchain with a non-positive `val`.
+
+We've now seen all three valid forms of model assertions -- `property`,
+`succeeds-when`, and `fails-when`.
+
 ### More comprehensive properties API documentation
 
 For the full listing of functionality available in properties, see the API

--- a/src/Pact/Analyze/Check.hs
+++ b/src/Pact/Analyze/Check.hs
@@ -527,9 +527,12 @@ moduleTables modules ModuleData{..} = do
               , "malformed list (inconsistent use of comma separators?)"
               )
             Just model' -> withExceptT ModuleParseFailure $ liftEither $ do
-              exps <- collectExps "invariant" model'
-              runExpParserOver exps $
-                flip runReaderT (varIdArgs _utFields) . expToInvariant SBool
+              exps <- collectInvariants model'
+              for exps $ \meta ->
+                case flip runReaderT (varIdArgs _utFields) $
+                  expToInvariant SBool meta of
+                  Left err   -> Left (meta, err)
+                  Right good -> Right (Located (getInfo meta) good)
 
         pure $ Table tabName schema invariants
 
@@ -576,17 +579,25 @@ moduleCapabilities md = do
 
 data PropertyScope
   = Everywhere
+  -- ^ This property applies to the whole module
   | Excluding (Set Text)
+  -- ^ This property applies to all but the named functions (and pacts)
   | Including (Set Text)
+  -- ^ This property applies to only the named functions (and pacts)
 
-data ModuleProperty = ModuleProperty
-  { _moduleProperty      :: Exp Info
-  , _modulePropertyScope :: PropertyScope
+data ModuleCheck = ModuleCheck
+  { _moduleCheckType   :: Prop 'TyBool -> Check
+  -- ^ The style of check to use ('PropertyHolds', 'SucceedsWhen', or
+  -- 'FailsWhen')
+  , _checkPropertyBody :: Exp Info
+  -- ^ The body of the property to check
+  , _moduleCheckScope  :: PropertyScope
+  -- ^ Where does this property apply?
   }
 
 -- Does this (module-scoped) property apply to this function?
-applicableCheck :: DefName -> ModuleProperty -> Bool
-applicableCheck (DefName funName) (ModuleProperty _ propScope) =
+applicableCheck :: DefName -> ModuleCheck -> Bool
+applicableCheck (DefName funName) (ModuleCheck _ _ propScope) =
   case propScope of
     Everywhere      -> True
     Excluding names -> funName `Set.notMember` names
@@ -622,7 +633,7 @@ normalizeListLit lits = case lits of
 parseModuleModelDecl
   :: [Exp Info]
   -> Either ParseFailure
-       [Either (Text, DefinedProperty (Exp Info)) ModuleProperty]
+       [Either (Text, DefinedProperty (Exp Info)) ModuleCheck]
 parseModuleModelDecl exps = traverse parseDecl exps where
 
   parseDecl exp@(ParenList (EAtom' "defproperty" : rest)) = case rest of
@@ -633,8 +644,8 @@ parseModuleModelDecl exps = traverse parseDecl exps where
       pure $ Left (propname, DefinedProperty [] body)
     _ -> Left (exp, "Invalid property definition")
   parseDecl exp = do
-    (body, propScope) <- parsePropertyExp exp
-    pure $ Right $ ModuleProperty body propScope
+    (propTy, body, propScope) <- parsePropertyExp exp
+    pure $ Right $ ModuleCheck propTy body propScope
 
   parseNames :: Exp Info -> Either ParseFailure (Set Text)
   parseNames exp@(SquareList names) = case normalizeListLit names of
@@ -646,16 +657,26 @@ parseModuleModelDecl exps = traverse parseDecl exps where
   parseName (EAtom' name) = Right name
   parseName exp           = Left (exp, "expected a bare word name")
 
-  parsePropertyExp :: Exp Info -> Either ParseFailure (Exp Info, PropertyScope)
+  getPropTy = \case
+    "property"      -> Just PropertyHolds
+    "succeeds-when" -> Just SucceedsWhen
+    "fails-when"    -> Just FailsWhen
+    _               -> Nothing
+
+  parsePropertyExp
+    :: Exp Info
+    -> Either ParseFailure (Prop 'TyBool -> Check, Exp Info, PropertyScope)
   parsePropertyExp exp = case exp of
-    ParenList (EAtom' "property" : rest) -> case rest of
-      [ exp' ]
-        -> pure (exp', Everywhere)
-      [ exp', BraceList [ EStrLiteral' "except", ColonExp, names ] ]
-        -> (exp',) . Excluding <$> parseNames names
-      [ exp', BraceList [ EStrLiteral' "only",   ColonExp, names ] ]
-        -> (exp',) . Including <$> parseNames names
-      _ -> Left (exp, "malformed property definition")
+    ParenList (EAtom' propTyName : rest)
+      | Just propTy <- getPropTy propTyName
+      -> case rest of
+        [ exp' ]
+          -> pure (propTy, exp', Everywhere)
+        [ exp', BraceList [ EStrLiteral' "except", ColonExp, names ] ]
+          -> (propTy, exp',) . Excluding <$> parseNames names
+        [ exp', BraceList [ EStrLiteral' "only",   ColonExp, names ] ]
+          -> (propTy, exp',) . Including <$> parseNames names
+        _ -> Left (exp, "malformed property definition")
     _ -> Left (exp, "expected a set of property / defproperty")
 
 -- | Get the set ('HM.HashMap') of refs to functions, pacts, and constants in
@@ -677,7 +698,7 @@ moduleTypecheckableRefs ModuleData{..} = foldl f noRefs (HM.toList _mdRefMap)
 -- | Module-level propery definitions and declarations
 data ModelDecl = ModelDecl
   { _moduleDefProperties :: HM.HashMap Text (DefinedProperty (Exp Info))
-  , _moduleProperties    :: [ModuleProperty]
+  , _moduleProperties    :: [ModuleCheck]
   }
 
 -- | Get the model defined in this module
@@ -774,16 +795,20 @@ stepCheck tables consts propDefs funTy model = do
   FunctionEnvironment envVidStart nameVids vidTys
     <- makeFunctionEnvironment funTy
   checks <- withExcept ModuleParseFailure $ liftEither $ do
-    exps <- collectExps "property" model
-    runExpParserOver exps $
-      expToCheck (mkTableEnv tables) envVidStart nameVids vidTys consts propDefs
+    exps <- collectProperties model
+    for exps $ \(propTy, meta) ->
+      case expToCheck (mkTableEnv tables) envVidStart nameVids vidTys consts
+        propDefs propTy meta of
+        Left err   -> Left (meta, err)
+        Right good -> Right (Located (getInfo meta) good)
+
   pure $ Right checks
 
 -- | Get the set of checks for a function.
 moduleFunCheck
   :: [Table]
   -- ^ All tables defined in this module and imported by it
-  -> [ModuleProperty]
+  -> [ModuleCheck]
   -- ^ The set of properties that apply to all functions in the module
   -> HM.HashMap Text EProp
   -- ^ Constants defined in this module
@@ -812,32 +837,35 @@ moduleFunCheck tables modCheckExps consts propDefs defn funTy = do
         , "malformed list (inconsistent use of comma separators?)"
         )
       Just model' -> withExcept ModuleParseFailure $ liftEither $ do
-        exps <- collectExps "property" model'
+        exps <- collectProperties model'
         let funName = _dDefName (_tDef defn)
-            applicableModuleChecks = map _moduleProperty $
+            applicableModuleChecks =
               filter (applicableCheck funName) modCheckExps
-        runExpParserOver (applicableModuleChecks <> exps) $
-          expToCheck (mkTableEnv tables) envVidStart nameVids vidTys consts
-            propDefs
+                <&> \(ModuleCheck ty prop _scope) -> (ty, prop)
+
+        for (applicableModuleChecks <> exps) $ \(propTy, meta) ->
+          case expToCheck (mkTableEnv tables) envVidStart nameVids vidTys
+            consts propDefs propTy meta of
+            Left err   -> Left (meta, err)
+            Right good -> Right (Located (getInfo meta) good)
 
   pure $ Right checks
 
--- | Remove the "invariant" or "property" application from every exp
-collectExps :: Text -> [Exp Info] -> Either ParseFailure [Exp Info]
-collectExps name multiExp = for multiExp $ \case
-  ParenList [EAtom' name', v] | name' == name -> Right v
-  exp -> Left (exp, "expected an application of " ++ T.unpack name)
+-- | Remove the "property", "succeeds-when", or "fails-when" application from
+-- every exp.
+collectProperties
+  :: [Exp Info] -> Either ParseFailure [(Prop 'TyBool -> Check, Exp Info)]
+collectProperties multiExp = for multiExp $ \case
+  ParenList [EAtom' "property",      v] -> Right (PropertyHolds, v)
+  ParenList [EAtom' "succeeds-when", v] -> Right (SucceedsWhen,  v)
+  ParenList [EAtom' "fails-when",    v] -> Right (FailsWhen,     v)
+  exp -> Left (exp, "expected an application of \"property\", \"succeeds-when\", or \"fails-when\"")
 
--- | This runs a parser over a collection of 'Exp's, collecting the failures
--- or successes.
-runExpParserOver
-  :: forall t.
-     [Exp Info]
-  -> (Exp Info -> Either String t)
-  -> Either ParseFailure [Located t]
-runExpParserOver exps parser = sequence $ exps <&> \meta -> case parser meta of
-  Left err   -> Left (meta, err)
-  Right good -> Right (Located (getInfo meta) good)
+-- | Remove the "invariant" application from every exp
+collectInvariants :: [Exp Info] -> Either ParseFailure [Exp Info]
+collectInvariants multiExp = for multiExp $ \case
+  ParenList [EAtom' "invariant", v] -> Right v
+  exp -> Left (exp, "expected an application of \"invariant\"")
 
 -- | Typecheck a 'Ref'. This is used to extract an @'AST' 'Node'@, which is
 -- translated to either a term or property.

--- a/src/Pact/Analyze/Eval.hs
+++ b/src/Pact/Analyze/Eval.hs
@@ -48,6 +48,14 @@ import           Pact.Analyze.Util
 analyzeCheck :: Check -> Query (S Bool)
 analyzeCheck = \case
     PropertyHolds p -> assumingSuccess =<< evalProp p
+    SucceedsWhen p  -> do
+      success <- view (qeAnalyzeState.succeeds)
+      p'      <- evalProp p
+      pure $ p' .=> success
+    FailsWhen p  -> do
+      success <- view (qeAnalyzeState.succeeds)
+      p'      <- evalProp p
+      pure $ p' .=> sNot success
     Valid p         -> evalProp p
     Satisfiable p   -> evalProp p
 

--- a/src/Pact/Analyze/Parse/Prop.hs
+++ b/src/Pact/Analyze/Parse/Prop.hs
@@ -769,11 +769,14 @@ expToCheck
   -- ^ Environment mapping names to constants
   -> HM.HashMap Text (DefinedProperty (Exp Info))
   -- ^ Defined props in the environment
+  -> (Prop 'TyBool -> Check)
+  -- ^ The style of check to use ('PropertyHolds', 'SucceedsWhen', or
+  -- 'FailsWhen')
   -> Exp Info
   -- ^ Exp to convert
   -> Either String Check
-expToCheck tableEnv' genStart nameEnv idEnv consts propDefs body =
-  PropertyHolds . prenexConvert
+expToCheck tableEnv' genStart nameEnv idEnv consts propDefs checkCtor body =
+  checkCtor . prenexConvert
     <$> expToProp tableEnv' genStart nameEnv idEnv consts propDefs SBool body
 
 expToProp

--- a/src/Pact/Analyze/Types.hs
+++ b/src/Pact/Analyze/Types.hs
@@ -76,17 +76,23 @@ genVarId = genId varId
 
 data Check
   = PropertyHolds (Prop 'TyBool) -- valid, assuming success
+  | SucceedsWhen  (Prop 'TyBool) -- property implies transaction success (validation)
+  | FailsWhen     (Prop 'TyBool) -- property implies transaction failure (validation)
   | Satisfiable   (Prop 'TyBool) -- sat,   not assuming success
   | Valid         (Prop 'TyBool) -- valid, not assuming success
 
 instance Show Check where
   showsPrec p c = showParen (p > 10) $ case c of
     PropertyHolds prop -> showString "PropertyHolds " . showsTm 11 prop
+    SucceedsWhen prop  -> showString "SucceedsWhen "  . showsTm 11 prop
+    FailsWhen prop     -> showString "FailsWhen "     . showsTm 11 prop
     Satisfiable prop   -> showString "Satisfiable "   . showsTm 11 prop
     Valid prop         -> showString "Valid "         . showsTm 11 prop
 
 checkGoal :: Check -> Goal
 checkGoal (PropertyHolds _) = Validation
+checkGoal (SucceedsWhen _)  = Validation
+checkGoal (FailsWhen _)     = Validation
 checkGoal (Satisfiable _)   = Satisfaction
 checkGoal (Valid _)         = Validation
 

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -3482,3 +3482,32 @@ spec = describe "analyze" $ do
         (with-default-read accounts acct { 'balance: 0 } { 'balance := balance }
           balance))
       |]
+
+  describe "succeeds-when / fails-when" $ do
+    expectVerified [text|
+      (defun test:bool (x:integer)
+        @model [
+          ; this succeeds exactly when x > 0, and fails exactly when x <= 0
+          (succeeds-when (> x 0))
+          (fails-when    (<= x 0))
+
+          ; however, it's valid to assert something weaker
+          (succeeds-when (> x 1000))
+          (fails-when    (< x -1000))
+          ]
+        (enforce (> x 0)))
+      |]
+
+    -- succeeds-when / fails-when also work at the module level
+    expectVerified'
+      [text|
+        (succeeds-when (> x 0))
+        (fails-when    (<= x 0))
+
+        (succeeds-when (> x 0)  { 'only:   [test] })
+        (fails-when    (<= x 0) { 'only:   [test] })
+
+        (succeeds-when (> x 1000) { 'except: [] })
+        (fails-when    (<= x 0)   { 'except: [] })
+      |]
+      "(defun test:bool (x:integer) (enforce (> x 0)))"


### PR DESCRIPTION
These add the ability to talk about transaction success and failure,
which `property` can't do.

Fixes #124.