### PR TITLE
use fail from MonadFail

### DIFF
--- a/src/Pact/Parse.hs
+++ b/src/Pact/Parse.hs
@@ -36,6 +36,7 @@ import Control.Applicative
 import Control.DeepSeq (NFData)
 import Control.Lens (Wrapped(..))
 import Control.Monad
+import Control.Monad.Fail (MonadFail)
 import qualified Data.Aeson as A
 import qualified Data.Attoparsec.Text as AP
 import Data.Char (digitToInt)
@@ -57,7 +58,7 @@ import Pact.Types.Term (ToTerm)
 
 
 -- | Main parser for Pact expressions.
-expr :: (Monad m, TokenParsing m, DeltaParsing m) => PactParser m (Exp Parsed)
+expr :: (MonadFail m, TokenParsing m, DeltaParsing m) => PactParser m (Exp Parsed)
 expr = do
   delt <- position
   let inf = do
@@ -80,7 +81,7 @@ expr = do
     ]
 {-# INLINE expr #-}
 
-number :: (Monad m, TokenParsing m, DeltaParsing m) => PactParser m Literal
+number :: (MonadFail m, TokenParsing m, DeltaParsing m) => PactParser m Literal
 number = do
   -- Tricky: note that we use `char :: CharParsing m => Char -> m Char` rather
   -- than `symbolic :: TokenParsing m => Char -> m Char` here. We use the char
@@ -103,7 +104,7 @@ number = do
 {-# INLINE number #-}
 
 
-qualifiedAtom :: (Monad p, TokenParsing p) => p (Text,[Text])
+qualifiedAtom :: (MonadFail p, TokenParsing p) => p (Text,[Text])
 qualifiedAtom = ident style `sepBy` dot >>= \as -> case reverse as of
   [] -> fail "qualifiedAtom"
   (a:qs) -> return (a,reverse qs)
@@ -117,12 +118,12 @@ bool = msum
 
 
 -- | Parse one or more Pact expressions.
-exprs :: (TokenParsing m, DeltaParsing m) => PactParser m [Exp Parsed]
+exprs :: (MonadFail m, TokenParsing m, DeltaParsing m) => PactParser m [Exp Parsed]
 exprs = some expr
 
 -- | Parse one or more Pact expressions and EOF.
 -- Unnecessary with Atto's 'parseOnly'.
-exprsOnly :: (Monad m, TokenParsing m, DeltaParsing m) => m [Exp Parsed]
+exprsOnly :: (MonadFail m, TokenParsing m, DeltaParsing m) => m [Exp Parsed]
 exprsOnly = unPactParser $ whiteSpace *> exprs <* TF.eof
 
 -- | JSON serialization for 'readDecimal' and public meta info;

--- a/src/Pact/Types/Capability.hs
+++ b/src/Pact/Types/Capability.hs
@@ -76,7 +76,7 @@ parseSigCapability txt = parsed >>= compiled >>= parseApp
   where
     parseApp ts = case ts of
       [(TApp (App (TVar (QName q) _) as _) _)] -> SigCapability q <$> mapM toPV as
-      _ -> fail $ "Sig capability parse failed: Expected single qualified capability in form (qual.DEFCAP arg arg ...)"
+      _ -> Left $ "Sig capability parse failed: Expected single qualified capability in form (qual.DEFCAP arg arg ...)"
     compiled ParsedCode{..} = fmapL (("Sig capability parse failed: " ++) . show) $
       compileExps (mkTextInfo _pcCode) _pcExps
     parsed = parsePact txt

--- a/src/Pact/Types/Parser.hs
+++ b/src/Pact/Types/Parser.hs
@@ -21,13 +21,14 @@ module Pact.Types.Parser
 import Text.Trifecta
 import Control.Applicative
 import Control.Monad
+import Control.Monad.Fail (MonadFail)
 import Prelude
 import qualified Data.HashSet as HS
 import Text.Parser.Token.Highlight
 import Text.Parser.Token.Style
 
 newtype PactParser p a = PactParser { unPactParser :: p a }
-  deriving (Functor, Applicative, Alternative, Monad, MonadPlus, Parsing, CharParsing, DeltaParsing)
+  deriving (Functor, Applicative, Alternative, Monad, MonadPlus, MonadFail, Parsing, CharParsing, DeltaParsing)
 
 instance TokenParsing p => TokenParsing (PactParser p) where
   someSpace   = PactParser $ buildSomeSpaceParser someSpace $ CommentStyle "" "" ";" False

--- a/src/Pact/Types/Util.hs
+++ b/src/Pact/Types/Util.hs
@@ -55,6 +55,7 @@ import Data.Text (Text,pack,unpack)
 import Data.Text.Encoding
 import Control.Concurrent
 import Control.Lens hiding (Empty)
+import Control.Monad.Fail (MonadFail)
 
 
 
@@ -140,7 +141,7 @@ toB16JSON s = String $ toB16Text s
 toB16Text :: ByteString -> Text
 toB16Text s = decodeUtf8 $ B16.encode s
 
-failMaybe :: Monad m => String -> Maybe a -> m a
+failMaybe :: MonadFail m => String -> Maybe a -> m a
 failMaybe err m = maybe (fail err) return m
 
 maybeToEither :: String -> Maybe a -> Either String a


### PR DESCRIPTION
`Monad.fail` is deprecated and has been removed in most recent versions of `base`.