### PR TITLE
Remove `megaparsec` Constraint From cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,6 +15,5 @@ source-repository-package
     tag: 6ee9fcb026ebdb49b810802a981d166680d867c9
 
 constraints:
-    megaparsec < 7.0
-  , servant < 0.16
+    servant < 0.16
   , swagger2 < 2.4


### PR DESCRIPTION
missed in the last bump