### PR TITLE
CI: Avoid building Pact twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -210,8 +210,8 @@ script:
   set -ex
   case "$BUILD" in
     stack)
-      stack build --no-terminal --test --ghc-options="-Werror" $ARGS
-      stack bench --benchmark-arguments "+RTS -K1k"
+      stack build --no-terminal --test --bench --no-run-benchmarks --ghc-options="-Werror" $ARGS
+      stack bench --no-terminal --benchmark-arguments "+RTS -K1k"
       ;;
     cabal)
       cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES


### PR DESCRIPTION
By default, `stack test` (alias of `stack build --test`) and `stack bench` (alias of `stack build --bench`) set different cabal configurations, and thus back-to-back calls of `stack test` and `stack bench` will force the library and exec components of Pact to be needlessly rebuilt between the two.

This PR fixes that, which should cut off at least 5 minutes from each Travis CI run.