### PR TITLE
Move to SBV 8.4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ cache:
 before_test:
   - "curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64"
   - "7z x stack.zip stack.exe"
-  - "curl -sS -oz3.zip -L --insecure https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-win.zip"
+  - "curl -sS -oz3.zip -L --insecure https://github.com/Z3Prover/z3/releases/download/z3-4.8.6/z3-4.8.6-x64-win.zip"
   - "7z x z3.zip -oc:\\z3 -r"
-  - "set PATH=C:\\z3\\z3-4.8.5-x64-win\\bin;%PATH%"
+  - "set PATH=C:\\z3\\z3-4.8.6-x64-win\\bin;%PATH%"
 
 environment:
   global:

--- a/default.nix
+++ b/default.nix
@@ -9,14 +9,14 @@ let rpSrc = builtins.fetchTarball {
 };
 overlay = self: super: {
   z3 = super.z3.overrideAttrs (drv: {
-    name = "z3-4.8.6";
-    version = "4.8.6";
+    name = "z3-4.8.7-head";
+    version = "4.8.7-head";
     patches = [];
     src = self.fetchFromGitHub {
       owner = "Z3Prover";
       repo = "z3";
-      rev = "78ed71b8de7d4d089f2799bf2d06f411ac6b9062";
-      sha256 = "1sywcqj5y8yp28m4cdvzsgw74kd6zr1s3y1x17ky8pr9prvpvl6x";
+      rev = "4ce6b53d95821a2cfcb46a579bc2561b2101689f";
+      sha256 = "1dnkfdyvwznbgwf2b637svg0fxg66dpn90bqvfypnys5y46cqq84";
     };
   });
 };

--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ overlay = self: super: {
       owner = "Z3Prover";
       repo = "z3";
       rev = "78ed71b8de7d4d089f2799bf2d06f411ac6b9062";
-      sha256 = "11ay98clv7ln0a5vqxzvh6wwqbswsjbik2084hav5kfws4xvklfa";
+      sha256 = "1sywcqj5y8yp28m4cdvzsgw74kd6zr1s3y1x17ky8pr9prvpvl6x";
     };
   });
 };

--- a/default.nix
+++ b/default.nix
@@ -9,14 +9,14 @@ let rpSrc = builtins.fetchTarball {
 };
 overlay = self: super: {
   z3 = super.z3.overrideAttrs (drv: {
-    name = "z3-4.8.5";
-    version = "4.8.5";
+    name = "z3-4.8.6";
+    version = "4.8.6";
     patches = [];
     src = self.fetchFromGitHub {
       owner = "Z3Prover";
       repo = "z3";
-      rev = "e79542cc689d52ec4cb34ce4ae3fbe56e7a0bf70";
-      sha256 = "11sy98clv7ln0a5vqxzvh6wwqbswsjbik2084hav5kfws4xvklfa";
+      rev = "78ed71b8de7d4d089f2799bf2d06f411ac6b9062";
+      sha256 = "11ay98clv7ln0a5vqxzvh6wwqbswsjbik2084hav5kfws4xvklfa";
     };
   });
 };

--- a/overrides.nix
+++ b/overrides.nix
@@ -63,8 +63,8 @@ in {
 
   sbv = dontCheck (callHackageDirect {
     pkg = "sbv";
-    ver = "8.2";
-    sha256 = "1isa8p9dnahkljwj0kz10119dwiycf11jvzdc934lnjv1spxkc9k";
+    ver = "8.4";
+    sha256 = "0gg0m7dg9qkcnw4rkyjpgv0glwijjdcm3d345x5wrs5nvicyc7ml";
   });
 
   swagger2 = dontCheck (callHackageDirect {

--- a/pact.cabal
+++ b/pact.cabal
@@ -221,7 +221,7 @@ library
                 , memory
                 , neat-interpolation >= 0.3.2.4
                 , safe-exceptions >= 0.1.5.0 && < 0.2
-                , sbv >= 7.11 && < 8.3
+                , sbv >= 7.11 && < 8.5
                 , servant-server
                 , statistics >= 0.13.3 && < 0.16
                 , wai-cors

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,9 +6,6 @@ extra-deps:
   # --- Missing from Stackage --- #
   - ed25519-donna-0.1.1
 
-  # --- Forced Downgrades --- #
-  - sbv-8.2
-
   # --- Forced Upgrades --- #
   - trifecta-2.1
 

--- a/static.nix
+++ b/static.nix
@@ -68,8 +68,8 @@ in (rp.ghcMusl64.override {
 
           sbv = dontHaddock (dontCheck (callHackageDirect {
             pkg = "sbv";
-            ver = "8.2";
-            sha256 = "1isa8p9dnahkljwj0kz10119dwiycf11jvzdc934lnjv1spxkc9k";
+            ver = "8.4";
+            sha256 = "0gg0m7dg9qkcnw4rkyjpgv0glwijjdcm3d345x5wrs5nvicyc7ml";
           }));
 
   #        # Our own custom fork


### PR DESCRIPTION
/cc @fosskers @emilypi @larskuhtz

This ~almost~ fixes #670, ~but we're not ready to merge yet~.

I upgraded to Z3 4.8.6 which includes support for the option `model.inline_def` that SBV 8.4 needs (introduced here: https://github.com/Z3Prover/z3/commit/a8bfab32735449e8553cd39a14ee2db57b82aeca). Once I did this, I ran into a different issue that is related to a new-ish function from the sequence theory (`seq.nth`) that SBV is now using: https://github.com/Z3Prover/z3/issues/2640.

Once there is a fix for this in Z3, we can move to SBV 8.4.