### PR TITLE
Stack CI

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -21,7 +21,7 @@ jobs:
         exclude:
         - os: 'windows-latest'
           ghc: '8.6.5'
-        include: 
+        include:
         - os: 'windows-latest'
           storepath: '--store-path=${HOME}/AppData/Roaming/cabal/store'
 
@@ -62,7 +62,7 @@ jobs:
       if: contains(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
-        sudo apt-get install -y git librocksdb-dev zlib1g-dev libtinfo-dev libsqlite3-dev libz3-dev z3
+        sudo apt-get install -y git zlib1g-dev libtinfo-dev libsqlite3-dev libz3-dev z3
     - name: Install non-Haskell dependencies (macOS)
       if: contains(matrix.os, 'mac')
       run: |
@@ -142,7 +142,7 @@ jobs:
         constraints:
           direct-sqlite==2.3.24
         EOF
-        
+
     - uses: actions/cache@v1
       name: Cache dist-newstyle
       with:
@@ -204,4 +204,3 @@ jobs:
       run: |
         aws s3 cp s3://$ARTIFACT_BUCKET/pact/$BINFILE s3://$ARTIFACT_BUCKET/pact/$LATEST_BINFILE
         aws s3api put-object-acl --bucket $ARTIFACT_BUCKET --key=pact/$LATEST_BINFILE --acl public-read
-

--- a/.github/workflows/stack-ci.yaml
+++ b/.github/workflows/stack-ci.yaml
@@ -1,0 +1,38 @@
+name: Build
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - ci/*
+
+jobs:
+  build:
+    name: CI
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        resolver: ['stack.yaml']
+    steps:
+      - name: Install non-Haskell dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git zlib1g-dev libtinfo-dev libsqlite3-dev libz3-dev z3
+
+      - name: Setup Stack
+        uses: mstksg/setup-stack@v1
+
+      - name: Clone project
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.stack
+          key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles('stack.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.resolver }}-
+
+      - name: Build and run tests
+        run: 'stack build --fast --no-terminal --stack-yaml=${{ matrix.resolver }}'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # stack yaml for ghc builds
 
-resolver: lts-14.18
+resolver: lts-14.27
 
 extra-deps:
   # --- Missing from Stackage --- #


### PR DESCRIPTION
This PR adds a Github CI pipeline that builds Pact via `stack` without optimizations and without running tests. This functions as quick build confirmation (turnaround is about 3 minutes) and is useful when testing updates to `stack.yaml`. This isn't meant to replace the Travis build.