### PR TITLE
Ensure we never property check lists longer than 10.

### DIFF
--- a/tests/AnalyzePropertiesSpec.hs
+++ b/tests/AnalyzePropertiesSpec.hs
@@ -67,15 +67,7 @@ testDualEvaluation' etm ty gState = do
 
               -- compare results
               case singEq ty' ty'' of
-                Just Refl
-                  -- we only test bounded lists up to length 10. discard if the
-                  -- pact list is too long.
-                  -- TODO: this should only be considered a temporary fix. Done
-                  -- properly we need to check all intermediate values.
-                  | SList{} <- ty'
-                  , length pactSval > 10
-                  -> discard
-                  | otherwise -> withEq ty' $ withShow ty' $ sval' === pactSval
+                Just Refl -> withEq ty' $ withShow ty' $ sval' === pactSval
                 Nothing   ->
                   if singEqB ty' (SList SAny) || singEqB ty'' (SList SAny)
                   then discard -- TODO: check this case


### PR DESCRIPTION
Previously, we could generate intermediate computations using lists of
length longer than 10, since we only checked if the final result was
longer than 10. Example of a test that actually failed:

    (enforce
      (=
        (make-list 10 0)
        (drop 1 (reverse (make-list 11 0)))
        ""))

The new method of generating lists only generates valid lists of length
<= 10. We do this by only allowing integer literals as the length
argumenent to `make-list`. The downside is that we rule out a bunch of
valid programs.

Ways lists are generated:
* `make-list`: we only `make-list` lists of a valid length
* `reverse` / `sort`: these preserve length
* `concat`: for each sublist we halve the allowed length
* `drop` / `take`: these always return a list no longer than their
  argument.