### PR TITLE
Don't cache GHC in CI

### DIFF
--- a/.github/workflows/stack-ci.yaml
+++ b/.github/workflows/stack-ci.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: Stack Build
 on:
   pull_request:
   push:
@@ -10,15 +10,16 @@ jobs:
   build:
     name: CI
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        resolver: ['stack.yaml']
     steps:
       - name: Install non-Haskell dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y git zlib1g-dev libtinfo-dev libsqlite3-dev libz3-dev z3
+
+      - name: Setup GHC
+        uses: actions/setup-haskell@v1
+        with:
+          ghc-version: "8.6.5"
 
       - name: Setup Stack
         uses: mstksg/setup-stack@v1
@@ -30,9 +31,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles('stack.yaml') }}
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.resolver }}-
+            ${{ runner.os }}-stack-
 
-      - name: Build and run tests
-        run: 'stack build --fast --no-terminal --stack-yaml=${{ matrix.resolver }}'
+      - name: Build
+        run: 'stack build --fast --no-terminal --system-ghc'


### PR DESCRIPTION
Avoids having `stack` download its own `ghc`, and thus won't cache it either. Luckily, fetching GHC via `actions/setup-haskell` is instantaneous.