### PR TITLE
Add analysis for bitwise operations

### DIFF
--- a/src/Pact/Analyze/Errors.hs
+++ b/src/Pact/Analyze/Errors.hs
@@ -20,6 +20,7 @@ data AnalyzeFailureNoLoc
   | AValUnexpectedlySVal SBVI.SVal
   | KeyNotPresent Text EType
   | MalformedLogicalOpExec LogicalOp Int
+  | MalformedBitwiseOp BitwiseOp Int
   | ObjFieldOfWrongType Text EType
   | PossibleRoundoff Text
   | UnsupportedDecArithOp ArithOp
@@ -43,6 +44,7 @@ describeAnalyzeFailureNoLoc = \case
     AValUnexpectedlySVal sval -> "in evalProp, unexpectedly found AVal: " <> tShow sval
     KeyNotPresent key obj -> "key " <> key <> " unexpectedly not found in object " <> tShow obj
     MalformedLogicalOpExec op count -> "malformed logical op " <> tShow op <> " with " <> tShow count <> " args"
+    MalformedBitwiseOp op count -> "malformed bitwise op " <> tShow op <> " with " <> tShow count <> " args"
     ObjFieldOfWrongType fName fType -> "object field " <> fName <> " of type " <> tShow fType <> " unexpectedly either an object or a ground type when we expected the other"
     PossibleRoundoff msg -> msg
     UnsupportedDecArithOp op -> "unsupported decimal arithmetic op: " <> tShow op

--- a/src/Pact/Analyze/Feature.hs
+++ b/src/Pact/Analyze/Feature.hs
@@ -36,6 +36,7 @@ import qualified Pact.Types.Pretty      as Pretty
 
 data FeatureClass
   = CNumerical
+  | CBitwise
   | CLogical
   | CObject
   | CList
@@ -51,6 +52,7 @@ data FeatureClass
 
 classTitle :: FeatureClass -> Text
 classTitle CNumerical      = "Numerical"
+classTitle CBitwise        = "Bitwise"
 classTitle CLogical        = "Logical"
 classTitle CObject         = "Object"
 classTitle CString         = "String"
@@ -80,6 +82,12 @@ data Feature
   | FCeilingRound
   | FFloorRound
   | FModulus
+  -- Bitwise operators
+  | FBitwiseAnd
+  | FBitwiseOr
+  | FXor
+  | FShift
+  | FComplement
   -- Logical operators
   | FGreaterThan
   | FLessThan
@@ -497,6 +505,86 @@ doc FModulus = Doc
         [ ("x", TyCon int)
         , ("y", TyCon int)
         ]
+        (TyCon int)
+  ]
+
+-- Bitwise operators
+
+doc FBitwiseAnd = Doc
+  "&"
+  CBitwise
+  InvAndProp
+  "Bitwise and"
+  [ Usage
+      "(& x y)"
+      Map.empty
+      $ Fun
+        Nothing
+        [ ("x", TyCon int)
+        , ("y", TyCon int)
+        ]
+        (TyCon int)
+  ]
+
+doc FBitwiseOr = Doc
+  "|"
+  CBitwise
+  InvAndProp
+  "Bitwise or"
+  [ Usage
+      "(| x y)"
+      Map.empty
+      $ Fun
+        Nothing
+        [ ("x", TyCon int)
+        , ("y", TyCon int)
+        ]
+        (TyCon int)
+  ]
+
+doc FXor = Doc
+  "xor"
+  CBitwise
+  InvAndProp
+  "Bitwise exclusive-or"
+  [ Usage
+      "(xor x y)"
+      Map.empty
+      $ Fun
+        Nothing
+        [ ("x", TyCon int)
+        , ("y", TyCon int)
+        ]
+        (TyCon int)
+  ]
+
+doc FShift = Doc
+  "shift"
+  CBitwise
+  InvAndProp
+  "Shift `x` `y` bits left if `y` is positive, or right by `-y` bits otherwise."
+  [ Usage
+      "(shift x y)"
+      Map.empty
+      $ Fun
+        Nothing
+        [ ("x", TyCon int)
+        , ("y", TyCon int)
+        ]
+        (TyCon int)
+  ]
+
+doc FComplement = Doc
+  "~"
+  CBitwise
+  InvAndProp
+  "Reverse all bits in `x`"
+  [ Usage
+      "(~ x)"
+      Map.empty
+      $ Fun
+        Nothing
+        [ ("x", TyCon int) ]
         (TyCon int)
   ]
 
@@ -1562,6 +1650,11 @@ PAT(SBankersRound, FBankersRound)
 PAT(SCeilingRound, FCeilingRound)
 PAT(SFloorRound, FFloorRound)
 PAT(SModulus, FModulus)
+PAT(SBitwiseAnd, FBitwiseAnd)
+PAT(SBitwiseOr, FBitwiseOr)
+PAT(SXor, FXor)
+PAT(SShift, FShift)
+PAT(SComplement, FComplement)
 PAT(SGreaterThan, FGreaterThan)
 PAT(SLessThan, FLessThan)
 PAT(SGreaterThanOrEqual, FGreaterThanOrEqual)

--- a/src/Pact/Analyze/Parse/Prop.hs
+++ b/src/Pact/Analyze/Parse/Prop.hs
@@ -471,6 +471,10 @@ inferPreProp preProp = case preProp of
           -- For all other (simple) types, any comparison operator is valid
           _ -> pure $ Some SBool $ CoreProp $ Comparison aTy op a' b'
 
+  PreApp (toOp bitwiseOpP -> Just op) args ->
+    Some SInteger . PNumerical . BitwiseOp op <$>
+      traverse (checkPreProp SInteger) args
+
   PreApp op'@(toOp logicalOpP -> Just op) args ->
     Some SBool <$> case (op, args) of
       (NotOp, [a  ])  -> PNot <$> checkPreProp SBool a

--- a/src/Pact/Analyze/PrenexNormalize.hs
+++ b/src/Pact/Analyze/PrenexNormalize.hs
@@ -79,6 +79,8 @@ singFloat ty p = case p of
     -> PropSpecific . RowWriteCount tn   <$> float pRk
   PropSpecific (RowReadCount tn pRk)
     -> PropSpecific . RowReadCount tn    <$> float pRk
+  CoreProp (Numerical (BitwiseOp op args))
+    -> PNumerical . BitwiseOp op         <$> traverse (singFloat ty) args
 
   -- decimal
   CoreProp (Numerical (DecArithOp op a b))

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -1509,6 +1509,13 @@ translateNode astNode = withAstContext astNode $ case astNode of
 
   AST_NFun _ "keys" [_] -> throwError' $ NoKeys astNode
 
+  AST_NFun _node (toOp bitwiseOpP -> Just op) args -> do
+    args' <- for args $ \arg -> do
+      Some SInteger arg' <- translateNode arg
+      pure arg'
+    pure $ Some SInteger $ inject @(Numerical Term) $
+      BitwiseOp op args'
+
   _ -> throwError' $ UnexpectedNode astNode
 
 captureOneFreeVar :: TranslateM (VarId, Text, EType)

--- a/src/Pact/Analyze/Types/Languages.hs
+++ b/src/Pact/Analyze/Types/Languages.hs
@@ -454,6 +454,8 @@ eqNumerical _ty (RoundingLikeOp1 op1 a1) (RoundingLikeOp1 op2 a2)
   = op1 == op2 && eqTm a1 a2
 eqNumerical _ty (RoundingLikeOp2 op1 a1 b1) (RoundingLikeOp2 op2 a2 b2)
   = op1 == op2 && eqTm a1 a2 && eqTm b1 b2
+eqNumerical _ty (BitwiseOp op1 args1) (BitwiseOp op2 args2)
+  = op1 == op2 && and (zipWith eqTm args1 args2)
 eqNumerical _ _ _ = False
 
 showsNumerical :: IsTerm tm => SingTy a -> Int -> Numerical tm a -> ShowS
@@ -513,6 +515,11 @@ showsNumerical _ty p tm = showParen (p > 10) $ case tm of
     . showsTm 11 a
     . showChar ' '
     . showsTm 11 b
+  BitwiseOp op args ->
+      showString "BitwiseOp "
+    . showsPrec 11 op
+    . showChar ' '
+    . showListWith (singShowsTm SInteger 0) args
 
 prettyNumerical :: IsTerm tm => SingTy a -> Numerical tm a -> Doc
 prettyNumerical _ty = \case
@@ -525,6 +532,7 @@ prettyNumerical _ty = \case
   ModOp a b              -> parensSep [prettyTm a, prettyTm b            ]
   RoundingLikeOp1 op a   -> parensSep [pretty op,  prettyTm a            ]
   RoundingLikeOp2 op a b -> parensSep [pretty op,  prettyTm a, prettyTm b]
+  BitwiseOp op args      -> parensSep $ pretty op : fmap prettyTm args
 
 eqCoreTm :: IsTerm tm => SingTy ty -> Core tm ty -> Core tm ty -> Bool
 eqCoreTm ty (Lit a)                      (Lit b)

--- a/src/Pact/Analyze/Types/Numerical.hs
+++ b/src/Pact/Analyze/Types/Numerical.hs
@@ -264,6 +264,26 @@ unaryArithOpP = mkOpNamePrism
 instance Pretty UnaryArithOp where
   pretty = toDoc unaryArithOpP
 
+data BitwiseOp
+  = BitwiseAnd
+  | BitwiseOr
+  | Xor
+  | Shift
+  | Complement
+  deriving (Show, Eq, Ord)
+
+bitwiseOpP :: Prism' Text BitwiseOp
+bitwiseOpP = mkOpNamePrism
+  [ (SBitwiseAnd, BitwiseAnd)
+  , (SBitwiseOr,  BitwiseOr)
+  , (SXor,        Xor)
+  , (SShift,      Shift)
+  , (SComplement, Complement)
+  ]
+
+instance Pretty BitwiseOp where
+  pretty = toDoc bitwiseOpP
+
 -- decimal -> integer -> decimal
 -- decimal -> decimal
 data RoundingLikeOp
@@ -316,6 +336,7 @@ data Numerical t (a :: Ty) where
   ModOp           :: t 'TyInteger    -> t 'TyInteger ->                 Numerical t 'TyInteger
   RoundingLikeOp1 :: RoundingLikeOp  -> t 'TyDecimal ->                 Numerical t 'TyInteger
   RoundingLikeOp2 :: RoundingLikeOp  -> t 'TyDecimal -> t 'TyInteger -> Numerical t 'TyDecimal
+  BitwiseOp       :: BitwiseOp       -> [t 'TyInteger]               -> Numerical t 'TyInteger
 
 instance (Pretty (t 'TyInteger), Pretty (t 'TyDecimal))
   => Pretty (Numerical t a) where
@@ -329,6 +350,7 @@ instance (Pretty (t 'TyInteger), Pretty (t 'TyDecimal))
     ModOp a b              -> [pretty SModulus, pretty a, pretty b]
     RoundingLikeOp1 op a   -> [pretty op, pretty a]
     RoundingLikeOp2 op a b -> [pretty op, pretty a, pretty b]
+    BitwiseOp op args      -> pretty op : fmap pretty args
 
 deriving instance (Eq   (t 'TyDecimal), Eq   (t 'TyInteger)) => Eq   (Numerical t a)
 deriving instance (Show (t 'TyDecimal), Show (t 'TyInteger)) => Show (Numerical t a)

--- a/tests/Analyze/Gen.hs
+++ b/tests/Analyze/Gen.hs
@@ -182,7 +182,7 @@ genCore :: (HasCallStack, MonadGen m) => BoundedType -> m ETerm
 genCore (BoundedInt size) = Gen.recursive Gen.choice [
     Some SInteger . Lit' <$> genInteger size
   ] $ scale 4 <$> [
-    Gen.subtermM2 (genCore (BoundedInt size)) (genCore (BoundedInt (1 ... 1e3))) $
+    Gen.subtermM2 (genCore (BoundedInt size)) (genCore (BoundedInt (1 ... 1000))) $
       \x y -> mkInt $ Numerical $ ModOp (extract x) (extract y)
   , do op <- genArithOp
        let (size1, size2) = arithSize op size
@@ -196,6 +196,13 @@ genCore (BoundedInt size) = Gen.recursive Gen.choice [
     op <- genRoundingLikeOp
     mkInt $ Numerical $ RoundingLikeOp1 op (extract x)
   , Gen.subtermM (genCore strSize) $ mkInt . StrLength . extract
+  , do op <- Gen.element [BitwiseAnd, BitwiseOr, Xor]
+       Gen.subtermM2 (genCore (BoundedInt size)) (genCore (BoundedInt size)) $
+         \x y -> mkInt $ Numerical $ BitwiseOp op [extract x, extract y]
+  , Gen.subtermM2 (genCore (BoundedInt size)) (genCore (BoundedInt (1 ... 10))) $
+      \x y -> mkInt $ Numerical $ BitwiseOp Shift [extract x, extract y]
+  , Gen.subtermM (genCore (BoundedInt size)) $
+    mkInt . Numerical . BitwiseOp Complement . (:[]) . extract
   ]
 genCore bounded@(BoundedDecimal size) = Gen.recursive Gen.choice [
     Some SDecimal . Lit' <$> genDecimal size

--- a/tests/Analyze/Translate.hs
+++ b/tests/Analyze/Translate.hs
@@ -75,6 +75,9 @@ toPactTm = \case
       ModOp x y ->
         mkApp modDef [Some SInteger x, Some SInteger y]
 
+      BitwiseOp op args ->
+        mkApp (bitwiseOpToDef op) (Some SInteger <$> args)
+
     StrLength x ->
       mkApp lengthDef [Some SStr x]
 
@@ -214,6 +217,14 @@ toPactTm = \case
       Div -> divDef
       Pow -> powDef
       Log -> logDef
+
+    bitwiseOpToDef :: BitwiseOp -> NativeDef
+    bitwiseOpToDef = \case
+      BitwiseAnd -> bitAndDef
+      BitwiseOr  -> bitOrDef
+      Xor        -> xorDef
+      Shift      -> shiftDef
+      Complement -> complementDef
 
     unaryArithOpToDef :: UnaryArithOp -> NativeDef
     unaryArithOpToDef = \case

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -2132,6 +2132,18 @@ spec = describe "analyze" $ do
                     1581138830084.1918464
                     1581138830084)
                   1.000000000000121334316980759948431357013938975877803928214364623522650045615600621337146939720454311443026061056754776474139591383112306668111215913835129748371209820415844429729847990579481732664375546615468582277686924612859136684739968417878803629721864))
+
+                (enforce (= 2 (& 2 3)) "bitwise 2 and 3" )
+                (enforce (= 1 (& 5 -7)) "bitwise 5 and -7")
+                (enforce (= 3 (| 2 3)) "bitwise 2 or 3")
+                (enforce (= -3 (| 5 -7)) "bitwise 5 or -7")
+                (enforce (= 6 (xor 2 4)) "bitwise 2 xor 4")
+                (enforce (= -4 (xor 5 -7)) "bitwise 5 xor -7")
+                (enforce (= -16 (~ 15)) "complement 15")
+                (enforce (= 65280 (shift 255 8)) "shift 255 8")
+                (enforce (= -65280 (shift -255 8)) "shift -255 8")
+                (enforce (= 127 (shift 255 -1)) "shift 255 -1")
+                (enforce (= -128 (shift -255 -1)) "shift -255 -1")
               ))
           |]
     in expectPass code $ Valid $ sNot Abort'


### PR DESCRIPTION
The last PR that was opened for this (#592) was set to merge into `feat/integer-bit-manipulations` instead of `master`. This PR is to merge it into master.