### PR TITLE
FV omnibus: "soft" unsupported, static cap tracing, fixes

### DIFF
--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -451,7 +451,13 @@ evalTerm = \case
       (evalTerm else')
 
   Enforce mTid cond -> do
-    cond' <- restrictingDbAccess DisallowDb $ evalTerm cond
+
+    -- TODO: `Enforce` conflates `enforce` and `enforce-guard`, and
+    -- the latter does NOT restrict db access. For now, making Analyze
+    -- more permissive than `enforce` but less permissive than `enforce-guard`.
+    -- NB it's worth considering whether `enforce` can be read-only.
+
+    cond' <- restrictingDbAccess DisallowWrites $ evalTerm cond
     maybe (pure ()) (`tagAssert` cond') mTid
     succeeds %= (.&& cond')
     pure sTrue

--- a/src/Pact/Analyze/Eval/Term.hs
+++ b/src/Pact/Analyze/Eval/Term.hs
@@ -338,7 +338,8 @@ aValsOfObj schema obj = foldObject (obj , schema) $ \sym (SBVI.SBV sval) _
   -> Map.singleton (T.pack (symbolVal sym)) (AVal Nothing sval)
 
 writeFields
-  :: S Bool -- | Did the row being written previously exist?
+  :: S Bool
+     -- ^ Did the row being written previously exist?
   -> TagId -> TableName -> S RowKey
   -> S (ConcreteObj ty) -> SingTy ('TyObject ty)
   -> Analyze ()

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -101,7 +101,7 @@ data TranslateFailureNoLoc
   | BadPartialBind EType [String]
   | UnexpectedDefaultReadType EType EType
   | UnsupportedNonFatal Text
-  | UnscopedCapability CapName [Text]
+  | UnscopedCapability CapName
   deriving (Eq, Show)
 
 describeTranslateFailureNoLoc :: TranslateFailureNoLoc -> Text
@@ -136,8 +136,7 @@ describeTranslateFailureNoLoc = \case
   BadPartialBind (EType objTy) columnNames -> "Couldn't extract fields " <> tShow columnNames <> " from object of type " <> tShow objTy
   UnexpectedDefaultReadType (EType expected) (EType received) -> "Bad type in a `with-default-read`: we expected " <> tShow expected <> " (the type of the provided default), but saw " <> tShow received <> " (based on the fields that were bound)."
   UnsupportedNonFatal msg -> "Unsupported operation: " <> msg
-  UnscopedCapability (CapName cap) vars -> "Direct execution restricted by capability (" <> T.pack cap <>
-    (T.concat $ map (" " <>) vars) <> ")"
+  UnscopedCapability (CapName cap) -> "Direct execution restricted by capability " <> T.pack cap
 
 
 data TranslateEnv
@@ -1309,7 +1308,7 @@ translateNode astNode = withAstContext astNode $ case astNode of
         emit $ TraceRequireGrant recov capName bindingTs $ Located (nodeInfo node) tid
         pure $ Some SBool $ Enforce Nothing $ HasGrant tid cap vars
       else do
-        addWarning' $ UnscopedCapability capName (map (_nnName . fst) bindings)
+        addWarning' $ UnscopedCapability capName
         pure $ Some SBool $ Lit' True
 
   AST_ComposeCapability (AST_InlinedApp modName funName bindings appBodyA) ->

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -1583,16 +1583,16 @@ translateNode astNode = withAstContext astNode $ case astNode of
     cset <- translateNode a
     inp <- translateNode b
     case (cset,inp) of
-      (Some SInteger _cset',Some SStr inp') -> do
-        warnUnsupported node "is-charset unsupported, expression will always succeed"
-        pure $ Some SBool $ CoreTerm $ Constantly SStr (Lit' True) inp'
+      (Some SInteger _cset',Some SStr _inp') -> do
+        addWarning node $ UnsupportedNonFatal "is-charset: substituting true expression"
+        pure $ Some SBool $ Lit' True
       _ -> failing $ "Pattern match failure"
 
   _ -> throwError' $ UnexpectedNode astNode
 
 -- | Accumulate a non-fatal translation problem
-warnUnsupported :: Node -> Text -> TranslateM ()
-warnUnsupported n t = tsWarnings %= (TranslateFailure (P.getInfo n) (UnsupportedNonFatal t):)
+addWarning :: P.HasInfo i => i -> TranslateFailureNoLoc -> TranslateM ()
+addWarning n w = tsWarnings %= (TranslateFailure (P.getInfo n) w:)
 
 captureOneFreeVar :: TranslateM (VarId, Text, EType)
 captureOneFreeVar = do

--- a/src/Pact/Analyze/Translate.hs
+++ b/src/Pact/Analyze/Translate.hs
@@ -1574,6 +1574,19 @@ translateNode astNode = withAstContext astNode $ case astNode of
     pure $ Some SInteger $ inject @(Numerical Term) $
       BitwiseOp op args'
 
+  AST_NFun _node "is-charset" [ a, b ] -> do
+    cset <- translateNode a
+    inp <- translateNode b
+    case (cset,inp) of
+      (Some SInteger _cset',Some SStr inp') -> do
+        -- TODO this looks toward a "soft unsupported" by allowing
+        -- analysis to proceed when seeing an unsupported term.
+        -- Here, it's replacing `(is-charset cs inp)` with
+        -- `(constantly true inp)`.
+        -- TODO at a minimum need a way to warn about this.
+        pure $ Some SBool $ CoreTerm $ Constantly SStr (Lit' True) inp'
+      _ -> failing $ "Pattern match failure"
+
   _ -> throwError' $ UnexpectedNode astNode
 
 captureOneFreeVar :: TranslateM (VarId, Text, EType)

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -90,6 +90,10 @@ repl = repl' Interactive
 repl' :: ReplMode -> IO (Either () (Term Name))
 repl' m = initReplState m Nothing >>= \s -> runPipedRepl' (m == Interactive) s stdin
 
+-- | Repl that doesn't die on normal errors
+_repl :: IO ()
+_repl = forever $ repl
+
 isPactFile :: String -> Bool
 isPactFile fp = endsWith fp ".pact"
 
@@ -266,7 +270,6 @@ updateForOp i a = do
                     replState <- liftIO $ readMVar mv
                     let verifyUri = _rlsVerifyUri replState
                     (initReplState mode verifyUri >>= put >> void useReplLib)
-                  liftIO $ print a
                   (a <$) <$> loadFile i fp
     TcErrors es -> forM_ es (outStrLn HErr) >> return (Right a)
     Print t -> do

--- a/src/Pact/Types/Typecheck.hs
+++ b/src/Pact/Types/Typecheck.hs
@@ -88,6 +88,7 @@ instance Ord TcId where
 -- show instance is important, used as variable name
 instance Show TcId where show TcId {..} = unpack _tiName ++ show _tiId
 instance Pretty TcId where pretty = viaShow
+instance HasInfo TcId where getInfo = _tiInfo
 
 
 -- | Role of an AST in an overload.
@@ -273,6 +274,7 @@ instance Show Node where
   show (Node i t) = show i ++ "::" ++ show t
 instance Pretty Node where
   pretty (Node i t) = pretty i <> "::" <> pretty t
+instance HasInfo Node where getInfo = getInfo . _aId
 
 -- | Pair an unescaped, unmangled "bare" name with something.
 data Named i = Named {

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -4015,7 +4015,7 @@ spec = describe "analyze" $ do
               "bar")))
         |]
 
-    describe "unused variable in property" $
+    describe "defpact property timeout on only one step" $
       expectVerified [text|
 
         (defun validate-length (a:string)

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -4015,6 +4015,28 @@ spec = describe "analyze" $ do
               "bar")))
         |]
 
+    describe "unused variable in property" $
+      expectVerified [text|
+
+        (defun validate-length (a:string)
+          (enforce (>= (length a) 3) "")
+          (enforce (<= (length a) 256) "")
+        )
+
+        (defpact foo (a:string)
+          @model [ (property (and
+                              (>= (length a) 3)
+                              (<= (length a) 256)))
+                 ]
+
+          (step 1)
+          (step (validate-length a))
+          )
+
+        |]
+
+
+
   describe "with-default-read" $ do
     expectVerified [text|
       (defun test:integer (acct:string)

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -242,6 +242,7 @@ expectPass code check = expectTest
   testEnv { testCode = wrap code ""
           , testCheck = check
           , testPred = handlePositiveTestResult
+          , testName = "expectPass"
           }
 
 expectFail :: HasCallStack => Text -> Check -> Spec
@@ -249,6 +250,7 @@ expectFail code check = expectTest
   testEnv { testCode  = wrap code ""
           , testCheck = check
           , testPred  = (`shouldSatisfy` isJust)
+          , testName = "expectFail"
           }
 
 expectFailureMessage :: HasCallStack => Text -> Text -> Spec
@@ -261,6 +263,7 @@ expectFailureMessage code needleMsg = expectTest
                           needleMsg `T.isInfixOf` (describeCheckFailure cf)
                         _ ->
                           False
+          , testName = "expectFailureMessage"
           }
 
 intConserves :: TableName -> ColumnName -> Prop 'TyBool

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -4027,7 +4027,7 @@ spec = describe "analyze" $ do
               "bar")))
         |]
 
-    describe "defpact property timeout on 2nd step only" $
+    xdescribe "defpact property timeout on 2nd step only" $
       expectVerified [text|
 
         (defpact foo (a:string)

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -4015,22 +4015,15 @@ spec = describe "analyze" $ do
               "bar")))
         |]
 
-    describe "defpact property timeout on only one step" $
+    describe "defpact property timeout on 2nd step only" $
       expectVerified [text|
 
-        (defun validate-length (a:string)
-          (enforce (>= (length a) 3) "")
-          (enforce (<= (length a) 256) "")
-        )
-
         (defpact foo (a:string)
-          @model [ (property (and
-                              (>= (length a) 3)
-                              (<= (length a) 256)))
+          @model [ (property (<= (length a) 256))
                  ]
 
           (step 1)
-          (step (validate-length a))
+          (step (enforce (<= (length a) 256) ""))
           )
 
         |]

--- a/tests/RemoteVerifySpec.hs
+++ b/tests/RemoteVerifySpec.hs
@@ -97,7 +97,7 @@ testSingleModule = do
 
   it "verifies over the network" $
     fmap (view Remote.responseLines) resp `shouldBe`
-    (Right ["Property proven valid",""])
+    (Right [""])
 
 testUnsortedModules :: Spec
 testUnsortedModules = do
@@ -114,7 +114,7 @@ testUnsortedModules = do
 
   it "verifies over the network" $
     fmap (view Remote.responseLines) resp `shouldBe`
-    (Right ["Property proven valid",""])
+    (Right [""])
   where
     code = [text|
       (env-keys ["admin"])


### PR DESCRIPTION
Work to get FV usable with recent pact:
1. "Soft" unsupported warning for `is-charset`
2. Static cap tracing to detect/warn about functions "protected" by a capability (avoids  function having vacuous properties otherwise)
3. Fix for column-delta on `with-default-read` (#799)
4. Timeout bug on `length`
5. Improve unit tests for maintenance
6. Improve tool output (remove success messages)

![image](https://user-images.githubusercontent.com/8353613/81617249-17720980-93b3-11ea-924c-e22a3c8085e7.png)
