### PR TITLE
Managed caps only install once

### DIFF
--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -183,7 +183,7 @@ topLevelCall i name gasArgs action = call (StackFrame name i Nothing) $
 
 acquireModuleAdmin :: Info -> ModuleName -> Governance (Def Ref) -> Eval e CapAcquireResult
 acquireModuleAdmin i modName modGov =
-  acquireCapability noopApplyMgrFun (CapManaged Nothing) (ModuleAdminCapability modName) $ enforceModuleAdmin i modGov
+  acquireCapability i noopApplyMgrFun (CapManaged Nothing) (ModuleAdminCapability modName) $ enforceModuleAdmin i modGov
 
 enforceModuleAdmin :: Info -> Governance (Def Ref) -> Eval e ()
 enforceModuleAdmin i modGov =
@@ -265,7 +265,7 @@ eval (TModule (MDModule m) bod i) =
       -- governance however is not called on install
       _ -> return ()
     -- in any case, grant module admin to this transaction
-    void $ acquireCapability noopApplyMgrFun (CapManaged Nothing) (ModuleAdminCapability $ _mName m) $ return ()
+    void $ acquireCapability i noopApplyMgrFun (CapManaged Nothing) (ModuleAdminCapability $ _mName m) $ return ()
     -- build/install module from defs
     (g,govM) <- loadModule mangledM bod i g0
     writeRow i Write Modules (_mName mangledM) =<< traverse (traverse toPersistDirect') govM

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -568,8 +568,8 @@ setGasModel _ as = do
 -- | This is the only place we can do an external call to a capability,
 -- using 'evalCap False'.
 testCapability :: ZNativeFun ReplState
-testCapability _ [ c@TApp{} ] = do
-  cap <- evalCap CapCallStack False $ _tApp c
+testCapability i [ c@TApp{} ] = do
+  cap <- evalCap i CapCallStack False $ _tApp c
   return . tStr $ case cap of
     AlreadyAcquired -> "Capability already granted"
     NewlyAcquired -> "Capability granted"

--- a/src/Pact/Runtime/Capabilities.hs
+++ b/src/Pact/Runtime/Capabilities.hs
@@ -30,11 +30,9 @@ module Pact.Runtime.Capabilities
 
 import Control.Monad
 import Control.Lens hiding (DefName)
-import Data.Bool
 import Data.Default
 import Data.Foldable
 import Data.List
-import Data.Maybe
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 
@@ -51,19 +49,27 @@ type ApplyMgrFun e = Def Ref -> [PactValue] -> [PactValue] -> Eval e (Either Pac
 noopApplyMgrFun :: ApplyMgrFun e
 noopApplyMgrFun _ mgd _ = return $ Right mgd
 
-
+-- | Get any cap that is currently granted, of any scope.
 grantedCaps :: Eval e (S.Set Capability)
-grantedCaps = S.fromList . toList <$> use evalCapabilities
+grantedCaps = toSet <$> getAllStackCaps <*> getAllManaged
+  where
+    toSet a b = S.fromList $ a ++ b
+    getAllManaged = concatMap toList . S.toList <$> use (evalCapabilities . capManaged)
 
 -- | Matches Managed -> managed list, callstack and composed to stack list
 -- Composed should possibly check both ...
 capabilityGranted :: CapScope m -> Capability -> Eval e Bool
-capabilityGranted scope cap = memSet <$> scopeCaps
+capabilityGranted scope cap = elem cap <$> scopeCaps
   where
-    memSet = S.member cap . S.fromList . concatMap toList
+    scopeCaps :: Eval e [Capability]
     scopeCaps = case scope of
-      CapManaged _ -> use $ evalCapabilities . capManaged
-      _ -> use $ evalCapabilities . capStack
+      -- Managed: only check top-level, not composed
+      CapManaged _ -> map _csCap . S.toList <$> use (evalCapabilities . capManaged)
+      -- Other: check acquired, both top and composed.
+      _ -> getAllStackCaps
+
+getAllStackCaps :: Eval e [Capability]
+getAllStackCaps = concatMap toList <$> use (evalCapabilities . capStack)
 
 popCapStack :: (CapSlot Capability -> Eval e a) -> Eval e a
 popCapStack act = do
@@ -79,16 +85,31 @@ popCapStack act = do
 -- guard throwing a failure. Upon successful return of
 -- `test` install capability.
 acquireCapability
-  :: ApplyMgrFun e
+  :: HasInfo i
+  => i
+  -> ApplyMgrFun e
   -> CapScope (Maybe (Def Ref))
   -> Capability
   -> Eval e ()
   -> Eval e CapAcquireResult
-acquireCapability af scope cap test = granted >>= bool evalCap alreadyGranted
+acquireCapability i af scope cap test = go
   where
 
-    granted = capabilityGranted scope cap
     alreadyGranted = return AlreadyAcquired
+
+    go = do
+      granted <- capabilityGranted scope cap
+      if granted
+        then alreadyGranted
+        else do
+          seen <- seenCaps
+          if cap `S.member` seen
+            then evalError' i $ "Duplicate install of capability " <> pretty cap <> ", scope " <> pretty scope
+            else evalCap
+
+    seenCaps = case scope of
+      CapManaged _ -> use $ evalCapabilities . capManagedSeen
+      _ -> return mempty
 
     evalCap = do
       -- liftIO $ print ("acquireCapability",scope,cap)
@@ -102,7 +123,9 @@ acquireCapability af scope cap test = granted >>= bool evalCap alreadyGranted
     evalManaged =
       push >> test >> popCapStack installManaged
 
-    installManaged c = evalCapabilities . capManaged %= (c:)
+    installManaged cs = do
+      evalCapabilities . capManagedSeen %= S.insert (_csCap cs)
+      evalCapabilities . capManaged %= S.insert cs
 
     -- Callstack: check if managed, in which case push, otherwise
     -- push and test.
@@ -131,7 +154,7 @@ checkManaged applyF cap = use (evalCapabilities . capManaged) >>= go
     noMatch = return $ Nothing
 
     go mgdCaps = do
-      (success,failures,processedMgdCaps) <- foldM check (Nothing,[],[]) mgdCaps
+      (success,failures,processedMgdCaps) <- foldM check (Nothing,[],mempty) mgdCaps
       case success of
         Just newMgdCap -> do
           evalCapabilities . capManaged .= processedMgdCaps
@@ -143,14 +166,14 @@ checkManaged applyF cap = use (evalCapabilities . capManaged) >>= go
             (intercalate "," (map (renderCompactString' . peDoc) es))
 
     check (successR,failedRs,ms) m = case successR of
-      Just {} -> return (successR,[],m:ms) -- short circuit on success
+      Just {} -> return (successR,[],S.insert m ms) -- short circuit on success
       Nothing -> do
         r <- runManaged m
         case r of
-          Nothing -> return (Nothing,failedRs,m:ms) -- skip
-          Just (Left e) -> return (Nothing,e:failedRs,m:ms) -- record failure and continue
+          Nothing -> return (Nothing,failedRs,S.insert m ms) -- skip
+          Just (Left e) -> return (Nothing,e:failedRs,S.insert m ms) -- record failure and continue
           Just (Right newMgdCap) ->
-            return (Just newMgdCap,[],newMgdCap:ms)
+            return (Just newMgdCap,[],S.insert newMgdCap ms)
 
     runManaged mcs = case _csScope mcs of -- validate scope
       CapManaged (Just mf) -> case _csCap mcs of -- validate user mg cap and has mgr fun
@@ -171,29 +194,16 @@ checkManaged applyF cap = use (evalCapabilities . capManaged) >>= go
 revokeAllCapabilities :: Eval e ()
 revokeAllCapabilities = evalCapabilities .= def
 
--- | Check signature caps against current granted set, and track what caps
--- were matched in this transaction in order to only match once.
+-- | Check signature caps against current granted set.
 checkSigCaps
   :: M.Map PublicKey (S.Set Capability)
      -> Eval e (M.Map PublicKey (S.Set Capability))
 checkSigCaps sigs = go
   where
     go = do
-      alreadyMatched <- use (evalCapabilities . capSigMatched)
       granted <- grantedCaps
-      let (sigs',newMatched) = M.foldrWithKey (match granted) (mempty,alreadyMatched) sigs
-      evalCapabilities . capSigMatched .= newMatched
-      return sigs'
+      return $ M.filter (match granted) sigs
 
-    match granted pk sigCaps (r,matched) = do
-      if S.null sigCaps then
-        (M.insert pk sigCaps r,matched)
-      else
-        if S.null sigGranted then
-          (r,matched)
-        else
-          (M.insert pk sigGranted r,M.insertWith (S.union) pk sigGranted matched)
-      where
-        sigMatched = fromMaybe mempty $ M.lookup pk matched
-        sigUnmatched = sigCaps S.\\ sigMatched
-        sigGranted = S.intersection sigUnmatched granted
+    match granted sigCaps =
+      S.null sigCaps ||
+      not (S.null (S.intersection granted sigCaps))

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -173,7 +173,7 @@ data EvalState = EvalState {
       -- | Gas tally
     , _evalGas :: Gas
       -- | Capability list
-    , _evalCapabilities :: Capabilities Capability
+    , _evalCapabilities :: Capabilities
     } deriving (Show)
 makeLenses ''EvalState
 instance Default EvalState where def = EvalState def def def 0 def

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -307,5 +307,9 @@
  (pay "alice" "bob" 1))
 
 (expect-failure
- "reinstall of capability should fail (signature out of scope)"
+ "reinstall of capability should fail"
  (install-pay "alice" "bob" 10))
+
+(expect-failure
+ "reinstall of capability should fail"
+ (install-pay "alice" "carl" 1))


### PR DESCRIPTION
Simplifies and rationalizes capability behavior such that scoped caps can be re-installed and re-checked, but managed caps cannot. Gets rid of crufty signature-matched-capability tracking.