### PR TITLE
Add read-string

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -395,6 +395,17 @@ Read KEY from top level of message data body, or data body itself if not provide
 ```
 
 
+### read-string {#read-string}
+
+*key*&nbsp;`string` *&rarr;*&nbsp;`string`
+
+
+Parse KEY string or number value from top level of message data body as string.
+```lisp
+(read-string "sender")
+```
+
+
 ### remove {#remove}
 
 *key*&nbsp;`string` *object*&nbsp;`object:<{o}>` *&rarr;*&nbsp;`object:<{o}>`

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -516,6 +516,7 @@ evalTerm = \case
   ReadKeySet  nameT -> readKeySet  =<< evalTerm nameT
   ReadDecimal nameT -> readDecimal =<< evalTerm nameT
   ReadInteger nameT -> readInteger =<< evalTerm nameT
+  ReadString  nameT -> readString  =<< evalTerm nameT
 
   PactId -> do
     whetherInPact <- view inPact
@@ -756,6 +757,7 @@ withReset number action = do
       txMetadata   = TxMetadata (mkFreeArray $ "txKeySets"  <> tShow number)
                                 (mkFreeArray $ "txDecimals" <> tShow number)
                                 (mkFreeArray $ "txIntegers" <> tShow number)
+                                (mkFreeArray $ "txStrings"  <> tShow number)
 
       newRegistry = Registry $ mkFreeArray $ "registry" <> tShow number
       newGuardPasses = writeArray (mkFreeArray $ "guardPasses" <> tShow number)

--- a/src/Pact/Analyze/Patterns.hs
+++ b/src/Pact/Analyze/Patterns.hs
@@ -108,6 +108,10 @@ pattern AST_ReadInteger :: forall a. AST a -> AST a
 pattern AST_ReadInteger name <-
   App _node (NativeFunc "read-integer") [name]
 
+pattern AST_ReadString :: forall a. AST a -> AST a
+pattern AST_ReadString name <-
+  App _node (NativeFunc "read-string") [name]
+
 pattern AST_ReadMsg :: forall a. AST a -> AST a
 pattern AST_ReadMsg name <-
   App _node (NativeFunc "read-msg") [name]

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -934,6 +934,10 @@ translateNode astNode = withAstContext astNode $ case astNode of
     Some SStr nameT <- translateNode nameA
     return $ Some SInteger $ ReadInteger nameT
 
+  AST_ReadString nameA -> do
+    Some SStr nameT <- translateNode nameA
+    return $ Some SStr $ ReadString nameT
+
   AST_ReadMsg _ -> throwError' $ NoReadMsg astNode
 
   AST_PactId -> pure $ Some SStr PactId

--- a/src/Pact/Analyze/Types/Eval.hs
+++ b/src/Pact/Analyze/Types/Eval.hs
@@ -151,7 +151,7 @@ data TxMetadata
     { _tmKeySets  :: SFunArray Str Guard
     , _tmDecimals :: SFunArray Str Decimal
     , _tmIntegers :: SFunArray Str Integer
-    -- TODO: strings
+    , _tmStrings  :: SFunArray Str Str
     }
   deriving Show
 
@@ -192,6 +192,7 @@ mkAnalyzeEnv modName pactMetadata gov registry tables caps args stepChoices tags
   let txMetadata   = TxMetadata (mkFreeArray "txKeySets")
                                 (mkFreeArray "txDecimals")
                                 (mkFreeArray "txIntegers")
+                                (mkFreeArray "txStrings")
       --
       -- NOTE: for now we create an always-passing singleton "trivial guard"
       -- that we hand out for pact and module creation. this will not suffice
@@ -486,6 +487,9 @@ class HasAnalyzeEnv a where
   txIntegers :: Lens' a (SFunArray Str Integer)
   txIntegers = analyzeEnv.aeTxMetadata.tmIntegers
 
+  txStrings :: Lens' a (SFunArray Str Str)
+  txStrings = analyzeEnv.aeTxMetadata.tmStrings
+
   inPact :: Lens' a (S Bool)
   inPact = analyzeEnv.aePactMetadata.pmInPact
 
@@ -712,6 +716,14 @@ readDecimal
   -> m (S Decimal)
 readDecimal sStr = fmap (withProv $ fromMetadata sStr) $
   readArray <$> view txDecimals <*> pure (_sSbv sStr)
+
+-- | Reads a named string from tx metadata
+readString
+  :: (MonadReader r m, HasAnalyzeEnv r)
+  => S Str
+  -> m (S Str)
+readString sStr = fmap (withProv $ fromMetadata sStr) $
+  readArray <$> view txStrings <*> pure (_sSbv sStr)
 
 -- | Reads a named integer from tx metadata
 readInteger

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -1330,6 +1330,7 @@ data Term (a :: Ty) where
   ReadKeySet      :: Term 'TyStr -> Term 'TyGuard
   ReadDecimal     :: Term 'TyStr -> Term 'TyDecimal
   ReadInteger     :: Term 'TyStr -> Term 'TyInteger
+  ReadString      :: Term 'TyStr -> Term 'TyStr
 
   -- TODO: ReadMsg
 
@@ -1503,6 +1504,7 @@ showsTerm ty p tm = withSing ty $ showParen (p > 10) $ case tm of
   ReadKeySet  name -> showString "ReadKeySet " . showsPrec 11 name
   ReadDecimal name -> showString "ReadDecimal " . showsPrec 11 name
   ReadInteger name -> showString "ReadInteger " . showsPrec 11 name
+  ReadString  name -> showString "ReadString " . showsPrec 11 name
   PactId           -> showString "PactId"
   Pact steps       -> showString "Pact " . showList steps
   Yield tid a      ->
@@ -1586,6 +1588,7 @@ prettyTerm ty = \case
   ReadKeySet name       -> parensSep ["read-keyset", pretty name]
   ReadDecimal name      -> parensSep ["read-decimal", pretty name]
   ReadInteger name      -> parensSep ["read-integer", pretty name]
+  ReadString name       -> parensSep ["read-string", pretty name]
   PactId                -> parensSep ["pact-id"]
   MkKsRefGuard name     -> parensSep ["keyset-ref-guard", pretty name]
   MkPactGuard name      -> parensSep ["create-pact-guard", pretty name]
@@ -1620,6 +1623,8 @@ eqTerm _ty (ReadKeySet a) (ReadKeySet b)
 eqTerm _ty (ReadDecimal a) (ReadDecimal b)
   = a == b
 eqTerm _ty (ReadInteger a) (ReadInteger b)
+  = a == b
+eqTerm _ty (ReadString a) (ReadString b)
   = a == b
 eqTerm _ty (GuardPasses a1 b1) (GuardPasses a2 b2)
   = a1 == a2 && b1 == b2

--- a/src/Pact/Gas/Table.hs
+++ b/src/Pact/Gas/Table.hs
@@ -92,6 +92,7 @@ defaultGasTable =
     , ("and?", const 1)
     , ("log", const 1)
     , ("read-decimal", const 1)
+    , ("read-string", const 1)
     , ("length", const 1)
     , ("sqrt", const 1)
     , ("<", const 1)

--- a/tests/Analyze/Translate.hs
+++ b/tests/Analyze/Translate.hs
@@ -22,6 +22,7 @@ import           Pact.Native               (dropDef, enforceDef, enforceOneDef,
                                             formatDef, hashDef, ifDef,
                                             lengthDef, makeListDef,
                                             pactVersionDef, readDecimalDef,
+                                            readIntegerDef, readStringDef,
                                             reverseDef, sortDef, strToIntDef,
                                             takeDef
   -- TODO: mapDef foldDef filterDef whereDef composeDef atDef
@@ -89,9 +90,6 @@ toPactTm = \case
 
     StrToIntBase b s ->
       mkApp strToIntDef [Some SInteger b, Some SStr s]
-
-    -- TODO:
-    -- ReadInteger
 
     Comparison ty' op x y ->
       mkApp (comparisonOpToDef op) [Some ty' x, Some ty' y]
@@ -165,6 +163,10 @@ toPactTm = \case
   Some SGuard (ReadKeySet x) -> mkApp readKeysetDef [Some SStr x]
 
   Some SDecimal (ReadDecimal x) -> mkApp readDecimalDef [Some SStr x]
+
+  Some SInteger (ReadInteger x) -> mkApp readIntegerDef [Some SStr x]
+
+  Some SStr (ReadString x) -> mkApp readStringDef [Some SStr x]
 
   Some STime (ParseTime Nothing x) ->
     mkApp timeDef [Some SStr x]

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -588,6 +588,30 @@ spec = describe "analyze" $ do
   -- TODO: test use of read-integer from property once possible
   --
 
+  describe "read-string" $ do
+    describe "value can be anything" $ do
+      let code =
+            [text|
+              (defun test:bool ()
+                (enforce
+                  (= "arbitrary string"
+                     (read-string "some-key"))
+                  ""))
+            |]
+      expectPass code $ Satisfiable Abort'
+      expectPass code $ Satisfiable Success'
+
+    describe "read always produces the same value" $ do
+      let code =
+            [text|
+              (defun test:bool ()
+                (enforce
+                  (= (read-string "some-key")
+                     (read-string "some-key"))
+                  ""))
+            |]
+      expectPass code $ Valid Success'
+
   describe "enforce-keyset.row-level.at" $ do
     let code =
           [text|

--- a/tests/pact/json.repl
+++ b/tests/pact/json.repl
@@ -16,6 +16,7 @@
 (expect "read-integer with neg string value" -1 (read-integer "nintn"))
 (expect "read-decimal with number value" 1.0 (read-decimal "dec"))
 (expect "read-decimal with neg number value" -1.0 (read-decimal "ndec"))
+(expect "read-string with string value" "hello" (read-string "str"))
 (expect "read-msg for object" { "list": [ { "a": true } {"b": "hello" } ] } (read-msg "obj"))
 (expect "read-msg for list" [1.0 2.0 3.0] (read-msg "list"))
 (expect "read-msg for bool" true (read-msg "bool"))


### PR DESCRIPTION
Concrete and symbolic implementation for new function `read-string`.

We already had `read-integer`, `read-decimal`, but no `read-string`. Technically `read-msg` can deserialize strings already, but it can return _any_ type which is not the best for typechecking and analysis, and folks who see `read-integer` and `read-decimal` would probably be surprised that no `-string` counterpart exists.