### PR TITLE
Fix column-read for with-read

### DIFF
--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -3072,6 +3072,21 @@ spec = describe "analyze" $ do
 
     expectVerified code
 
+  describe "column-read" $ do
+    expectVerified $
+      [text|
+        (defschema sch a:integer b:integer)
+        (deftable tab:{sch})
+
+        (defun test:integer ()
+          @model [
+            (property (column-read tab 'a))
+            (property (not (column-read tab 'b)))
+          ]
+          (with-read tab "key" { "a" := a }
+            a))
+      |]
+
   describe "column quantification" $ do
     let code =
           [text|


### PR DESCRIPTION
This fixes analysis for the `column-read` property in the face of `with-read`. Now we no longer mark all columns of the table has having been read when we read only a subset of them.