### PR TITLE
fix redundant patterns

### DIFF
--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -53,7 +53,7 @@ initPactService CommandConfig {..} loggers spv = do
       blockTime = 0
       prevBlockHash = ""
 
-  let mkCEI p@PactDbEnv {..} = do
+  let mkCEI p@PactDbEnv {} = do
         klog "Creating Pact Schema"
         initSchema p
         return CommandExecInterface

--- a/src/Pact/Analyze/Parse/Prop.hs
+++ b/src/Pact/Analyze/Parse/Prop.hs
@@ -145,8 +145,6 @@ expToPreProp = \case
     pretty SPropRead <> " must specify a time ('before or 'after). example: " <>
     "(= result (read accounts user 'before))"
 
-  exp@(ParenList [EAtom' SObjectProjection, _, _]) -> throwErrorIn exp
-    "Property object access must use a static string or symbol"
   exp@(BraceList exps) ->
     let go (keyExp : Colon' : valExp : rest) = Map.insert
           <$> case keyExp of

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -162,7 +162,7 @@ installSigCap SigCapability{..} cdef = do
     NewlyInstalled mc -> return mc
     _ -> evalError' cdef "Unexpected result from managed sig cap install"
   where
-    mkApp d@Def{..} as =
+    mkApp d@Def{} as =
       App (TVar (Ref (TDef d (getInfo d))) (getInfo d))
           (map liftTerm as) (getInfo d)
 
@@ -179,7 +179,7 @@ requireCapability =
   "Specifies and tests for existing grant of CAPABILITY, failing if not found in environment."
   where
     requireCapability' :: NativeFun e
-    requireCapability' i [TApp a@App{..} _] = gasUnreduced i [] $ do
+    requireCapability' i [TApp a@App{} _] = gasUnreduced i [] $ do
       (cap,_,_) <- appToCap a
       granted <- capabilityAcquired cap
       unless granted $ evalError' i $ "require-capability: not granted: " <> pretty cap

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -287,7 +287,7 @@ withDefaultRead fi as@[table',key',defaultRow',b@(TBinding ps bd (BindSchema _) 
   let argsToReduce = [table',key',defaultRow']
   (!g0,!tkd) <- gasUnreduced fi argsToReduce (mapM reduce argsToReduce)
   case tkd of
-    [table@TTable {..}, TLitString key, TObject (Object defaultRow _ _ _) _] -> do
+    [table@TTable {}, TLitString key, TObject (Object defaultRow _ _ _) _] -> do
       guardTable fi table GtWithDefaultRead
       mrow <- readRow (_faInfo fi) (userTable table) (RowKey key)
       case mrow of
@@ -301,7 +301,7 @@ withRead fi as@[table',key',b@(TBinding ps bd (BindSchema _) _)] = do
   let argsToReduce = [table',key']
   (!g0,!tk) <- gasUnreduced fi argsToReduce (mapM reduce argsToReduce)
   case tk of
-    [table@TTable {..},TLitString key] -> do
+    [table@TTable {},TLitString key] -> do
       guardTable fi table GtWithRead
       mrow <- readRow (_faInfo fi) (userTable table) (RowKey key)
       case mrow of
@@ -316,7 +316,7 @@ bindToRow ps bd b (ObjectMap row) =
   bindReduce ps bd (_tInfo b) (\s -> fromPactValue <$> M.lookup (FieldKey s) row)
 
 keys' :: GasRNativeFun e
-keys' g i [table@TTable {..}] =
+keys' g i [table@TTable {}] =
   gasPostReads i g
     ((\b -> TList (V.fromList b) tTyString def) . map toTerm) $ do
       guardTable i table GtKeys
@@ -325,7 +325,7 @@ keys' _ i as = argsError i as
 
 
 txids' :: GasRNativeFun e
-txids' g i [table@TTable {..},TLitInteger key] = do
+txids' g i [table@TTable {},TLitInteger key] = do
   checkNonLocalAllowed i
   gasPostReads i g
     ((\b -> TList (V.fromList b) tTyInteger def) . map toTerm) $ do
@@ -334,7 +334,7 @@ txids' g i [table@TTable {..},TLitInteger key] = do
 txids' _ i as = argsError i as
 
 txlog :: GasRNativeFun e
-txlog g i [table@TTable {..},TLitInteger tid] = do
+txlog g i [table@TTable {},TLitInteger tid] = do
   checkNonLocalAllowed i
   gasPostReads i g (toTList TyAny def . map txlogToObj) $ do
       guardTable i table GtTxLog

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -100,7 +100,7 @@ runPipedRepl :: ReplState -> Handle -> IO (Either () (Term Name))
 runPipedRepl = runPipedRepl' False
 
 runPipedRepl' :: Bool -> ReplState -> Handle -> IO (Either () (Term Name))
-runPipedRepl' p s@ReplState{..} h =
+runPipedRepl' p s@ReplState{} h =
     evalStateT (useReplLib >> pipeLoop p h Nothing) s
 
 initReplState :: MonadIO m => ReplMode -> Maybe String -> m ReplState

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -357,7 +357,7 @@ continuePact i as = case as of
       viewLibState (view rlsPacts) >>= \pacts ->
         case M.lookup pactId pacts of
           Nothing -> evalError' i $ "Invalid pact id: " <> pretty pactId
-          Just PactExec{..} -> do
+          Just PactExec{} -> do
             evalPactExec .= Nothing
             local (set eePactStep $ Just pactStep) $ resumePact (_faInfo i) Nothing
 

--- a/src/Pact/Runtime/Capabilities.hs
+++ b/src/Pact/Runtime/Capabilities.hs
@@ -167,7 +167,7 @@ checkManaged
   -> UserCapability
   -> Def Ref
   -> Eval e (Maybe [UserCapability])
-checkManaged i (applyF,installF) cap@SigCapability{..} cdef = case _dDefMeta cdef of
+checkManaged i (applyF,installF) cap@SigCapability{} cdef = case _dDefMeta cdef of
   Nothing -> return Nothing
   Just (DMDefcap dcm) -> use (evalCapabilities . capManaged) >>= go dcm . S.toList
   where

--- a/src/Pact/Types/Capability.hs
+++ b/src/Pact/Types/Capability.hs
@@ -156,7 +156,7 @@ decomposeManaged' idx cap@SigCapability{..} = case decomposeManaged idx cap of
 
 -- | Match static value to managed.
 matchManaged :: ManagedCapability UserCapability -> UserCapability -> Bool
-matchManaged ManagedCapability{..} cap@SigCapability{..} = case _mcManaged of
+matchManaged ManagedCapability{..} cap@SigCapability{} = case _mcManaged of
   Left {} -> _mcStatic == cap
   Right UserManagedCap{..} -> case decomposeManaged' _umcManageParamIndex cap of
     Nothing -> False

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -1188,10 +1188,10 @@ typeof t = case t of
       TModule {} -> Left "module"
       TList {..} -> Right $ TyList _tListType
       TDef {..} -> Left $ pack $ defTypeRep (_dDefType _tDef)
-      TNative {..} -> Left "defun"
+      TNative {} -> Left "defun"
       TConst {..} -> Left $ "const:" <> _aName _tConstArg
-      TApp {..} -> Left "app"
-      TVar {..} -> Left "var"
+      TApp {} -> Left "app"
+      TVar {} -> Left "var"
       TBinding {..} -> case _tBindType of
         BindLet -> Left "let"
         BindSchema bt -> Right $ TySchema TyBinding bt def

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -349,7 +349,7 @@ data AST n =
 instance Pretty t => Pretty (AST t) where
   pretty a = case a of
      Prim {..} -> sep [ pn, equals, pretty _aPrimValue ]
-     Var {..} -> pn
+     Var {} -> pn
      Object {..} -> sep
        [ pn
        , pretty _aObject
@@ -373,7 +373,7 @@ instance Pretty t => Pretty (AST t) where
        , indent 2 $ parensSep [ indent 2 $ vsep $ map pretty _aAppArgs ]
        , indent 2 $ pretty _aAppFun
        ]
-     Table {..} -> pn
+     Table {} -> pn
      Step {..} ->
        let rb x = case _aRollback of
                   Nothing -> x

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -893,7 +893,7 @@ data CommandResultCheck = CommandResultCheck
 
 
 makeCheck :: Command T.Text -> ExpectResult -> CommandResultCheck
-makeCheck c@Command{..} expect = CommandResultCheck (cmdToRequestKey c) expect
+makeCheck c@Command{} expect = CommandResultCheck (cmdToRequestKey c) expect
 
 runAll :: Manager -> [Command T.Text] -> IO (HM.HashMap RequestKey (CommandResult Hash))
 runAll mgr cmds = runAll' mgr cmds noSPVSupport

--- a/tests/PactTestsSpec.hs
+++ b/tests/PactTestsSpec.hs
@@ -70,7 +70,7 @@ runScript fp = describe fp $ do
 
 runBadScript :: String -> SpecWith ()
 runBadScript fp = describe ("bad-" ++ fp) $ do
-  (r,ReplState{..}) <- runIO $ execScript' Quiet fp
+  (r,ReplState{}) <- runIO $ execScript' Quiet fp
   let expectedError = M.lookup fp badErrors
   it "has error in badErrors" $ expectedError `shouldSatisfy` isJust
   it ("failed as expected: " ++ show expectedError) $


### PR DESCRIPTION
This removes various redundant pattern matches and bindings in record wildcards.

Cf. https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/8.10#new-recordwildcards-warnings