### PR TITLE
Bump cabal version + Designate `bench` as Benchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -211,7 +211,7 @@ script:
   case "$BUILD" in
     stack)
       stack build --no-terminal --test --ghc-options="-Werror" $ARGS
-      stack exec -- bench +RTS -K1k
+      stack bench --benchmark-arguments "+RTS -K1k"
       ;;
     cabal)
       cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES

--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,7 @@ packages:
 package pact
     tests: True
     profiling: True
+    profiling-detail: all-functions
 
 debug-info: True
 
@@ -14,6 +15,6 @@ source-repository-package
     tag: 6ee9fcb026ebdb49b810802a981d166680d867c9
 
 constraints:
-    megaparsec <7.0
+    megaparsec < 7.0
   , servant < 0.16
   , swagger2 < 2.4

--- a/pact.cabal
+++ b/pact.cabal
@@ -1,20 +1,20 @@
+cabal-version:       2.2
 name:                pact
 version:             3.1.0
 synopsis:            Smart contract language library and REPL
 description:
-            Pact is a transactional, database-focused, Turing-incomplete, interpreted language for smart contracts,
-            logic to be deployed and executed on a blockchain/distributed ledger. For more information see
-            <http://kadena.io/pact>.
+  Pact is a transactional, database-focused, Turing-incomplete, interpreted language for smart contracts,
+  logic to be deployed and executed on a blockchain/distributed ledger. For more information see
+  <http://kadena.io/pact>.
 homepage:            https://github.com/kadena-io/pact
 bug-reports:         https://github.com/kadena-io/pact/issues
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Stuart Popejoy
 maintainer:          stuart@kadena.io
 copyright:           Copyright (C) 2016 Stuart Popejoy
 category:            Language
 build-type:          Simple
-cabal-version:       >=1.22
 
 flag cryptonite-ed25519
   description: use cryptonite instead of ed25519-donna
@@ -144,55 +144,55 @@ library
   build-depends:       Decimal >= 0.4.2 && < 0.6
                      , aeson >= 0.11.3.0 && < 1.5
                      , algebraic-graphs >= 0.2 && < 0.4
-                     , prettyprinter >= 1.2 && < 1.3
-                     , prettyprinter-ansi-terminal >= 1.1 && < 1.2
-                     , prettyprinter-convert-ansi-wl-pprint
-                     , attoparsec >= 0.13.0.2 && < 0.14
+                     , prettyprinter ^>= 1.2
+                     , prettyprinter-ansi-terminal ^>= 1.1
+                     , prettyprinter-convert-ansi-wl-pprint == 1.1
+                     , attoparsec ^>= 0.13.0.2
                      , base >=4.9.0.0 && < 4.13
-                     , base16-bytestring >=0.1.1.6 && < 0.2
-                     , base64-bytestring >= 1.0.0.1
-                     , bound >= 2 && < 2.1
-                     , bytestring >=0.10.8.1 && < 0.11
-                     , cereal >=0.5.4.0 && < 0.6
+                     , base16-bytestring ^>=0.1.1.6
+                     , base64-bytestring ^>= 1.0.0.1
+                     , bound ^>= 2
+                     , bytestring ^>= 0.10.8.1
+                     , cereal ^>= 0.5.4.0
                      , containers >= 0.5.7 && < 0.7
-                     , data-default >= 0.7.1.1 && < 0.8
-                     , deepseq >= 1.4.2.0 && < 1.5
-                     , deriving-compat >= 0.5.1
+                     , data-default ^>= 0.7.1.1
+                     , deepseq ^>= 1.4.2.0
+                     , deriving-compat ^>= 0.5.1
                      , directory >= 1.2.6.2 && < 1.4
                      , exceptions >= 0.8.3 && < 0.11
-                     , filepath >= 1.4.1.0 && < 1.5
-                     , hashable >= 1.2.4.0 && < 1.3
+                     , filepath ^>= 1.4.1.0
+                     , hashable ^>= 1.2.4.0
                      , hspec >= 2.2.4 && < 2.8
                      , lens >= 4.14 && < 4.18
-                     , lens-aeson >= 1.0.0.5 && < 1.1
-                     , megaparsec >= 6
-                     , mtl >= 2.2.1 && < 2.3
+                     , lens-aeson ^>= 1.0.0.5
+                     , megaparsec >= 6.0 && < 7.0
+                     , mtl ^>= 2.2.1
                      , old-locale >= 1.0.0.7 && < 1.1
                      , optparse-applicative >= 0.12.1.0 && < 0.15
                      , parsers >= 0.12.4 && < 0.13
-                     , reflection
-                     , safe >= 0.3.11 && < 0.4
-                     , scientific >= 0.3.4.9 && < 0.4
-                     , semigroups >= 0.18.2 && < 0.19
+                     , reflection ^>= 2.1
+                     , safe ^>= 0.3.11
+                     , scientific ^>= 0.3.4.9
+                     , semigroups ^>= 0.18.2
                      , semigroupoids >= 5.0
                      , stm >= 2.4.4.1 && < 2.6
-                     , text >= 1.2.2.1 && < 1.3
+                     , text ^>= 1.2.2.1
                      -- kadena ghcjs compat fork
                      , thyme == 0.3.6.0
-                     , transformers >= 0.5.2.0 && < 0.6
-                     , trifecta >= 2 && < 2.1
-                     , unordered-containers >= 0.2.7.2 && < 0.3
-                     , utf8-string >= 1.0.1.1 && < 1.1
+                     , transformers ^>= 0.5.2.0
+                     , trifecta ^>= 2
+                     , unordered-containers ^>= 0.2.7.2
+                     , utf8-string ^>= 1.0.1.1
                      , vector >= 0.11.0.0 && < 0.13
-                     , vector-algorithms >= 0.7
+                     , vector-algorithms
                      , vector-space >= 0.10.4 && < 0.16
-                     , mmorph >= 1.1 && < 1.2
+                     , mmorph ^>= 1.1
                      , constraints
-                     , servant
+                     , servant < 0.16
                      , servant-client
                      , servant-client-core
                      , servant-swagger
-                     , swagger2 >= 2.3
+                     , swagger2 ^>= 2.3
 
   if impl(ghcjs)
     build-depends:
@@ -206,7 +206,7 @@ library
                 , cryptonite
                 , direct-sqlite
                 , fast-logger
-                , haskeline >= 0.7.3 && < 0.8
+                , haskeline ^>= 0.7.3
                 , http-client
                 , memory
                 , neat-interpolation
@@ -248,7 +248,8 @@ executable pact
   if os(darwin)
     ghc-options: -optP-Wno-nonportable-include-path
 
-executable bench
+benchmark bench
+  type:                exitcode-stdio-1.0
   main-is:             Bench.hs
   build-depends:       base
                      , pact
@@ -272,7 +273,7 @@ test-suite hspec
               , Decimal
               , HUnit
               , aeson
-              , base16-bytestring >=0.1.1.6 && < 0.2
+              , base16-bytestring ^>= 0.1.1.6
               , bound
               , bytestring
               , containers

--- a/pact.cabal
+++ b/pact.cabal
@@ -3,9 +3,9 @@ name:                pact
 version:             3.1.0
 synopsis:            Smart contract language library and REPL
 description:
-  Pact is a transactional, database-focused, Turing-incomplete, interpreted language for smart contracts,
-  logic to be deployed and executed on a blockchain/distributed ledger. For more information see
-  <http://kadena.io/pact>.
+            Pact is a transactional, database-focused, Turing-incomplete, interpreted language for smart contracts,
+            logic to be deployed and executed on a blockchain/distributed ledger. For more information see
+            <http://kadena.io/pact>.
 homepage:            https://github.com/kadena-io/pact
 bug-reports:         https://github.com/kadena-io/pact/issues
 license:             BSD-3-Clause
@@ -144,55 +144,55 @@ library
   build-depends:       Decimal >= 0.4.2 && < 0.6
                      , aeson >= 0.11.3.0 && < 1.5
                      , algebraic-graphs >= 0.2 && < 0.4
-                     , prettyprinter ^>= 1.2
-                     , prettyprinter-ansi-terminal ^>= 1.1
-                     , prettyprinter-convert-ansi-wl-pprint == 1.1
-                     , attoparsec ^>= 0.13.0.2
+                     , prettyprinter >= 1.2 && < 1.3
+                     , prettyprinter-ansi-terminal >= 1.1 && < 1.2
+                     , prettyprinter-convert-ansi-wl-pprint
+                     , attoparsec >= 0.13.0.2 && < 0.14
                      , base >=4.9.0.0 && < 4.13
-                     , base16-bytestring ^>=0.1.1.6
-                     , base64-bytestring ^>= 1.0.0.1
-                     , bound ^>= 2
-                     , bytestring ^>= 0.10.8.1
-                     , cereal ^>= 0.5.4.0
+                     , base16-bytestring >=0.1.1.6 && < 0.2
+                     , base64-bytestring >= 1.0.0.1
+                     , bound >= 2 && < 2.1
+                     , bytestring >=0.10.8.1 && < 0.11
+                     , cereal >=0.5.4.0 && < 0.6
                      , containers >= 0.5.7 && < 0.7
-                     , data-default ^>= 0.7.1.1
-                     , deepseq ^>= 1.4.2.0
-                     , deriving-compat ^>= 0.5.1
+                     , data-default >= 0.7.1.1 && < 0.8
+                     , deepseq >= 1.4.2.0 && < 1.5
+                     , deriving-compat >= 0.5.1
                      , directory >= 1.2.6.2 && < 1.4
                      , exceptions >= 0.8.3 && < 0.11
-                     , filepath ^>= 1.4.1.0
-                     , hashable ^>= 1.2.4.0
+                     , filepath >= 1.4.1.0 && < 1.5
+                     , hashable >= 1.2.4.0 && < 1.3
                      , hspec >= 2.2.4 && < 2.8
                      , lens >= 4.14 && < 4.18
-                     , lens-aeson ^>= 1.0.0.5
-                     , megaparsec >= 6.0 && < 7.0
-                     , mtl ^>= 2.2.1
+                     , lens-aeson >= 1.0.0.5 && < 1.1
+                     , megaparsec >= 6
+                     , mtl >= 2.2.1 && < 2.3
                      , old-locale >= 1.0.0.7 && < 1.1
                      , optparse-applicative >= 0.12.1.0 && < 0.15
                      , parsers >= 0.12.4 && < 0.13
-                     , reflection ^>= 2.1
-                     , safe ^>= 0.3.11
-                     , scientific ^>= 0.3.4.9
-                     , semigroups ^>= 0.18.2
+                     , reflection
+                     , safe >= 0.3.11 && < 0.4
+                     , scientific >= 0.3.4.9 && < 0.4
+                     , semigroups >= 0.18.2 && < 0.19
                      , semigroupoids >= 5.0
                      , stm >= 2.4.4.1 && < 2.6
-                     , text ^>= 1.2.2.1
+                     , text >= 1.2.2.1 && < 1.3
                      -- kadena ghcjs compat fork
                      , thyme == 0.3.6.0
-                     , transformers ^>= 0.5.2.0
-                     , trifecta ^>= 2
-                     , unordered-containers ^>= 0.2.7.2
-                     , utf8-string ^>= 1.0.1.1
+                     , transformers >= 0.5.2.0 && < 0.6
+                     , trifecta >= 2 && < 2.1
+                     , unordered-containers >= 0.2.7.2 && < 0.3
+                     , utf8-string >= 1.0.1.1 && < 1.1
                      , vector >= 0.11.0.0 && < 0.13
-                     , vector-algorithms
+                     , vector-algorithms >= 0.7
                      , vector-space >= 0.10.4 && < 0.16
-                     , mmorph ^>= 1.1
+                     , mmorph >= 1.1 && < 1.2
                      , constraints
-                     , servant < 0.16
+                     , servant
                      , servant-client
                      , servant-client-core
                      , servant-swagger
-                     , swagger2 ^>= 2.3
+                     , swagger2 >= 2.3
 
   if impl(ghcjs)
     build-depends:
@@ -206,7 +206,7 @@ library
                 , cryptonite
                 , direct-sqlite
                 , fast-logger
-                , haskeline ^>= 0.7.3
+                , haskeline >= 0.7.3 && < 0.8
                 , http-client
                 , memory
                 , neat-interpolation
@@ -273,7 +273,7 @@ test-suite hspec
               , Decimal
               , HUnit
               , aeson
-              , base16-bytestring ^>= 0.1.1.6
+              , base16-bytestring >=0.1.1.6 && < 0.2
               , bound
               , bytestring
               , containers


### PR DESCRIPTION
This PR bumps the cabal version to 2.2, which is the current stable version supported by Nix. This is done so we can treat the `bench` target as a proper benchmark