### PR TITLE
Fix Base64 Decoding 

### DIFF
--- a/src/Pact/Types/Util.hs
+++ b/src/Pact/Types/Util.hs
@@ -136,7 +136,11 @@ toB64UrlUnpaddedText :: ByteString -> Text
 toB64UrlUnpaddedText s = decodeUtf8 $ encodeBase64UrlUnpadded s
 
 fromB64UrlUnpaddedText :: ByteString -> Either String Text
-fromB64UrlUnpaddedText = fmap decodeUtf8 . decodeBase64UrlUnpadded
+fromB64UrlUnpaddedText bs = case decodeBase64UrlUnpadded bs of
+  Right bs' -> case decodeUtf8' bs' of
+    Left _ -> Left $ "Base64URL decode failed: invalid unicode"
+    Right t -> Right t
+  Left e -> Left $ "Base64URL decode failed: " ++ e
 
 parseB16JSON :: Value -> Parser ByteString
 parseB16JSON = withText "Base16" parseB16Text

--- a/tests/pact/base64.repl
+++ b/tests/pact/base64.repl
@@ -24,3 +24,28 @@
   "base64 decoding fails on non base64-encoded input"
   "Could not decode string"
   (base64-decode "aGVsbG8gd29ybGQh%"))
+
+(expect-failure
+  "base64 decoding fails on garbage input 1"
+  "Could not decode string"
+  (base64-decode "aaa"))
+
+(expect-failure
+  "base64 decoding fails on garbage input 2"
+  "Could not decode string"
+  (base64-decode "asdflk"))
+
+(expect-failure
+  "base64 decoding fails on garbage input 3"
+  "Could not decode string"
+  (base64-decode "!@#$%&"))
+
+(expect-failure
+  "base64 decoding fails on garbage input 4"
+  "Could not decode string"
+  (base64-decode "\x0237"))
+
+(expect-failure
+  "base64 decoding fails on garbage input 5"
+  "Could not decode string"
+  (base64-decode "+\x0000"))


### PR DESCRIPTION
This makes the native `base64-decode` catch unicode exceptions thrown as a result of decoding utf8 text values, returning an opaque error instead of crashing the repl.