### PR TITLE
Flag to allow reads in local

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1647,7 +1647,7 @@ Set environment confidential ENTITY id, or unset with no argument.
  *&rarr;*&nbsp;`[string]`
 
 
-Queries, or with arguments, sets execution config flags. Valid flags: ["DisableHistoryInTransactionalMode","DisableModuleInstall","OldReadOnlyBehavior"]
+Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableModuleInstall","OldReadOnlyBehavior"]
 ```lisp
 pact> (env-exec-config ['DisableHistoryInTransactionalMode]) (env-exec-config)
 ["DisableHistoryInTransactionalMode"]

--- a/docs/en/pact-reference.md
+++ b/docs/en/pact-reference.md
@@ -1415,6 +1415,9 @@ flexibility in designing data access, and is intended to enshrine the module as 
 See also [module guards](#module-guards) for how this concept can be leveraged to protect more than
 just tables.
 
+Note that as of Pact 3.5, the option has been added to selectively allow unguarded reads and transaction history
+access in local mode only, at the discretion of the node operator.
+
 ### Row-level keysets {#rowlevelkeysets}
 
 Keysets can be stored as a column value in a row, allowing for *row-level* authorization.

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -54,6 +54,19 @@ instance Readable (TxLog (ObjectMap PactValue)) where
 instance Readable (TxId, TxLog (ObjectMap PactValue)) where
   readable = ReadData . _txValue . snd
 
+-- | Parameterize calls to 'guardTable' with op.
+data GuardTableOp
+  = GtRead
+  | GtSelect
+  | GtWithRead
+  | GtWithDefaultRead
+  | GtKeys
+  | GtTxIds
+  | GtTxLog
+  | GtKeyLog
+  | GtWrite
+  | GtCreateTable
+
 
 dbDefs :: NativeModule
 dbDefs =
@@ -193,7 +206,7 @@ read' g0 i as@(table@TTable {}:TLitString key:rest) = do
     [] -> return []
     [l] -> colsToList (argsError i as) l
     _ -> argsError i as
-  guardTable i table
+  guardTable i table GtRead
   mrow <- readRow (_faInfo i) (userTable table) (RowKey key)
   case mrow of
     Nothing -> failTx (_faInfo i) $ "read: row not found: " <> pretty key
@@ -243,7 +256,7 @@ select' :: FunApp -> [Term Ref] -> Maybe [(Info,FieldKey)] ->
 select' i _ cols' app@TApp{} tbl@TTable{} = do
     g0 <- computeGas (Right i) (GUnreduced [])
     g1 <- computeGas (Right i) $ GSelect cols'
-    guardTable i tbl
+    guardTable i tbl GtSelect
     let fi = _faInfo i
         tblTy = _tTableType tbl
     ks <- keys fi (userTable tbl)
@@ -275,7 +288,7 @@ withDefaultRead fi as@[table',key',defaultRow',b@(TBinding ps bd (BindSchema _) 
   (!g0,!tkd) <- gasUnreduced fi argsToReduce (mapM reduce argsToReduce)
   case tkd of
     [table@TTable {..}, TLitString key, TObject (Object defaultRow _ _ _) _] -> do
-      guardTable fi table
+      guardTable fi table GtWithDefaultRead
       mrow <- readRow (_faInfo fi) (userTable table) (RowKey key)
       case mrow of
         Nothing -> (g0,) <$> (bindToRow ps bd b =<< enforcePactValue' defaultRow)
@@ -289,7 +302,7 @@ withRead fi as@[table',key',b@(TBinding ps bd (BindSchema _) _)] = do
   (!g0,!tk) <- gasUnreduced fi argsToReduce (mapM reduce argsToReduce)
   case tk of
     [table@TTable {..},TLitString key] -> do
-      guardTable fi table
+      guardTable fi table GtWithRead
       mrow <- readRow (_faInfo fi) (userTable table) (RowKey key)
       case mrow of
         Nothing -> failTx (_faInfo fi) $ "with-read: row not found: " <> pretty key
@@ -306,7 +319,7 @@ keys' :: GasRNativeFun e
 keys' g i [table@TTable {..}] =
   gasPostReads i g
     ((\b -> TList (V.fromList b) tTyString def) . map toTerm) $ do
-      guardTable i table
+      guardTable i table GtKeys
       keys (_faInfo i) (userTable table)
 keys' _ i as = argsError i as
 
@@ -316,7 +329,7 @@ txids' g i [table@TTable {..},TLitInteger key] = do
   checkNonLocalAllowed i
   gasPostReads i g
     ((\b -> TList (V.fromList b) tTyInteger def) . map toTerm) $ do
-      guardTable i table
+      guardTable i table GtTxIds
       txids (_faInfo i) (userTable' table) (fromIntegral key)
 txids' _ i as = argsError i as
 
@@ -324,7 +337,7 @@ txlog :: GasRNativeFun e
 txlog g i [table@TTable {..},TLitInteger tid] = do
   checkNonLocalAllowed i
   gasPostReads i g (toTList TyAny def . map txlogToObj) $ do
-      guardTable i table
+      guardTable i table GtTxLog
       getTxLog (_faInfo i) (userTable table) (fromIntegral tid)
 txlog _ i as = argsError i as
 
@@ -350,7 +363,7 @@ keylog g i [table@TTable {..},TLitString key,TLitInteger utid] = do
         where toTxidObj (t,r) =
                 toTObject TyAny def [("txid", toTerm t),("value",columnsToObject _tTableType (_txValue r))]
   gasPostReads i g postProc $ do
-    guardTable i table
+    guardTable i table GtKeyLog
     tids <- txids (_faInfo i) (userTable' table) (fromIntegral utid)
     logs <- fmap concat $ forM tids $ \tid -> map (tid,) <$> getTxLog (_faInfo i) (userTable table) tid
     return $ filter (\(_,TxLog {..}) -> _txKey == key) logs
@@ -365,7 +378,7 @@ write wt partial i as = do
       ps' <- enforcePactValue' ps
       cost0 <- computeGas (Right i) (GUnreduced [])
       cost1 <- computeGas (Right i) (GPreWrite (WriteData wt (asString key) ps'))
-      guardTable i table
+      guardTable i table GtWrite
       case _tTableType of
         TyAny -> return ()
         TyVar {} -> return ()
@@ -377,16 +390,26 @@ write wt partial i as = do
 
 createTable' :: GasRNativeFun e
 createTable' g i [t@TTable {..}] = do
-  guardTable i t
+  guardTable i t GtCreateTable
   let (UserTables tn) = userTable t
   computeGas' g i (GPreWrite (WriteTable (asString tn))) $
     success "TableCreated" $ createUserTable (_faInfo i) tn _tModuleName
 createTable' _ i as = argsError i as
 
-guardTable :: Pretty n => FunApp -> Term n -> Eval e ()
-guardTable i TTable {..} = guardForModuleCall (_faInfo i) _tModuleName $
-  enforceBlessedHashes i _tModuleName _tHash
-guardTable i t = evalError' i $ "Internal error: guardTable called with non-table term: " <> pretty t
+guardTable :: Pretty n => FunApp -> Term n -> GuardTableOp -> Eval e ()
+guardTable i TTable {..} dbop =
+  checkLocalBypass $
+    guardForModuleCall (_faInfo i) _tModuleName $
+      enforceBlessedHashes i _tModuleName _tHash
+  where checkLocalBypass notBypassed = do
+          localBypassEnabled <- isExecutionFlagSet FlagAllowReadInLocal
+          case dbop of
+            GtWrite -> notBypassed
+            GtCreateTable -> notBypassed
+            _ | localBypassEnabled -> return ()
+              | otherwise -> notBypassed
+
+guardTable i t _ = evalError' i $ "Internal error: guardTable called with non-table term: " <> pretty t
 
 enforceBlessedHashes :: FunApp -> ModuleName -> ModuleHash -> Eval e ()
 enforceBlessedHashes i mn h = getModule i mn >>= \m -> case (_mdModule m) of

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -130,6 +130,8 @@ data ExecutionFlag
   | FlagDisableHistoryInTransactionalMode
   -- | Preserve runReadOnly failing inside of runSysOnly
   | FlagOldReadOnlyBehavior
+  -- | Disable table module guard for read operations in local
+  | FlagAllowReadInLocal
   deriving (Eq,Ord,Show,Enum,Bounded)
 
 -- | Flag string representation

--- a/tests/pact/db.repl
+++ b/tests/pact/db.repl
@@ -12,6 +12,8 @@
 
   (deftable persons:{person})
 
+  (deftable persons2:{person})
+
   (defconst ID_A "A")
   (defconst ROW_A:object{person}
     { 'name:"joe", 'age:46, "dob":(parse-time "%F" "1970-01-01") })
@@ -73,13 +75,94 @@
 (expect "read-persons2 works w/o admin key" ROW_A (dbtest2.read-persons2 ID_A))
 (commit-tx)
 
+;;
+;; test admin table guards
+(env-exec-config []) ;; clear disable history flag
 (begin-tx)
 (use dbtest)
-(expect-failure "insert protected by admin key" (insert persons "foo" ROW_A))
-(expect-failure "keys protected by admin key" (keys persons))
-(expect-failure "txids protected by admin key" (txids persons 0))
-(expect-failure "txlog protected by admin key" (txlog persons 2))
-(expect-failure "keylogs protected by admin key" (keylog persons "" 2))
+(expect-failure
+ "write protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ (write persons "foo" ROW_A))
+(expect-failure
+ "update protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ (update persons "foo" ROW_A))
+(expect-failure
+ "insert protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ (insert persons "foo" ROW_A))
+(expect-failure
+ "keys protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ (keys persons))
+(expect-failure
+ "txids protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ (txids persons 0))
+(expect-failure
+ "txlog protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ (txlog persons 2))
+(expect-failure
+ "keylogs protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ (keylog persons "" 2))
+(expect-failure
+ "read protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ (read persons ID_A))
+(expect-failure
+ "with-read protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ (with-read persons ID_A { 'name:= name } name))
+(expect-failure
+ "with-default-read protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ (with-default-read persons ID_A { 'name: "stu" } { 'name:= name } name))
+(expect-failure
+ "select protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ (select persons (constantly true)))
+(expect-failure
+ "keys protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ (keys persons))
+(expect-failure
+ "create-table protected by admin key" "Keyset failure (=): 'dbtest-admin"
+ (create-table persons2))
 
 ;; just making sure this doesn't blow up, output is still TBD on better Term output in general
 (describe-table persons)
+
+(commit-tx)
+;; test disabling admin table guards
+(env-exec-config ["AllowReadInLocal"])
+(use dbtest)
+(expect-failure
+ "write protected by admin key in local" "Keyset failure (=): 'dbtest-admin"
+ (write persons "foo" ROW_A))
+(expect-failure
+ "update protected by admin key in local" "Keyset failure (=): 'dbtest-admin"
+ (update persons "foo" ROW_A))
+(expect-failure
+ "insert protected by admin key in local" "Keyset failure (=): 'dbtest-admin"
+ (insert persons "foo" ROW_A))
+(expect
+ "keys allowed in local" [ID_A]
+ (keys persons))
+(expect
+ "txids allowed in local" [1]
+ (txids persons 0))
+(expect
+ "txlog allowed in local" [ID_A]
+ (map (at "key") (txlog persons 1)))
+(expect
+ "keylogs allowed in local" [1]
+ (map (at "txid") (keylog persons ID_A 1)))
+(expect
+ "read allowed in local" "joe"
+ (at "name" (read persons ID_A)))
+(expect
+ "with-read allowed in local" "joe"
+ (with-read persons ID_A { 'name:= name } name))
+(expect
+ "with-default-read allowed in local" "stu"
+ (with-default-read persons "zzz" { 'name: "stu" } { 'name:= name } name))
+(expect
+ "select allowed in local" [46]
+ (map (at "age") (select persons (constantly true))))
+(expect
+ "keys allowed in local" [ID_A]
+ (keys persons))
+(expect-failure
+ "create-table protected by admin key in local" "Keyset failure (=): 'dbtest-admin"
+ (create-table persons2))


### PR DESCRIPTION
Allows all pact read-only db ops to be accessible in local directly without module admin. 

The flag will be exposed in config in chainweb so that node operators can disable, as the performance impacts can be severe.