### PR TITLE
Fix cabal warning

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -279,7 +279,6 @@ benchmark bench
   default-language:    Haskell2010
 
 executable gasmodel
-  type:                exitcode-stdio-1.0
   main-is:             GasModel.hs
   build-depends:       base
                      , pact


### PR DESCRIPTION
`type: ` is available on `benchmark` and `test-suite`, but not `executable`

```
$ cabal new-build 
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - pact-3.3.1 (exe:gasmodel) (first run)
 - pact-3.3.1 (test:hspec) (first run)
 - pact-3.3.1 (exe:pact) (first run)
Warning: pact.cabal:282:3: Unknown field: "type"
Configuring executable 'gasmodel' for pact-3.3.1..
Warning: pact.cabal:282:3: Unknown field: "type"
Configuring test suite 'hspec' for pact-3.3.1..
Warning: pact.cabal:282:3: Unknown field: "type"
Configuring executable 'pact' for pact-3.3.1..
```