### PR TITLE
GHC 8.8 Support, Part 2: Remove sbv down-pin

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -45,8 +45,8 @@ in {
 
   sbv = dontCheck (callHackageDirect {
     pkg = "sbv";
-    ver = "8.2";
-    sha256 = "1isa8p9dnahkljwj0kz10119dwiycf11jvzdc934lnjv1spxkc9k";
+    ver = "8.3";
+    sha256 = "0r6f615129aih0j329c07dbkf11m9k8mnajs95jkvj0xf6vgh57h";
   });
 
   swagger2 = dontCheck (callHackageDirect {

--- a/pact.cabal
+++ b/pact.cabal
@@ -216,7 +216,7 @@ library
                 , memory
                 , neat-interpolation >= 0.3.2.4
                 , safe-exceptions >= 0.1.5.0 && < 0.2
-                , sbv >= 7.11
+                , sbv >= 7.11 && < 8.4
                 , servant-server
                 , statistics >= 0.13.3 && < 0.16
                 , wai-cors

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,6 @@ extra-deps:
 
   # --- Forced Downgrades --- #
   - hedgehog-0.6.1
-  - sbv-8.2
 
   # --- Forced Upgrades --- #
   - trifecta-2.1


### PR DESCRIPTION
`lts-14` provides `sbv-8.3` already, and we can safely up-pin in Nix to `8.3` since everything builds. We indicate a hard upper-bound on `8.4`, since that introduces a number of breaking changes.