### PR TITLE
Execution config

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -134,7 +134,7 @@ true
 
 Create a namespace called NAMESPACE where ownership and use of the namespace is controlled by GUARD. If NAMESPACE is already defined, then the guard previously defined in NAMESPACE will be enforced, and GUARD will be rotated in its place.
 ```lisp
-(define-namespace 'my-namespace (read-keyset 'user-ks)) (read-keyset 'admin-ks)
+(define-namespace 'my-namespace (read-keyset 'user-ks) (read-keyset 'admin-ks))
 ```
 
 Top level only: this function will fail if used in module code.
@@ -1647,7 +1647,11 @@ Set environment confidential ENTITY id, or unset with no argument.
  *&rarr;*&nbsp;`object:*`
 
 
-Set or query execution config flags: ALLOW-MODULE-INSTALL allows module and interface installs; ALLOW-HISTORY-IN-TX allows history calls (tx-log, etc) in non-local execution
+Queries, or with arguments, sets execution config flags. ALLOW-MODULE-INSTALL allows module and interface installs; ALLOW-HISTORY-IN-TX allows history calls (tx-log, etc) in non-local execution
+```lisp
+pact> (env-exec-config true false) (env-exec-config)
+{"allow-history-in-tx": false,"allow-module-install": true}
+```
 
 
 ### env-gas {#env-gas}
@@ -1657,7 +1661,11 @@ Set or query execution config flags: ALLOW-MODULE-INSTALL allows module and inte
 *gas*&nbsp;`integer` *&rarr;*&nbsp;`string`
 
 
-Query gas state, or set it to GAS.
+Query gas state, or set it to GAS. Note that certain plaforms may charge additional gas that is not captured by the interpreter gas model, such as an overall transaction-size cost.
+```lisp
+pact> (env-gasmodel "table") (env-gaslimit 10) (env-gas 0) (map (+ 1) [1 2 3]) (env-gas)
+7
+```
 
 
 ### env-gaslimit {#env-gaslimit}
@@ -1673,7 +1681,11 @@ Set environment gas limit to LIMIT.
  *&rarr;*&nbsp;`string`
 
 
-Enable and obtain gas logging
+Enable and obtain gas logging. Bracket around the code whose gas logs you want to inspect.
+```lisp
+pact> (env-gasmodel "table") (env-gaslimit 10) (env-gaslog) (map (+ 1) [1 2 3]) (env-gaslog)
+["TOTAL: 7" "map:GUnreduced: 4" "+:GUnreduced: 1" "+:GUnreduced: 1" "+:GUnreduced: 1"]
+```
 
 
 ### env-gasmodel {#env-gasmodel}

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1640,6 +1640,16 @@ Set environment confidential ENTITY id, or unset with no argument.
 ```
 
 
+### env-exec-config {#env-exec-config}
+
+*allow-module-install*&nbsp;`bool` *allow-history-in-tx*&nbsp;`bool` *&rarr;*&nbsp;`object:*`
+
+ *&rarr;*&nbsp;`object:*`
+
+
+Set or query execution config flags: ALLOW-MODULE-INSTALL allows module and interface installs; ALLOW-HISTORY-IN-TX allows history calls (tx-log, etc) in non-local execution
+
+
 ### env-gas {#env-gas}
 
  *&rarr;*&nbsp;`integer`
@@ -1656,6 +1666,14 @@ Query gas state, or set it to GAS.
 
 
 Set environment gas limit to LIMIT.
+
+
+### env-gaslog {#env-gaslog}
+
+ *&rarr;*&nbsp;`string`
+
+
+Enable and obtain gas logging
 
 
 ### env-gasmodel {#env-gasmodel}

--- a/src-ghc/Pact/GasModel/Types.hs
+++ b/src-ghc/Pact/GasModel/Types.hs
@@ -11,20 +11,20 @@ module Pact.GasModel.Types
   , GasTestResult(..)
 
   , getDescription
-  
+
   , GasUnitTests(..)
   , concatGasUnitTests
   , mapOverGasUnitTests
 
   , NoopNFData(..)
-  
+
   , defGasUnitTests
   , createGasUnitTests
 
   , setState
   , setEnv
-  
-  
+
+
   ) where
 
 import Control.Concurrent (readMVar)
@@ -182,7 +182,7 @@ defMockGasSetup =
   mockSetupCleanup
 
 
--- | Helper functions for manipulating Gas Tests 
+-- | Helper functions for manipulating Gas Tests
 setState :: (EvalState -> EvalState) -> GasSetup e -> GasSetup e
 setState f setup = setState'
   where
@@ -227,7 +227,7 @@ getLoadedState code = do
 defEvalEnv :: PactDbEnv e -> EvalEnv e
 defEvalEnv db =
   setupEvalEnv db entity Transactional (initMsgData pactInitialHash)
-  initRefStore freeGasEnv permissiveNamespacePolicy noSPVSupport def
+  initRefStore freeGasEnv permissiveNamespacePolicy noSPVSupport def def
   where entity = Just $ EntityName "entity"
 
 -- MockDb
@@ -241,7 +241,7 @@ defMockDb :: MockDb
 defMockDb = mockdb
   where
     mockdb = def { mockRead = MockRead rowRead }
-    
+
     rowRead :: Domain k v -> k -> Method () (Maybe v)
     rowRead UserTables {} _ = rc (Just acctRow)
     rowRead KeySets (KeySetName ks)

--- a/src-ghc/Pact/Interpreter.hs
+++ b/src-ghc/Pact/Interpreter.hs
@@ -95,7 +95,7 @@ type EvalInput = Either (Maybe PactExec) [Term Name]
 type EvalOutput = ([Term Name],[TxLog Value],Maybe TxId)
 
 -- | Interpreter indirection for executing user action.
-data Interpreter e = Interpreter
+newtype Interpreter e = Interpreter
   { interpreter :: Eval e [Term Name] -> Eval e [Term Name] }
 
 -- | Default interpreter performs no indirection.

--- a/src-ghc/Pact/Interpreter.hs
+++ b/src-ghc/Pact/Interpreter.hs
@@ -157,8 +157,9 @@ setupEvalEnv
   -> NamespacePolicy
   -> SPVSupport
   -> PublicData
+  -> ExecutionConfig
   -> EvalEnv e
-setupEvalEnv dbEnv ent mode msgData refStore gasEnv np spv pd =
+setupEvalEnv dbEnv ent mode msgData refStore gasEnv np spv pd ec =
   EvalEnv {
     _eeRefStore = refStore
   , _eeMsgSigs = mkMsgSigs $ mdSigners msgData
@@ -174,6 +175,7 @@ setupEvalEnv dbEnv ent mode msgData refStore gasEnv np spv pd =
   , _eeNamespacePolicy = np
   , _eeSPVSupport = spv
   , _eePublicData = pd
+  , _eeExecutionConfig = ec
   }
   where
     mkMsgSigs ss = M.fromList $ map toPair ss

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -111,7 +111,8 @@ initPureEvalEnv :: Maybe String -> IO (EvalEnv LibState)
 initPureEvalEnv verifyUri = do
   mv <- initLibState neverLog verifyUri >>= newMVar
   return $ EvalEnv (RefStore nativeDefs) mempty Null Transactional
-    def def mv repldb def pactInitialHash freeGasEnv permissiveNamespacePolicy (spvs mv) def
+    def def mv repldb def pactInitialHash freeGasEnv
+    permissiveNamespacePolicy (spvs mv) def def
   where
     spvs mv = set spvSupport (spv mv) noSPVSupport
 

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -171,8 +171,9 @@ replDefs = ("Repl",
        []
        "Set environment gas limit to LIMIT."
      ,defZRNative "env-gas" envGas (funType tTyInteger [] <> funType tTyString [("gas",tTyInteger)])
-       []
-       "Query gas state, or set it to GAS."
+       ["(env-gasmodel \"table\") (env-gaslimit 10) (env-gas 0) (map (+ 1) [1 2 3]) (env-gas)"]
+       ("Query gas state, or set it to GAS. Note that certain plaforms may charge additional gas that is not captured " <>
+        "by the interpreter gas model, such as an overall transaction-size cost.")
      ,defZRNative "env-gasprice" setGasPrice (funType tTyString [("price",tTyDecimal)])
        []
        "Set environment gas price to PRICE."
@@ -183,13 +184,13 @@ replDefs = ("Repl",
        []
        "Update gas model to the model named MODEL."
      ,defZRNative "env-gaslog" gasLog (funType tTyString [])
-       []
-       "Enable and obtain gas logging"
+       ["(env-gasmodel \"table\") (env-gaslimit 10) (env-gaslog) (map (+ 1) [1 2 3]) (env-gaslog)"]
+       "Enable and obtain gas logging. Bracket around the code whose gas logs you want to inspect."
      ,defZRNative "env-exec-config" envExecConfig
       (funType (tTyObject TyAny) [("allow-module-install",tTyBool),("allow-history-in-tx",tTyBool)] <>
        funType (tTyObject TyAny) [])
-      []
-      ("Set or query execution config flags: ALLOW-MODULE-INSTALL allows module and interface " <>
+      ["(env-exec-config true false) (env-exec-config)"]
+      ("Queries, or with arguments, sets execution config flags. ALLOW-MODULE-INSTALL allows module and interface " <>
       "installs; ALLOW-HISTORY-IN-TX allows history calls (tx-log, etc) in non-local execution")
      ,defZRNative "verify" verify (funType tTyString [("module",tTyString)])
        []

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -32,6 +32,7 @@ module Pact.Types.Runtime
    KeyPredBuiltins(..),keyPredBuiltins,
    NamespacePolicy(..),
    permissiveNamespacePolicy,
+   ExecutionConfig(..),ecAllowModuleInstall,ecAllowHistoryInTx,
    module Pact.Types.Lang,
    module Pact.Types.Util,
    module Pact.Types.Persistence,
@@ -122,11 +123,12 @@ class PureSysOnly e => PureReadOnly e
 
 -- | Execution-wide configuration parameters.
 data ExecutionConfig = ExecutionConfig
-  { ecAllowModuleInstall :: Bool
+  { _ecAllowModuleInstall :: Bool
   -- ^ Permit 'module' and 'interface' actions.
-  , ecAllowHistoryInTx :: Bool
+  , _ecAllowHistoryInTx :: Bool
   -- ^ Allow database history actions in non-local execution.
   } deriving (Eq,Show)
+makeLenses ''ExecutionConfig
 
 instance Default ExecutionConfig where def = ExecutionConfig True True
 

--- a/tests/PactTestsSpec.hs
+++ b/tests/PactTestsSpec.hs
@@ -98,6 +98,8 @@ badErrors = M.fromList
     "Definitions in default namespace are not authorized")
   ,(pfx "bad-dupe-def.repl"
    ,"definition name conflict")
+  ,(pfx "bad-modules-disabled.repl"
+   ,"Module/interface install not supported")
   ]
   where
     pfx = ("tests/pact/bad/" ++)

--- a/tests/pact/bad/bad-modules-disabled.repl
+++ b/tests/pact/bad/bad-modules-disabled.repl
@@ -1,0 +1,4 @@
+(env-exec-config false true)
+(module M G
+  (defcap G () true)
+  (defun foo () true))

--- a/tests/pact/db.repl
+++ b/tests/pact/db.repl
@@ -46,6 +46,21 @@
 
 (expect "keylog works" [{"txid": 1, "value": ROW_A}] (keylog persons ID_A 1))
 
+(env-exec-config true false)
+(expect-failure
+ "txids disabled"
+ "Operation only permitted in local execution mode"
+ (txids persons 0))
+(expect-failure
+ "txlog disabled"
+ "Operation only permitted in local execution mode"
+ (txlog persons 1))
+(expect-failure
+ "keylog disabled"
+ "Operation only permitted in local execution mode"
+ (keylog persons ID_A 1))
+
+
 (insert stuff "k" { "stuff": { "dec": 1.2, "bool": true, "int": -3, "time": (parse-time "%F" "1970-01-01") } })
 (expect "object stored as object" "object:*" (typeof (at "stuff" (read stuff "k"))))
 


### PR DESCRIPTION
- `ExecutionConfig` introduces flags for enabling module/interface install, history queries in non-local
- `Interpreter` simplified to just bracketed operation
- `Signers` moved back to `MsgData`