### PR TITLE
LTS 15

### DIFF
--- a/.github/workflows/stack-ci.yaml
+++ b/.github/workflows/stack-ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup GHC
         uses: actions/setup-haskell@v1
         with:
-          ghc-version: "8.8.2"
+          ghc-version: "8.8.3"
 
       - name: Setup Stack
         uses: mstksg/setup-stack@v1
@@ -31,9 +31,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-stack882-${{ hashFiles('stack.yaml') }}
+          key: ${{ runner.os }}-stack883-${{ hashFiles('stack.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-stack882-
+            ${{ runner.os }}-stack883-
 
       - name: Build
         run: 'stack build --fast --no-terminal --system-ghc'

--- a/.github/workflows/stack-ci.yaml
+++ b/.github/workflows/stack-ci.yaml
@@ -36,4 +36,4 @@ jobs:
             ${{ runner.os }}-stack883-
 
       - name: Build
-        run: 'stack build --fast --no-terminal --system-ghc'
+        run: 'stack test --fast --no-terminal --system-ghc'

--- a/.github/workflows/stack-ci.yaml
+++ b/.github/workflows/stack-ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup GHC
         uses: actions/setup-haskell@v1
         with:
-          ghc-version: "8.6.5"
+          ghc-version: "8.8.2"
 
       - name: Setup Stack
         uses: mstksg/setup-stack@v1
@@ -31,9 +31,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml') }}
+          key: ${{ runner.os }}-stack882-${{ hashFiles('stack.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-stack-
+            ${{ runner.os }}-stack882-
 
       - name: Build
         run: 'stack build --fast --no-terminal --system-ghc'

--- a/.github/workflows/stack-ci.yaml
+++ b/.github/workflows/stack-ci.yaml
@@ -14,7 +14,13 @@ jobs:
       - name: Install non-Haskell dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y git zlib1g-dev libtinfo-dev libsqlite3-dev libz3-dev z3
+          sudo apt-get install -y git zlib1g-dev libtinfo-dev libsqlite3-dev libz3-dev
+
+      - name: Setup Z3
+        uses: pavpanchekha/setup-z3@v1.2
+        with:
+          version: "4.8.7"
+          architecture: "x64"
 
       - name: Setup GHC
         uses: actions/setup-haskell@v1
@@ -36,4 +42,4 @@ jobs:
             ${{ runner.os }}-stack883-
 
       - name: Build
-        run: 'stack test --fast --no-terminal --system-ghc'
+        run: "stack test --fast --no-terminal --system-ghc"

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ public
 .dir-locals.el
 docs/ko/_build/
 docs/ja/_build/
+*.hie

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,18 +142,19 @@ before_install:
 # Using compiler above sets CC to an invalid value, so unset it
 - unset CC
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    export Z3=`wget -q -O- "http://github.com/Z3Prover/z3/releases/tag/Z3-${Z3VERSION}" |  grep 'z3.*x64.*ubuntu.*.zip" ' | awk '{print $2}' | awk -F= '{print $2}' | awk -F\" '{print $2}' | head -n1` ;
+    export Z3=`wget -q -O- "http://github.com/Z3Prover/z3/releases/tag/z3-${Z3VERSION}" |  grep 'z3.*x64.*ubuntu.*.zip" ' | awk '{print $2}' | awk -F= '{print $2}' | awk -F\" '{print $2}' | head -n1` ;
     echo "Linux Z3 $Z3";
   fi
 # https://github.com/travis-ci/travis-ci/issues/6307
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     curl -sSL https://rvm.io/mpapis.asc | gpg --import -;
     rvm get stable;
-    export Z3=`wget -q -O- "http://github.com/Z3Prover/z3/releases/tag/Z3-${Z3VERSION}" |  grep 'z3.*x64.*osx.*.zip" ' | awk '{print $2}' | awk -F= '{print $2}' | awk -F\" '{print $2}' | head -n1` ;
+    export Z3=`wget -q -O- "http://github.com/Z3Prover/z3/releases/tag/z3-${Z3VERSION}" |  grep 'z3.*x64.*osx.*.zip" ' | awk '{print $2}' | awk -F= '{print $2}' | awk -F\" '{print $2}' | head -n1` ;
     echo "OS X Z3 $Z3";
   fi
 - export Z3Base=`basename $Z3 .zip`
-- wget --quiet -L -O z3.zip "https://github.com${Z3/blob/raw}"
+# - wget --quiet -L -O z3.zip "https://github.com${Z3/blob/raw}"
+- wget -L -O z3.zip "https://github.com${Z3/blob/raw}"
 - unzip -q z3.zip -d z3_downloaded
 - /bin/rm z3.zip
 - export PATH=$PATH:$PWD/z3_downloaded/$Z3Base/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,20 +92,20 @@ matrix:
   #   addons: {apt: {packages: [libgmp-dev]}}
 
   # OSX Build El Cap
-  - env: BUILD=stack ARGS="" Z3VERSION="4.8.5"
+  - env: BUILD=stack ARGS="" Z3VERSION="4.8.7"
     os: osx
     addons:
       artifacts:
         paths:
-          - .stack-work/dist/x86_64-osx/Cabal-2.4.0.1/build/pact/pact
+          - .stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/pact/pact
 
   # Linux build
-  - env: BUILD=stack ARGS="-j1" Z3VERSION="4.8.5"
+  - env: BUILD=stack ARGS="-j1" Z3VERSION="4.8.7"
     addons:
       apt: {packages: [libgmp-dev]}
       artifacts:
         paths:
-          - .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/pact/pact
+          - .stack-work/dist/x86_64-linux/Cabal-3.0.1.0/build/pact/pact
 
   # OSX Build Yosemite
   # - env: BUILD=stack ARGS=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -153,8 +153,7 @@ before_install:
     echo "OS X Z3 $Z3";
   fi
 - export Z3Base=`basename $Z3 .zip`
-# - wget --quiet -L -O z3.zip "https://github.com${Z3/blob/raw}"
-- wget -L -O z3.zip "https://github.com${Z3/blob/raw}"
+- wget --quiet -L -O z3.zip "https://github.com${Z3/blob/raw}"
 - unzip -q z3.zip -d z3_downloaded
 - /bin/rm z3.zip
 - export PATH=$PATH:$PWD/z3_downloaded/$Z3Base/bin

--- a/pact.cabal
+++ b/pact.cabal
@@ -165,7 +165,7 @@ library
   build-depends:       Decimal >= 0.4.2 && < 0.6
                      , aeson >= 0.11.3.0 && < 1.5
                      , algebraic-graphs >= 0.2 && < 0.6
-                     , prettyprinter >= 1.2 && < 1.4
+                     , prettyprinter >= 1.2 && < 1.6.1
                      , prettyprinter-ansi-terminal >= 1.1 && < 1.2
                      , attoparsec >= 0.13.0.2 && < 0.14
                      , base >=4.9.0.0 && < 4.14
@@ -216,7 +216,7 @@ library
                      , servant-client
                      , servant-client-core
                      , servant-swagger
-                     , swagger2 >= 2.3 && < 2.5
+                     , swagger2 >= 2.3 && < 2.6
 
   if impl(ghcjs)
     build-depends:
@@ -235,7 +235,7 @@ library
                 , memory
                 , neat-interpolation >= 0.3.2.4
                 , safe-exceptions >= 0.1.5.0 && < 0.2
-                , sbv >= 7.11 && < 8.3
+                , sbv >= 7.11 && < 8.7
                 , servant-server
                 , statistics >= 0.13.3 && < 0.16
                 , wai-cors

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -21,7 +21,7 @@ import Data.ByteString.Lazy (toStrict)
 import Data.Default
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as M
-import Data.Text (Text,unpack, pack)
+import Data.Text (unpack, pack)
 import Data.Text.Encoding
 
 -- import GHC.Clock

--- a/src/Pact/Analyze/Eval/Prop.hs
+++ b/src/Pact/Analyze/Eval/Prop.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
@@ -14,9 +13,6 @@ module Pact.Analyze.Eval.Prop where
 
 import           Control.Lens               (Lens', at, ix, view, (%=), (?~))
 import           Control.Monad.Except       (ExceptT, MonadError (throwError))
-#if !MIN_VERSION_base(4,13,0)
-import           Control.Monad.Fail         (MonadFail(..))
-#endif
 import           Control.Monad.Reader       (MonadReader (local), ReaderT)
 import           Control.Monad.State.Strict (MonadState, StateT (..))
 import           Data.Default               (def)
@@ -50,9 +46,6 @@ newtype Query a
     { queryAction :: StateT SymbolicSuccess (ReaderT QueryEnv (ExceptT AnalyzeFailure Alloc)) a }
   deriving (Functor, Applicative, Monad, MonadReader QueryEnv,
             MonadError AnalyzeFailure, MonadState SymbolicSuccess, MonadAlloc)
-
-instance MonadFail Query where
-    fail = throwError . AnalyzeFailure def . fromString
 
 instance (Mergeable a) => Mergeable (Query a) where
   -- We merge the result and state, performing any 'Alloc' actions that occur
@@ -236,20 +229,27 @@ evalPropSpecific (PropRead objTy@(SObjectUnsafe fields) ba tn pRk) = do
 
   aValFields <- foldrSingList
     (pure $ Some SObjectNil $ AnSBV $ literal ())
-    (\k ty accum -> do
-      Some objTy'@(SObject (SingList schema)) (AnSBV obj) <- accum
-      let fieldName = symbolVal k
-          cn = ColumnName fieldName
+    (\k ty accum -> accum >>= \case
+      Some objTy'@(SObject (SingList schema)) (AnSBV obj) -> do
+        let fieldName = symbolVal k
+            cn = ColumnName fieldName
 
-      AVal _prov sval <- mkAVal <$> view
-        (qeAnalyzeState.typedCell ty (beforeAfterLens ba) tn' cn sRk sFalse)
+        res <- mkAVal <$> view
+          (qeAnalyzeState.typedCell ty (beforeAfterLens ba) tn' cn sRk sFalse)
 
-      withSymVal ty $ withSymVal objTy' $ pure $ Some
-        (SObjectUnsafe (SingList (SCons k ty schema)))
-        (AnSBV (tuple (SBVI.SBV sval, obj))))
+        case res of
+          OpaqueVal -> badPat
+          AVal _prov sval -> do
+            withSymVal ty $ withSymVal objTy' $ pure $ Some
+              (SObjectUnsafe (SingList (SCons k ty schema)))
+              (AnSBV (tuple (SBVI.SBV sval, obj)))
+      Some _ _ -> badPat)
     fields
 
   case aValFields of
     Some ty (AnSBV obj) -> case singEq ty objTy of
       Nothing   -> throwErrorNoLoc "expected a different object type"
       Just Refl -> pure $ sansProv obj
+  where
+    badPat :: Query a
+    badPat = throwError $ AnalyzeFailure def "Bad pattern match"

--- a/src/Pact/Analyze/Eval/Prop.hs
+++ b/src/Pact/Analyze/Eval/Prop.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
@@ -13,7 +14,9 @@ module Pact.Analyze.Eval.Prop where
 
 import           Control.Lens               (Lens', at, ix, view, (%=), (?~))
 import           Control.Monad.Except       (ExceptT, MonadError (throwError))
+#if !MIN_VERSION_base(4,13,0)
 import           Control.Monad.Fail         (MonadFail(..))
+#endif
 import           Control.Monad.Reader       (MonadReader (local), ReaderT)
 import           Control.Monad.State.Strict (MonadState, StateT (..))
 import           Data.Default               (def)

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
@@ -20,7 +21,9 @@ import           Control.Lens                (At (at), Lens', preview, use,
                                               _Just, ifoldlM)
 import           Control.Monad               (void, when)
 import           Control.Monad.Except        (Except, MonadError (throwError))
+#if !MIN_VERSION_base(4,13,0)
 import           Control.Monad.Fail          (MonadFail(..))
+#endif
 import           Control.Monad.Reader        (MonadReader (ask, local), runReaderT)
 import           Control.Monad.RWS.Strict    (RWST (RWST, runRWST))
 import           Control.Monad.State.Strict  (MonadState, modify', runStateT)

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -549,7 +549,6 @@ evalTerm = \case
     rowWriteCount tn sRk += 1
     tagAccessKey mtWrites tid sRk writeSucceeds
 
-    -- Just rowETy <- view $ aeTableSchemas.at tn
     view (aeTableSchemas.at tn) >>= \case
       Nothing -> failing "Bad pattern match"
       Just rowETy -> do

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
@@ -21,9 +20,6 @@ import           Control.Lens                (At (at), Lens', preview, use,
                                               _Just, ifoldlM)
 import           Control.Monad               (void, when)
 import           Control.Monad.Except        (Except, MonadError (throwError))
-#if !MIN_VERSION_base(4,13,0)
-import           Control.Monad.Fail          (MonadFail(..))
-#endif
 import           Control.Monad.Reader        (MonadReader (ask, local), runReaderT)
 import           Control.Monad.RWS.Strict    (RWST (RWST, runRWST))
 import           Control.Monad.State.Strict  (MonadState, modify', runStateT)
@@ -76,8 +72,8 @@ newtype Analyze a
   deriving (Functor, Applicative, Monad, MonadReader AnalyzeEnv,
             MonadState EvalAnalyzeState, MonadError AnalyzeFailure)
 
-instance MonadFail Analyze where
-    fail = throwError . AnalyzeFailure def . fromString
+failing :: String -> Analyze a
+failing = throwError . AnalyzeFailure def . fromString
 
 instance Analyzer Analyze where
   type TermOf Analyze = Term
@@ -297,11 +293,12 @@ readFields tn sRk tid (SObjectUnsafe (SingList (SCons sym fieldType subSchema)))
   tagAccessCell mtReads tid tFieldName av
   case av of
     OpaqueVal -> throwErrorNoLoc "Opaque value encountered in table read"
-    AVal (Just (FromCell oc)) sval
-      -> withSymVal fieldType $ withSymVal subObjTy $ do
-        S (Just (FromRow ocMap)) obj' <- readFields tn sRk tid subObjTy
-        pure $ withProv (FromRow $ Map.insert cn oc ocMap) $
-          tuple (SBVI.SBV sval, obj')
+    AVal (Just (FromCell oc)) sval -> withSymVal fieldType $ withSymVal subObjTy $ do
+      readFields tn sRk tid subObjTy >>= \case
+        S (Just (FromRow ocMap)) obj' -> pure
+          $ withProv (FromRow $ Map.insert cn oc ocMap)
+          $ tuple (SBVI.SBV sval, obj')
+        _ -> failing "Bad pattern match"
     AVal _ _ -> error
       "impossible: unexpected type of cell provenance in readFields"
 
@@ -552,30 +549,33 @@ evalTerm = \case
     rowWriteCount tn sRk += 1
     tagAccessKey mtWrites tid sRk writeSucceeds
 
-    Just rowETy <- view $ aeTableSchemas.at tn
-    prevAVals <- case rowETy of
-      EType rowTy@(SObject _) -> do
-        rowAVals <- peekFields tn sRk rowTy
-        -- assume invariants for values already in the DB:
-        applyInvariants tn rowAVals $ mapM_ addConstraint
-        pure rowAVals
-      _ -> throwErrorNoLoc $ FailureMessage $ "evalTerm: Write: Unrecognized type in row position: " <> T.pack (show rowETy)
+    -- Just rowETy <- view $ aeTableSchemas.at tn
+    view (aeTableSchemas.at tn) >>= \case
+      Nothing -> failing "Bad pattern match"
+      Just rowETy -> do
+        prevAVals <- case rowETy of
+          EType rowTy@(SObject _) -> do
+            rowAVals <- peekFields tn sRk rowTy
+            -- assume invariants for values already in the DB:
+            applyInvariants tn rowAVals $ mapM_ addConstraint
+            pure rowAVals
+          _ -> throwErrorNoLoc $ FailureMessage $ "evalTerm: Write: Unrecognized type in row position: " <> T.pack (show rowETy)
 
-    writeFields writeType tid tn sRk obj objTy
+        writeFields writeType tid tn sRk obj objTy
 
-    let newAVals = aValsOfObj schema (_sSbv obj)
-        -- NOTE: left-biased union prefers the new values:
-        nextAVals = Map.union newAVals prevAVals
+        let newAVals = aValsOfObj schema (_sSbv obj)
+            -- NOTE: left-biased union prefers the new values:
+            nextAVals = Map.union newAVals prevAVals
 
-    applyInvariants tn nextAVals $ \invariants' ->
-      let fs :: ZipList (Located (SBV Bool) -> Located (SBV Bool))
-          fs = ZipList $ (\s -> fmap (_sSbv s .&&)) <$> invariants'
-      in maintainsInvariants . at tn . _Just %= (fs <*>)
+        applyInvariants tn nextAVals $ \invariants' ->
+          let fs :: ZipList (Located (SBV Bool) -> Located (SBV Bool))
+              fs = ZipList $ (\s -> fmap (_sSbv s .&&)) <$> invariants'
+          in maintainsInvariants . at tn . _Just %= (fs <*>)
 
-    --
-    -- TODO: make a constant on the pact side that this uses:
-    --
-    pure $ literalS "Write succeeded"
+        --
+        -- TODO: make a constant on the pact side that this uses:
+        --
+        pure $ literalS "Write succeeded"
 
   Let _name vid eterm body -> do
     av <- evalETerm eterm

--- a/src/Pact/Analyze/Parse/Prop.hs
+++ b/src/Pact/Analyze/Parse/Prop.hs
@@ -650,8 +650,7 @@ inferPreProp preProp = case preProp of
     asum
       [ do haystack' <- checkPreProp SStr haystack
            pure $ Some SBool $ CoreProp $ StrContains needle' haystack'
-      , do
-        inferPreProp haystack >>= \case
+      , inferPreProp haystack >>= \case
           Some objTy@SObject{} obj ->
             pure $ Some SBool $ CoreProp $ ObjContains objTy needle' obj
           _ -> empty

--- a/src/Pact/Analyze/Parse/Prop.hs
+++ b/src/Pact/Analyze/Parse/Prop.hs
@@ -593,13 +593,13 @@ inferPreProp preProp = case preProp of
       _ -> throwErrorIn preProp $
         "can't infer the types of the arguments to " <> pretty opName
 
-  PreApp s [lst] | s == SReverse -> do
-    Some (SList ty) lst' <- inferPreProp lst
-    pure $ Some (SList ty) $ CoreProp $ ListReverse ty lst'
+  PreApp s [lst] | s == SReverse -> inferPreProp lst >>= \case
+    Some (SList ty) lst' -> pure $ Some (SList ty) $ CoreProp $ ListReverse ty lst'
+    _ -> empty
 
-  PreApp s [lst] | s == SSort -> do
-    Some (SList ty) lst' <- inferPreProp lst
-    pure $ Some (SList ty) $ CoreProp $ ListSort ty lst'
+  PreApp s [lst] | s == SSort -> inferPreProp lst >>= \case
+    Some (SList ty) lst' -> pure $ Some (SList ty) $ CoreProp $ ListSort ty lst'
+    _ -> empty
 
   PreApp s [index, lstOrObj] | s == SListTake {- == SObjectDrop -} -> do
     Some ty lstOrObj' <- inferPreProp lstOrObj
@@ -650,8 +650,11 @@ inferPreProp preProp = case preProp of
     asum
       [ do haystack' <- checkPreProp SStr haystack
            pure $ Some SBool $ CoreProp $ StrContains needle' haystack'
-      , do Some objTy@SObject{} obj <- inferPreProp haystack
-           pure $ Some SBool $ CoreProp $ ObjContains objTy needle' obj
+      , do
+        inferPreProp haystack >>= \case
+          Some objTy@SObject{} obj ->
+            pure $ Some SBool $ CoreProp $ ObjContains objTy needle' obj
+          _ -> empty
       ]
 
   PreApp s [arg] | s == STypeof -> do

--- a/src/Pact/Analyze/Parse/Types.hs
+++ b/src/Pact/Analyze/Parse/Types.hs
@@ -13,7 +13,6 @@ module Pact.Analyze.Parse.Types where
 import           Control.Applicative        (Alternative)
 import           Control.Lens               (makeLenses, (<&>))
 import           Control.Monad.Except       (MonadError (throwError))
-import           Control.Monad.Fail
 import           Control.Monad.Reader       (ReaderT)
 import           Control.Monad.State.Strict (StateT)
 import qualified Data.HashMap.Strict        as HM
@@ -21,7 +20,6 @@ import           Data.Map                   (Map)
 import qualified Data.Map                   as Map
 import           Data.Set                   (Set)
 import qualified Data.Set                   as Set
-import           Data.String                (fromString, IsString)
 import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import           Prelude                    hiding (exp)
@@ -158,9 +156,6 @@ data PropCheckEnv = PropCheckEnv
 
 newtype EitherFail e a = EitherFail { _getEither :: Either e a }
     deriving (Show, Eq, Ord, Functor, Applicative, Alternative, Monad, MonadError e)
-
-instance IsString str => MonadFail (EitherFail str) where
-    fail = EitherFail . Left . fromString
 
 type ParseEnv = Map Text VarId
 

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GADTs                      #-}
@@ -28,7 +29,9 @@ import           Control.Lens               (Lens', at, cons, makeLenses, snoc,
                                              (<>~), (?=), (^.), (<&>), _1, (^..))
 import           Control.Monad              (join, replicateM, (>=>))
 import           Control.Monad.Except       (Except, MonadError, throwError)
+#if !MIN_VERSION_base(4,13,0)
 import           Control.Monad.Fail         (MonadFail(..))
+#endif
 import           Control.Monad.Reader       (MonadReader (local),
                                              ReaderT (runReaderT))
 import           Control.Monad.State.Strict (MonadState, StateT, evalStateT,

--- a/src/Pact/Parse.hs
+++ b/src/Pact/Parse.hs
@@ -37,9 +37,6 @@ import Control.Applicative
 import Control.DeepSeq (NFData)
 import Control.Lens (Wrapped(..))
 import Control.Monad
-#if !MIN_VERSION_base(4,13,0)
-import Control.Monad.Fail (MonadFail)
-#endif
 import qualified Data.Aeson as A
 import qualified Data.Attoparsec.Text as AP
 import qualified Data.ByteString as BS
@@ -64,7 +61,7 @@ import Pact.Types.Term (ToTerm)
 
 
 -- | Main parser for Pact expressions.
-expr :: (MonadFail m, TokenParsing m, DeltaParsing m) => PactParser m (Exp Parsed)
+expr :: (Monad m, TokenParsing m, DeltaParsing m) => PactParser m (Exp Parsed)
 expr = do
   delt <- position
   let inf = do
@@ -87,7 +84,7 @@ expr = do
     ]
 {-# INLINE expr #-}
 
-number :: (MonadFail m, TokenParsing m, DeltaParsing m) => PactParser m Literal
+number :: (Monad m, TokenParsing m, DeltaParsing m) => PactParser m Literal
 number = do
   -- Tricky: note that we use `char :: CharParsing m => Char -> m Char` rather
   -- than `symbolic :: TokenParsing m => Char -> m Char` here. We use the char
@@ -103,16 +100,16 @@ number = do
     Just d ->
       let precision = length d
       in if precision > 255
-         then fail $ "decimal precision overflow (255 max): " ++ show num ++ "." ++ show d
+         then unexpected $ "decimal precision overflow (255 max): " ++ show num ++ "." ++ show d
          else return $ LDecimal $ Decimal
            (fromIntegral precision)
            (neg (strToNum (strToNum 0 num) d))
 {-# INLINE number #-}
 
 
-qualifiedAtom :: (MonadFail p, TokenParsing p) => p (Text,[Text])
+qualifiedAtom :: (Monad p, TokenParsing p) => p (Text,[Text])
 qualifiedAtom = ident style `sepBy` dot >>= \as -> case reverse as of
-  [] -> fail "qualifiedAtom"
+  [] -> unexpected "qualifiedAtom"
   (a:qs) -> return (a,reverse qs)
 
 bool :: (Monad m, DeltaParsing m) => PactParser m Literal
@@ -124,12 +121,12 @@ bool = msum
 
 
 -- | Parse one or more Pact expressions.
-exprs :: (MonadFail m, TokenParsing m, DeltaParsing m) => PactParser m [Exp Parsed]
+exprs :: (TokenParsing m, DeltaParsing m) => PactParser m [Exp Parsed]
 exprs = some expr
 
 -- | Parse one or more Pact expressions and EOF.
 -- Unnecessary with Atto's 'parseOnly'.
-exprsOnly :: (MonadFail m, TokenParsing m, DeltaParsing m) => m [Exp Parsed]
+exprsOnly :: (Monad m, TokenParsing m, DeltaParsing m) => m [Exp Parsed]
 exprsOnly = unPactParser $ whiteSpace *> exprs <* TF.eof
 
 -- | JSON serialization for 'readDecimal' and public meta info;

--- a/src/Pact/Parse.hs
+++ b/src/Pact/Parse.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE DefaultSignatures #-}
@@ -36,7 +37,9 @@ import Control.Applicative
 import Control.DeepSeq (NFData)
 import Control.Lens (Wrapped(..))
 import Control.Monad
+#if !MIN_VERSION_base(4,13,0)
 import Control.Monad.Fail (MonadFail)
+#endif
 import qualified Data.Aeson as A
 import qualified Data.Attoparsec.Text as AP
 import qualified Data.ByteString as BS

--- a/src/Pact/Parse.hs
+++ b/src/Pact/Parse.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE DefaultSignatures #-}

--- a/src/Pact/Types/Parser.hs
+++ b/src/Pact/Types/Parser.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE Rank2Types #-}
 -- |

--- a/src/Pact/Types/Parser.hs
+++ b/src/Pact/Types/Parser.hs
@@ -22,15 +22,12 @@ module Pact.Types.Parser
 import Control.Applicative
 import Control.Monad
 import Text.Trifecta
-#if !MIN_VERSION_base(4,13,0)
-import Control.Monad.Fail (MonadFail)
-#endif
 import qualified Data.HashSet as HS
 import Text.Parser.Token.Highlight
 import Text.Parser.Token.Style
 
 newtype PactParser p a = PactParser { unPactParser :: p a }
-  deriving (Functor, Applicative, Alternative, Monad, MonadPlus, MonadFail, Parsing, CharParsing, DeltaParsing)
+  deriving (Functor, Applicative, Alternative, Monad, MonadPlus, Parsing, CharParsing, DeltaParsing)
 
 instance TokenParsing p => TokenParsing (PactParser p) where
   someSpace   = PactParser $ buildSomeSpaceParser someSpace $ CommentStyle "" "" ";" False

--- a/src/Pact/Types/Parser.hs
+++ b/src/Pact/Types/Parser.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE Rank2Types #-}
 -- |
 -- Module      :  Pact.Types.Parser
 -- Copyright   :  (C) 2016 Stuart Popejoy
@@ -18,11 +19,12 @@ module Pact.Types.Parser
   where
 
 
-import Text.Trifecta
 import Control.Applicative
 import Control.Monad
+import Text.Trifecta
+#if !MIN_VERSION_base(4,13,0)
 import Control.Monad.Fail (MonadFail)
-import Prelude
+#endif
 import qualified Data.HashSet as HS
 import Text.Parser.Token.Highlight
 import Text.Parser.Token.Style

--- a/src/Pact/Types/SizeOf.hs
+++ b/src/Pact/Types/SizeOf.hs
@@ -27,7 +27,6 @@ import Data.Thyme hiding (Vector)
 import Data.Vector (Vector)
 import qualified Data.Vector as V
 import Data.Word (Word8)
-import GHC.Exts (Int(..))
 import Test.QuickCheck hiding (mapSize)
 import Test.QuickCheck.Instances()
 

--- a/src/Pact/Types/Util.hs
+++ b/src/Pact/Types/Util.hs
@@ -63,7 +63,9 @@ import Data.Text.Encoding
 import Control.Applicative ((<|>))
 import Control.Concurrent
 import Control.Lens hiding (Empty)
+#if !MIN_VERSION_base(4,13,0)
 import Control.Monad.Fail (MonadFail)
+#endif
 import Test.QuickCheck hiding (Result, Success)
 
 import Pact.Types.Parser (style, symbols)

--- a/src/Pact/Types/Util.hs
+++ b/src/Pact/Types/Util.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -63,9 +62,6 @@ import Data.Text.Encoding
 import Control.Applicative ((<|>))
 import Control.Concurrent
 import Control.Lens hiding (Empty)
-#if !MIN_VERSION_base(4,13,0)
-import Control.Monad.Fail (MonadFail)
-#endif
 import Test.QuickCheck hiding (Result, Success)
 
 import Pact.Types.Parser (style, symbols)

--- a/src/Pact/Types/Util.hs
+++ b/src/Pact/Types/Util.hs
@@ -38,7 +38,7 @@ module Pact.Types.Util
   , modifyMVar', modifyingMVar, useMVar
   -- | Miscellany
   , tShow, maybeDelim
-  , failMaybe, maybeToEither
+  , maybeToEither
   -- | Wrapping utilities
   , rewrap, rewrapping, wrap, unwrap
   -- | Arbitrary generator utils
@@ -160,9 +160,6 @@ toB16JSON s = String $ toB16Text s
 
 toB16Text :: ByteString -> Text
 toB16Text s = decodeUtf8 $ B16.encode s
-
-failMaybe :: MonadFail m => String -> Maybe a -> m a
-failMaybe err m = maybe (fail err) return m
 
 maybeToEither :: String -> Maybe a -> Either String a
 maybeToEither err Nothing = Left err

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,17 +1,17 @@
 # stack yaml for ghc builds
 
-resolver: lts-14.18
+resolver: lts-15.3
 
 extra-deps:
   # --- Missing from Stackage --- #
   - ed25519-donna-0.1.1
   - hspec-golden-0.1.0.1
+  - direct-sqlite-2.3.26
+  - sbv-8.6
 
   # --- Forced Downgrades --- #
-  - sbv-8.2
-
-  # --- Forced Upgrades --- #
-  - trifecta-2.1
+  - megaparsec-7.0.5
+  - prettyprinter-1.6.0
 
   # --- Custom Pins --- #
   - git: https://github.com/kadena-io/thyme.git

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # stack yaml for ghc builds
 
-resolver: lts-15.4
+resolver: lts-15.3
 
 extra-deps:
   # --- Missing from Stackage --- #

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,8 @@
 
 resolver: lts-15.4
 
+ghc-options: {"$locals": -funclutter-valid-hole-fits -fmax-relevant-binds=0}
+
 extra-deps:
   # --- Missing from Stackage --- #
   - ed25519-donna-0.1.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 # stack yaml for ghc builds
 
-resolver: lts-15.3
+resolver: lts-15.4
 
 extra-deps:
   # --- Missing from Stackage --- #

--- a/tests/Analyze/Gen.hs
+++ b/tests/Analyze/Gen.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
@@ -18,6 +19,9 @@ import           Control.Monad.State.Strict (MonadState, StateT (runStateT))
 import qualified Data.Decimal               as Decimal
 import qualified Data.Map.Strict            as Map
 import qualified Data.Text                  as T
+#if !MIN_VERSION_base(4,13,0)
+import           Data.Type.Equality         ((:~:) (Refl))
+#endif
 import           GHC.Natural                (Natural)
 import           GHC.Stack                  (HasCallStack)
 import           Hedgehog                   hiding (Update, Var)

--- a/tests/Analyze/Gen.hs
+++ b/tests/Analyze/Gen.hs
@@ -18,7 +18,6 @@ import           Control.Monad.State.Strict (MonadState, StateT (runStateT))
 import qualified Data.Decimal               as Decimal
 import qualified Data.Map.Strict            as Map
 import qualified Data.Text                  as T
-import           Data.Type.Equality         ((:~:) (Refl))
 import           GHC.Natural                (Natural)
 import           GHC.Stack                  (HasCallStack)
 import           Hedgehog                   hiding (Update, Var)

--- a/tests/GasModelSpec.hs
+++ b/tests/GasModelSpec.hs
@@ -26,7 +26,6 @@ import Pact.Types.Exp
 import Pact.Types.SizeOf
 import Pact.Types.PactValue
 import Pact.Types.Runtime
-import Pact.Types.Util (asString)
 import Pact.GasModel.GasModel
 import Pact.GasModel.Types
 import Pact.GasModel.Utils


### PR DESCRIPTION
Pact has long had GHC 8.8 compatibility. This PR updates the bounds of Pact-the-Library to be compatible with the LTS 15 package set (based on GHC 8.8). GHC 8.6 compat (necessary for our GHCjs builds) has been maintained and is guaranteed via our Nix CI. 

Ensuring that Pact is LTS15-compatible lets us keep up with the stable Haskell ecosystem, which is the first step to eventually supporting GHC 8.10. Support for GHC 8.10 would allow Chainweb to utilize the new low-latency garbage collector and in theory get a free performance improvement.

In doing this upgrade, it was discovered that Pact works just fine with the newest available z3 and SBV. So, bounds have been widened accordingly, and Travis updated to use the newest `z3` release.