### PR TITLE
GHC 8.8 Support, Part 1: swagger2-2.4 and trifecta-2.1

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -31,10 +31,8 @@ in {
   servant = whenGhcjs dontCheck super.servant;
   servant-client = whenGhcjs dontCheck super.servant-client;
   servant-server = whenGhcjs dontCheck super.servant-server;
-  swagger2 = whenGhcjs dontCheck super.swagger2;
   tdigest = whenGhcjs dontCheck super.tdigest;
   temporary = whenGhcjs dontCheck super.temporary;
-  trifecta = whenGhcjs dontCheck super.trifecta;
   unix-time = whenGhcjs dontCheck super.unix-time;
   wai-app-static = whenGhcjs dontCheck super.wai-app-static;
   wai-extra = whenGhcjs dontCheck super.wai-extra;
@@ -51,6 +49,24 @@ in {
     sha256 = "1isa8p9dnahkljwj0kz10119dwiycf11jvzdc934lnjv1spxkc9k";
   });
 
+  swagger2 = dontCheck (callHackageDirect {
+    pkg = "swagger2";
+    ver = "2.4";
+    sha256 = "1kgajvqbx8627191akn6pz4kiyi24gawvnvkyb7955dy7bnpd9pn";
+  });
+
+  insert-ordered-containers = dontCheck (callHackageDirect {
+    pkg = "insert-ordered-containers";
+    ver = "0.2.2";
+    sha256 = "1md93iaxsr4djx1i47zjwddd7pd4j3hzphj7495q7lz7mn8ifz4w";
+  });
+
+  servant-swagger = dontCheck (callHackageDirect {
+    pkg = "servant-swagger";
+    ver = "1.1.7.1";
+    sha256 = "1ymdcmdi234p9jbwa7rgj1j35n9xnx4kgfjba4gs2r8cnhqwak28";
+  });
+
   # Our own custom fork
   thyme = dontCheck (self.callCabal2nix "thyme" (pkgs.fetchFromGitHub {
     owner = "kadena-io";
@@ -59,4 +75,9 @@ in {
     sha256 = "09fcf896bs6i71qhj5w6qbwllkv3gywnn5wfsdrcm0w1y6h8i88f";
   }) {});
 
+  trifecta = dontCheck (callHackageDirect {
+    pkg = "trifecta";
+    ver = "2.1";
+    sha256 = "0hbv8q12rgg4ni679fbx7ac3blzqxj06dw1fyr6ipc8kjpypb049";
+  });
 }

--- a/pact.cabal
+++ b/pact.cabal
@@ -148,10 +148,9 @@ library
 
   build-depends:       Decimal >= 0.4.2 && < 0.6
                      , aeson >= 0.11.3.0 && < 1.5
-                     , algebraic-graphs >= 0.2 && < 0.4
+                     , algebraic-graphs >= 0.2 && < 0.5
                      , prettyprinter >= 1.2 && < 1.3
                      , prettyprinter-ansi-terminal >= 1.1 && < 1.2
-                     , prettyprinter-convert-ansi-wl-pprint
                      , attoparsec >= 0.13.0.2 && < 0.14
                      , base >=4.9.0.0 && < 4.13
                      , base16-bytestring >=0.1.1.6 && < 0.2
@@ -186,19 +185,19 @@ library
                      -- kadena ghcjs compat fork
                      , thyme == 0.3.6.0
                      , transformers >= 0.5.2.0 && < 0.6
-                     , trifecta >= 2 && < 2.1
+                     , trifecta >= 2.1
                      , unordered-containers >= 0.2.7.2 && < 0.3
                      , utf8-string >= 1.0.1.1 && < 1.1
                      , vector >= 0.11.0.0 && < 0.13
                      , vector-algorithms >= 0.7
-                     , vector-space >= 0.10.4 && < 0.16
+                     , vector-space >= 0.10.4 && < 0.17
                      , mmorph >= 1.1 && < 1.2
                      , constraints
                      , servant
                      , servant-client
                      , servant-client-core
                      , servant-swagger
-                     , swagger2 >= 2.3
+                     , swagger2 >= 2.4
 
   if impl(ghcjs)
     build-depends:

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -635,7 +635,7 @@ _compileF :: FilePath -> IO (Either PactError [Term Name])
 _compileF f = _parseF f >>= _compile id
 
 handleParseError :: TF.Result a -> IO a
-handleParseError (TF.Failure f) = putDoc (fromAnsiWlPprint (TF._errDoc f)) >> error "parseFailed"
+handleParseError (TF.Failure f) = putDoc (TF._errDoc f) >> error "parseFailed"
 handleParseError (TF.Success a) = return a
 
 _compileWith :: Compile a -> (ParseState CompileState -> ParseState CompileState) ->
@@ -676,7 +676,7 @@ _compileFile :: FilePath -> IO [Term Name]
 _compileFile f = do
     p <- _parseF f
     rs <- case p of
-            (TF.Failure e) -> putDoc (fromAnsiWlPprint (TF._errDoc e)) >> error "Parse failed"
+            (TF.Failure e) -> putDoc (TF._errDoc e) >> error "Parse failed"
             (TF.Success (es,s)) -> return $ map (compile s) es
     case sequence rs of
       Left e -> throwIO $ userError (show e)

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -160,8 +160,8 @@ handleParse :: TF.Result [Exp Parsed] -> ([Exp Parsed] -> Repl (Either String a)
 handleParse (TF.Failure e) _ = do
   mode <- use rMode
   let errDoc = _errDoc e
-  outStrLn HErr $ renderPrettyString' (colors mode) $ unAnnotate $ fromAnsiWlPprint errDoc
-  return $ Left $ renderCompactString' $ unAnnotate $ fromAnsiWlPprint errDoc
+  outStrLn HErr $ renderPrettyString' (colors mode) $ unAnnotate errDoc
+  return $ Left $ renderCompactString' $ unAnnotate $ errDoc
 handleParse (TF.Success es) a = a es
 
 colors :: ReplMode -> RenderColor

--- a/src/Pact/Types/Pretty.hs
+++ b/src/Pact/Types/Pretty.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE FlexibleInstances #-}
 
 module Pact.Types.Pretty
   ( (<+>)
@@ -29,7 +29,6 @@ module Pact.Types.Pretty
   , encloseSep
   , equals
   , fillSep
-  , fromAnsiWlPprint
   , hardline
   , hsep
   , indent
@@ -64,7 +63,6 @@ import qualified Data.HashMap.Strict  as HM
 import           Data.Int
 import           Data.Text            (Text, pack, unpack)
 import qualified Data.Text            as Text
-import           Data.Text.Prettyprint.Convert.AnsiWlPprint (fromAnsiWlPprint)
 import           Data.Text.Prettyprint.Doc
   (SimpleDocStream, annotate, unAnnotate, layoutPretty,
   defaultLayoutOptions, vsep, hsep, (<+>), colon, angles, list, braces,
@@ -78,7 +76,7 @@ import           Data.Text.Prettyprint.Doc.Render.Terminal
   (color, Color(..), AnsiStyle)
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Term
 import           Data.Text.Prettyprint.Doc.Render.Text as RText
-import           Text.Trifecta.Delta
+import           Text.Trifecta.Delta hiding (prettyDelta)
 
 data RenderColor = RColor | RPlain
 

--- a/src/Pact/Types/Swagger.hs
+++ b/src/Pact/Types/Swagger.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
 -- Module      :  Pact.Types.Swagger
@@ -41,6 +42,7 @@ module Pact.Types.Swagger
   ) where
 
 import GHC.Exts (fromList)
+import Data.Proxy (Proxy(..))
 import Data.Swagger
 import Data.Swagger.Declare
 import Data.Swagger.Internal
@@ -56,7 +58,8 @@ import Pact.Types.Util
 declareGenericSchema ::
   forall a d f proxy. (Generic a, Rep a ~ D1 d f, Datatype d) =>
   Schema -> proxy a -> Declare (Definitions Schema) NamedSchema
-declareGenericSchema s proxy = pure $ genericNameSchema defaultSchemaOptions proxy s
+declareGenericSchema s _ = pure $
+  genericNameSchema defaultSchemaOptions (Proxy :: Proxy a) s
 
 -- | 'ToSchema' generic implementation with empty schema.
 declareGenericEmpty ::
@@ -71,6 +74,7 @@ declareGenericString = declareGenericSchema (schemaOf $ swaggerType SwaggerStrin
 
 -- | 'ToSchema' instance for unprefixing single-constructor field names.
 lensyDeclareNamedSchema ::
+  forall a proxy.
   (GenericHasSimpleShape a
     "genericDeclareNamedSchemaUnrestricted"
     (GenericShape (Rep a)),
@@ -78,8 +82,8 @@ lensyDeclareNamedSchema ::
   => Int
   -> proxy a
   -> Declare (Definitions Schema) NamedSchema
-lensyDeclareNamedSchema i proxy =
-  genericDeclareNamedSchema (fromAesonOptions $ lensyOptions i) proxy
+lensyDeclareNamedSchema i _ =
+  genericDeclareNamedSchema (fromAesonOptions $ lensyOptions i) (Proxy :: Proxy a)
 
 
 namedSchema :: Text -> Schema -> Declare (Definitions Schema) NamedSchema
@@ -88,7 +92,7 @@ namedSchema n s = return $ NamedSchema (Just n) s
 
 -- | like 'byteSchema' but with (non-standard) "base64url" in format.
 byteBase64url :: Schema
-byteBase64url = set type_ SwaggerString . set format (Just "base64url") $ mempty
+byteBase64url = set type_ (Just SwaggerString) . set format (Just "base64url") $ mempty
 
 fixedLength :: Integral i => i -> Schema -> Schema
 fixedLength i =
@@ -121,7 +125,7 @@ swaggerDescription d s = do
   return $ namedSchema' { _namedSchemaSchema = schema' }
 
 swaggerType :: SwaggerType 'SwaggerKindSchema -> Schema -> Schema
-swaggerType = set type_
+swaggerType = set type_ . Just
 
 schemaOf :: (Schema -> Schema) -> Schema
 schemaOf f = f mempty
@@ -130,5 +134,5 @@ withSchema :: Schema -> (Schema -> Schema) -> Schema
 withSchema s f = f s
 
 -- debugSchema
-debugSchema :: ToSchema a => proxy a -> NamedSchema
-debugSchema = undeclare . declareNamedSchema
+debugSchema :: forall a proxy. ToSchema a => proxy a -> NamedSchema
+debugSchema _ = undeclare $ declareNamedSchema (Proxy :: Proxy a)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,17 @@
 # stack yaml for ghc builds
 
-resolver: lts-13.30
+resolver: lts-14.7
 
 extra-deps:
   # --- Missing from Stackage --- #
   - ed25519-donna-0.1.1
-  - prettyprinter-convert-ansi-wl-pprint-1.1
+
+  # --- Forced Downgrades --- #
+  - hedgehog-0.6.1
+  - sbv-8.2
 
   # --- Forced Upgrades --- #
-  - sbv-8.2
+  - trifecta-2.1
 
   # --- Custom Pins --- #
   - git: https://github.com/kadena-io/thyme.git

--- a/tests/ClientSpec.hs
+++ b/tests/ClientSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedLists   #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes       #-}
@@ -21,6 +22,9 @@ import Servant.Client
 import Pact.Types.Runtime
 import Pact.Types.PactValue
 
+#if ! MIN_VERSION_servant_client(0,16,0)
+type ClientError = ServantError
+#endif
 
 _testLogDir, _testConfigFilePath, _testPort, _serverPath :: String
 _testLogDir = testDir ++ "test-log/"
@@ -103,7 +107,7 @@ spec = describe "Servant API client tests" $ do
         ListenResponse lr -> (Right $ _crResult lr) `shouldSatisfy` (failWith ArgsError)
 
 
-failWith :: PactErrorType -> Either ServantError PactResult -> Bool
+failWith :: PactErrorType -> Either ClientError PactResult -> Bool
 failWith errType res = case res of
   Left _ -> False
   Right res' -> case res' of

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -38,7 +39,9 @@ import Pact.Types.Runtime (PactError(..))
 import Pact.Types.Util (toB16JSON)
 import Pact.Types.SPV
 
-
+#if ! MIN_VERSION_servant_client(0,16,0)
+type ClientError = ServantError
+#endif
 
 ---- TESTS -----
 
@@ -930,12 +933,12 @@ run mgr cmds = do
 
 
 
-doSend :: Manager -> SubmitBatch -> IO (Either ServantError RequestKeys)
+doSend :: Manager -> SubmitBatch -> IO (Either ClientError RequestKeys)
 doSend mgr req = do
   baseUrl <- serverBaseUrl
   runClientM (sendClient req) (mkClientEnv mgr baseUrl)
 
-doPoll :: Manager -> Poll -> IO (Either ServantError PollResponses)
+doPoll :: Manager -> Poll -> IO (Either ClientError PollResponses)
 doPoll mgr req = do
   baseUrl <- serverBaseUrl
   runClientM (pollClient req) (mkClientEnv mgr baseUrl)

--- a/tests/RemoteVerifySpec.hs
+++ b/tests/RemoteVerifySpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -31,6 +32,10 @@ import Pact.Repl.Types
 import Pact.Server.API
 import Pact.Types.Runtime
 
+#if ! MIN_VERSION_servant_client(0,16,0)
+type ClientError = ServantError
+#endif
+
 spec :: Spec
 spec = do
   describe "single module"                       testSingleModule
@@ -54,7 +59,7 @@ stateModuleData nm replState = replLookupModule replState nm
 serve :: Int -> IO ThreadId
 serve port = forkIO $ runServantServer port
 
-serveAndRequest :: Int -> Remote.Request -> IO (Either ServantError (Remote.Response))
+serveAndRequest :: Int -> Remote.Request -> IO (Either ClientError Remote.Response)
 serveAndRequest port body = do
   let url = "http://localhost:" ++ show port
   verifyBaseUrl <- parseBaseUrl url


### PR DESCRIPTION
This raises the lower bounds for `swagger2` and `trifecta`. After this PR is merged, #636 should follow, so that further bounds massaging isn't held back by the old `hedgehog` version. Then, in a third PR, final bounds massaging will occur, upon which Chainweb can be tested.

Thanks to @larskuhtz for most of this work. 