### PR TITLE
Replace 'fetchFromGithub' with 'callHackageDirect' for sbv

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -106,8 +106,8 @@ in
 
             sbv = dontCheck (callHackageDirect {
               pkg = "sbv";
-              ver = "8.1";
-              sha256 = "07kwnkgc65mjqikfiw29gd0lzb5ddcw15zhq43vr3saq85lb6d69";
+              ver = "8.2";
+              sha256 = "1isa8p9dnahkljwj0kz10119dwiycf11jvzdc934lnjv1spxkc9k";
             });
 
             # need crackNum 2.3

--- a/default.nix
+++ b/default.nix
@@ -104,13 +104,11 @@ in
             hlint = self.callHackage "hlint" "2.0.14" {};
             # hoogle = self.callHackage "hoogle" "5.0.15" {};
 
-            # sbv 8.1
-            sbv = dontCheck (self.callCabal2nix "sbv" (pkgs.fetchFromGitHub {
-              owner = "LeventErkok";
-              repo = "sbv";
-              rev = "365b1a369a2550d6284608df3fbc17e2663c4d3c";
-              sha256 = "134f148g28dg7b3c1rvkh85pfl9pdlvrvl6al4vlz72f3y5mb2xg";
-            }) {});
+            sbv = dontCheck (callHackageDirect {
+              pkg = "sbv";
+              ver = "8.1";
+              sha256 = "07kwnkgc65mjqikfiw29gd0lzb5ddcw15zhq43vr3saq85lb6d69";
+            });
 
             # need crackNum 2.3
             crackNum = pkgs.haskell.lib.dontCheck (self.callCabal2nix "crackNum" (pkgs.fetchFromGitHub {

--- a/static.nix
+++ b/static.nix
@@ -12,6 +12,12 @@ let
 in (rp.ghcMusl64.override {
   overrides = self: super:
     let guardGhcjs = p: if self.ghc.isGhcjs or false then null else p;
+        callHackageDirect = {pkg, ver, sha256}@args:
+          let pkgver = "${pkg}-${ver}";
+          in self.callCabal2nix pkg (rp.nixpkgs.fetchzip {
+               url = "http://hackage.haskell.org/package/${pkgver}/${pkgver}.tar.gz";
+               inherit sha256;
+             }) {};
       in with rp.nixpkgs.haskell.lib; {
         clock = overrideCabal super.clock (drv: {
           postPatch = ''
@@ -58,13 +64,11 @@ in (rp.ghcMusl64.override {
           hlint = self.callHackage "hlint" "2.0.14" {};
           # hoogle = self.callHackage "hoogle" "5.0.15" {};
 
-          # sbv 8.1
-          sbv = dontHaddock (dontCheck (self.callCabal2nix "sbv" (rp.nixpkgs.fetchFromGitHub {
-            owner = "LeventErkok";
-            repo = "sbv";
-            rev = "365b1a369a2550d6284608df3fbc17e2663c4d3c";
-            sha256 = "134f148g28dg7b3c1rvkh85pfl9pdlvrvl6al4vlz72f3y5mb2xg";
-          }) {}));
+          sbv = dontCheck (callHackageDirect {
+            pkg = "sbv";
+            ver = "8.2";
+            sha256 = "1isa8p9dnahkljwj0kz10119dwiycf11jvzdc934lnjv1spxkc9k";
+          });
 
           # Our own custom fork
           thyme = dontHaddock (dontCheck (self.callCabal2nix "thyme" (rp.nixpkgs.fetchFromGitHub {


### PR DESCRIPTION
https://github.com/LeventErkok/sbv is 404ing, which breaks the nix build:

```
$ nix-shell
building '/nix/store/8bpl7n8j1xzn2yf6g53wfhv4ng2gdj1m-source.drv'...
trying https://github.com/LeventErkok/sbv/archive/365b1a369a2550d6284608df3fbc17e2663c4d3c.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
error: cannot download source from any mirror
builder for '/nix/store/8bpl7n8j1xzn2yf6g53wfhv4ng2gdj1m-source.drv' failed with exit code 1
cannot build derivation '/nix/store/rmi2afs3j7rwr2f22ad6agp974p04bn5-cabal2nix-sbv.drv': 1 dependencies couldn't be built
error: build of '/nix/store/rmi2afs3j7rwr2f22ad6agp974p04bn5-cabal2nix-sbv.drv' failed
(use '--show-trace' to show detailed location information)
```

I don't know if the same hash is shared between `fetchFromGithub` and `callHackageDirect`. If it does, then this changes the actual commit pointed to.