### PR TITLE
Decode StackFrame JSON output

### DIFF
--- a/src/Pact/Types/Info.hs
+++ b/src/Pact/Types/Info.hs
@@ -127,7 +127,9 @@ parseRenderedInfo = peekChar >>= \c -> case c of
     cn <- round <$> scientific
     let delt = case fOrI of
           "<interactive>"
+            -- heuristic: ln == 0 means Columns ...
             | ln == 0 -> Columns cn 0
+            -- otherwise Lines, which reverses the 'succ' above
             | otherwise -> Lines (pred ln) cn 0 0
           f -> Directed (encodeUtf8 f) (pred ln) cn 0 0
     return (Info (Just ("",(Parsed delt 0))))

--- a/src/Pact/Types/PactError.hs
+++ b/src/Pact/Types/PactError.hs
@@ -23,12 +23,14 @@ module Pact.Types.PactError
   ) where
 
 
-
+import Control.Applicative
 import Control.Lens hiding ((.=),DefName)
+import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson hiding (Object)
+import Data.Attoparsec.Text as AP
 import Data.Default
-import Data.Text (Text, unpack)
+import Data.Text as T (Text, unpack, pack, init)
 import Control.DeepSeq (NFData)
 
 import GHC.Generics
@@ -45,11 +47,42 @@ data StackFrame = StackFrame {
 instance NFData StackFrame
 instance ToJSON StackFrame where toJSON = toJSON . show
 
+-- | BIG HUGE CAVEAT: Back compat requires maintaining the pre-existing
+-- 'ToJSON' instance, so this is ONLY for UX coming out of serialized
+-- endpoints like `poll` in Chainweb; "Info" and "FunApp" values will
+-- be sketchy. As such this is also permissive on failure.
+instance FromJSON StackFrame where
+  parseJSON = withText "StackFrame" $ \t -> case parseOnly parseStackFrame t of
+    Right sf -> pure sf
+    Left e -> pure $ StackFrame ("StackFrame parse failed: " <> pack e) def Nothing
+
+
 instance Show StackFrame where
     show (StackFrame n i app) = renderInfo i ++ ": " ++ case app of
       Nothing -> unpack n
       Just (_,as) -> "(" ++ unpack n ++ concatMap (\a -> " " ++ unpack (asString a)) as ++ ")"
+
+-- | Attempt to parse 'Show' instance output. Intentionally avoids parsing app args,
+-- cramming all of the text into '_sfName'.
+parseStackFrame :: AP.Parser StackFrame
+parseStackFrame = do
+  i <- parseRenderedInfo
+  void $ string ": "
+  parseDeets i <|> justName i
+  where
+    parseDeets i = do
+      void $ char '('
+      deets <- T.init <$> takeText
+      return $ StackFrame deets i $
+        Just (FunApp def "" Nothing Defun (funTypes $ FunType [] TyAny) Nothing
+             ,[])
+    justName i = takeText >>= \n -> return $ StackFrame n i Nothing
+
+_parseStackFrame :: Text -> Either String StackFrame
+_parseStackFrame = parseOnly parseStackFrame
+
 makeLenses ''StackFrame
+
 
 data PactErrorType
   = EvalError
@@ -75,11 +108,24 @@ instance Exception PactError
 instance ToJSON PactError where
   toJSON (PactError t i s d) =
     object [ "type" .= t, "info" .= renderInfo i, "callStack" .= s, "message" .= (show d)]
+-- CAVEAT: this is "UX only" due to issues with Info, StackFrame, and that
+-- historically these were ignored here. As such this is a "lenient" parser returning
+-- the old values on failure.
 instance FromJSON PactError where
   parseJSON = withObject "PactError" $ \o -> do
     typ <- o .: "type"
     doc <- o .: "message"
-    pure $ PactError typ def def (prettyString doc)
+    inf <- parseInf <$> o .: "info"
+    sf <- parseSFs <$> o .: "callStack"
+    pure $ PactError typ inf sf (prettyString doc)
+    where
+      parseInf t = case parseOnly parseRenderedInfo t of
+        Left _e -> def
+        Right i -> i
+      parseSFs :: [Text] -> [StackFrame]
+      parseSFs sfs = case sequence (map (parseOnly parseStackFrame) sfs) of
+        Left _e -> []
+        Right ss -> ss
 
 instance Show PactError where
     show (PactError t i _ s) = show i ++ ": Failure: " ++ maybe "" (++ ": ") msg ++ show s

--- a/tests/GoldenSpec.hs
+++ b/tests/GoldenSpec.hs
@@ -90,13 +90,13 @@ doCRTest tn s code = do
     { output = encode r
     , encodePretty = show
     , writeToFile = BL.writeFile
-    , readFromFile = readOutputRountrip
+    , readFromFile = readOutputRoundtrip
     , testName = tn
     , directory = "golden"
     }
   where
     -- hacks 'readFromFile' to run the golden value through the roundtrip.
-    readOutputRountrip = fmap (tryEncode . eitherDecode) . BL.readFile
+    readOutputRoundtrip = fmap (tryEncode . eitherDecode) . BL.readFile
     tryEncode :: Either String (CommandResult Hash) -> BL.ByteString
     tryEncode (Left e) = error e
     tryEncode (Right cr) = encode cr


### PR DESCRIPTION
Historically Pact left out `[StackFrame]` and `Info` from the `PactError` JSON decoder. This has resulted in empty stack traces in `poll` and `listen` `CommandResult` results in Chainweb. The challenge in fixing this is that both types were rendered as strings in a highly lossy format.

The solution is to provide a `FromJSON` instance that guarantees that the _re-serialized_ output will be the same. `PactError` will have `Info` and `[StackFrame]` values that are not `Eq` equal, but when re-serialized, will produce the same JSON output. 

This is verified by the golden test for `CommandResult`s, which performs a "output roundtrip" on the expected golden value. (The goldens for CRs were committed in #754 and are truly golden).