### PR TITLE
Use ByteString readFile and explicit UTF8 decoding

### DIFF
--- a/src-ghc/Pact/ApiReq.hs
+++ b/src-ghc/Pact/ApiReq.hs
@@ -184,9 +184,7 @@ mkApiReqExec ar@ApiReq{..} fp = do
   (code,cdata) <- withCurrentDirectory (takeDirectory fp) $ do
     code <- case (_ylCodeFile,_ylCode) of
       (Nothing,Just c) -> return c
-      (Just f,Nothing) -> liftIO (BSL.readFile f) >>=
-                          either (\e -> dieAR $ "Data file load failed: " ++ show e) return .
-                          eitherDecode
+      (Just f,Nothing) -> liftIO (readFile f)
       _ -> dieAR "Expected either a 'code' or 'codeFile' entry"
     cdata <- case (_ylDataFile,_ylData) of
       (Nothing,Just v) -> return v -- either (\e -> dieAR $ "Data decode failed: " ++ show e) return $ eitherDecode (BSL.pack v)

--- a/src-ghc/Pact/ApiReq.hs
+++ b/src-ghc/Pact/ApiReq.hs
@@ -184,7 +184,9 @@ mkApiReqExec ar@ApiReq{..} fp = do
   (code,cdata) <- withCurrentDirectory (takeDirectory fp) $ do
     code <- case (_ylCodeFile,_ylCode) of
       (Nothing,Just c) -> return c
-      (Just f,Nothing) -> liftIO (readFile f)
+      (Just f,Nothing) -> liftIO (BSL.readFile f) >>=
+                          either (\e -> dieAR $ "Data file load failed: " ++ show e) return .
+                          eitherDecode
       _ -> dieAR "Expected either a 'code' or 'codeFile' entry"
     cdata <- case (_ylDataFile,_ylData) of
       (Nothing,Just v) -> return v -- either (\e -> dieAR $ "Data decode failed: " ++ show e) return $ eitherDecode (BSL.pack v)

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -15,6 +15,7 @@ import Criterion.Main
 
 import Data.Aeson
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
 import Data.ByteString.Lazy (toStrict)
 import Data.Default
 import qualified Data.HashMap.Strict as HM
@@ -86,7 +87,7 @@ entity = Just $ EntityName "entity"
 
 loadBenchModule :: PactDbEnv e -> IO (ModuleData Ref,PersistModuleData)
 loadBenchModule db = do
-  m <- pack <$> readFile "tests/bench/bench.pact"
+  m <- decodeUtf8 <$> BS.readFile "tests/bench/bench.pact"
   pc <- parseCode m
   let md = MsgData
            (object

--- a/src-ghc/Pact/Main.hs
+++ b/src-ghc/Pact/Main.hs
@@ -33,9 +33,11 @@ import Control.Applicative
 import Control.Lens
 import Control.Monad.State.Strict
 
+import qualified Data.ByteString as BS
 import Data.List
 import qualified Data.HashMap.Strict as HM
 import Data.Text (unpack)
+import Data.Text.Encoding (decodeUtf8)
 
 import Text.Trifecta as TF hiding (err)
 
@@ -161,7 +163,8 @@ locatePactReplScript fp = do
 compileOnly :: String -> IO (Either String [Term Name])
 compileOnly fp = do
   !pr <- TF.parseFromFileEx exprsOnly fp
-  src <- readFile fp
+  srcBS <- BS.readFile fp
+  let src = unpack $ decodeUtf8 srcBS
   s <- initReplState (Script False fp) Nothing
   (`evalStateT` s) $ handleParse pr $ \es -> (sequence <$> forM es (\e -> handleCompile src e (return . Right)))
 

--- a/src/Pact/Parse.hs
+++ b/src/Pact/Parse.hs
@@ -39,11 +39,13 @@ import Control.Monad
 import Control.Monad.Fail (MonadFail)
 import qualified Data.Aeson as A
 import qualified Data.Attoparsec.Text as AP
+import qualified Data.ByteString as BS
 import Data.Char (digitToInt)
 import Data.Decimal
 import Data.List
 import Data.Serialize (Serialize)
-import Data.Text (Text)
+import Data.Text (Text, unpack)
+import Data.Text.Encoding
 import GHC.Generics (Generic)
 import Prelude
 import Text.Trifecta as TF
@@ -193,7 +195,10 @@ parsePact code = ParsedCode code <$> parseExprs code
 
 
 _parseF :: TF.Parser a -> FilePath -> IO (TF.Result (a,String))
-_parseF p fp = readFile fp >>= \s -> fmap (,s) <$> TF.parseFromFileEx p fp
+_parseF p fp = do
+  bs <- BS.readFile fp
+  let s = unpack $ decodeUtf8 bs
+  fmap (,s) <$> TF.parseFromFileEx p fp
 
 
 _parseS :: String -> TF.Result [Exp Parsed]

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -66,7 +66,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as M
 import Data.Monoid (appEndo)
 import Data.Text (Text, pack, unpack)
-import Data.Text.Encoding (encodeUtf8)
+import Data.Text.Encoding (encodeUtf8, decodeUtf8)
 
 import Text.Trifecta as TF hiding (line,err,try,newline)
 import Text.Trifecta.Delta
@@ -311,7 +311,8 @@ loadFile f = do
   rFile .= Just computedPath
   catch (do
           pr <- TF.parseFromFileEx exprsOnly computedPath
-          src <- liftIO $ readFile computedPath
+          srcBS <- liftIO $ BS.readFile computedPath
+          let src = unpack $ decodeUtf8 srcBS
           when (isPactFile f) $ rEvalState.evalRefs.rsLoaded .= HM.empty
           r <- parsedCompileEval src pr
           when (isPactFile f) $ void useReplLib


### PR DESCRIPTION
The String implementation of readFile tries to guess the system encoding
and therefore can fail on the same input unpredictably.  This commit
switches all uses of readFile to use the ByteString version.