### PR TITLE
Update SBV and remove SMTValue

### DIFF
--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -3,6 +3,6 @@
   "repo": "kpkgs",
   "branch": "master",
   "private": false,
-  "rev": "f24bb7dc44ad4e8256f19afb5687bcebce342f9c",
-  "sha256": "01zkd4li1g4rxcp99s6k1pkv5cbwx2wp9alpdlxccp96r0dkbx5w"
+  "rev": "8fd71c5952e0cfdbe2efb308085c590cf635e2dd",
+  "sha256": "01zkd4li1g4rxcp99s6k1pkv5cbwx2wp9alpdlxccp96r0dkbx50"
 }

--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -3,6 +3,6 @@
   "repo": "kpkgs",
   "branch": "master",
   "private": false,
-  "rev": "8fd71c5952e0cfdbe2efb308085c590cf635e2dd",
+  "rev": "0b312dde81d35a925cc3e9ed386d89bf36516341",
   "sha256": "0qnyphzdrv4dk5yk6smcn2qa3iz7bkk049cwzyq1358rcfnr6bjm"
 }

--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -4,5 +4,5 @@
   "branch": "master",
   "private": false,
   "rev": "0b312dde81d35a925cc3e9ed386d89bf36516341",
-  "sha256": "0qnyphzdrv4dk5yk6smcn2qa3iz7bkk049cwzyq1358rcfnr6bjm"
+  "sha256": "0qnyphzdrv4dk5yk6smcn2qa3iz7bkk049cwzyq1358rcfnr6bj0"
 }

--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -3,6 +3,6 @@
   "repo": "kpkgs",
   "branch": "master",
   "private": false,
-  "rev": "f0e8d1a21d5632a8ad7e8a9bbb94b0f7d4340274",
-  "sha256": "09nnniljjvbf811m0a92dg47pz79yix8hvfajbzklwavf1fffv24"
+  "rev": "f24bb7dc44ad4e8256f19afb5687bcebce342f9c",
+  "sha256": "09nnniljjvbf811m0a92dg47pz79yix8hvfajbzklwavf1fffv20"
 }

--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -4,5 +4,5 @@
   "branch": "master",
   "private": false,
   "rev": "f24bb7dc44ad4e8256f19afb5687bcebce342f9c",
-  "sha256": "09nnniljjvbf811m0a92dg47pz79yix8hvfajbzklwavf1fffv20"
+  "sha256": "01zkd4li1g4rxcp99s6k1pkv5cbwx2wp9alpdlxccp96r0dkbx5w"
 }

--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -4,5 +4,5 @@
   "branch": "master",
   "private": false,
   "rev": "8fd71c5952e0cfdbe2efb308085c590cf635e2dd",
-  "sha256": "01zkd4li1g4rxcp99s6k1pkv5cbwx2wp9alpdlxccp96r0dkbx50"
+  "sha256": "0qnyphzdrv4dk5yk6smcn2qa3iz7bkk049cwzyq1358rcfnr6bjm"
 }

--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -4,5 +4,5 @@
   "branch": "master",
   "private": false,
   "rev": "0b312dde81d35a925cc3e9ed386d89bf36516341",
-  "sha256": "0qnyphzdrv4dk5yk6smcn2qa3iz7bkk049cwzyq1358rcfnr6bj0"
+  "sha256": "1a6ff3shy4rjkqcvplai48j5ryq9yfmk6krvawjaabzgm3msk479"
 }

--- a/pact.cabal
+++ b/pact.cabal
@@ -236,7 +236,7 @@ library
                 , memory
                 , neat-interpolation >= 0.3 && < 0.4
                 , safe-exceptions >= 0.1.5.0 && < 0.2
-                , sbv >= 7.11 && < 8.7
+                , sbv >= 8.7
                 , servant-server
                 , statistics >= 0.13.3 && < 0.16
                 , wai-cors

--- a/src/Pact/Analyze/Model/Tags.hs
+++ b/src/Pact/Analyze/Model/Tags.hs
@@ -222,16 +222,16 @@ saturateModel =
       where
         go :: EType -> AVal -> SBV.Query AVal
         go (EType (ty :: SingTy t)) (AVal _mProv sval)
-          = withSymVal ty $ withSMTValue ty $
+          = withSymVal ty $
             mkAVal' . SBV.literal
               <$> SBV.getValue (SBVI.SBV sval :: SBV (Concrete t))
         go _ OpaqueVal = pure OpaqueVal
 
     -- NOTE: This currently rebuilds an SBV. Not sure if necessary.
-    fetchSbv :: (SymVal a, SBV.SMTValue a) => SBV a -> SBV.Query (SBV a)
+    fetchSbv :: (SymVal a) => SBV a -> SBV.Query (SBV a)
     fetchSbv = fmap SBV.literal . SBV.getValue
 
-    fetchS :: (SymVal a, SBV.SMTValue a) => S a -> SBV.Query (S a)
+    fetchS :: (SymVal a) => S a -> SBV.Query (S a)
     fetchS = traverseOf s2Sbv fetchSbv
 
     fetchObject :: UObject -> SBVI.QueryT IO UObject

--- a/src/Pact/Analyze/Types/Numerical.hs
+++ b/src/Pact/Analyze/Types/Numerical.hs
@@ -25,7 +25,6 @@ import qualified Data.Decimal                 as Decimal
 import           Data.SBV                     (HasKind (kindOf), SDivisible (..),
                                                SymVal (..), oneIf, sNot, (.&&),
                                                (.==), (.>), (.^), (.||))
-import           Data.SBV.Control             (SMTValue (sexprToVal))
 import           Data.SBV.Dynamic             (svAbs, svPlus, svTimes, svUNeg)
 import           Data.SBV.Internals           (CV (..), CVal (CInteger),
                                                SBV (SBV), SVal (SVal),
@@ -197,8 +196,6 @@ instance SymVal Decimal where
   literal a = SBV . SVal SBVI.KUnbounded . Left . normCV $ CV SBVI.KUnbounded (CInteger (unDecimal a))
   fromCV (CV _ (CInteger x)) = Decimal x
   fromCV x = error $ "in instance SymVal Decimal: expected CWInteger, found: " ++ show x
-
-instance SMTValue Decimal where sexprToVal = fmap Decimal . sexprToVal
 
 instance Pretty Decimal where
   pretty (Decimal dec) =

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ extra-deps:
   - ed25519-donna-0.1.1
   - hspec-golden-0.1.0.1
   - direct-sqlite-2.3.26
-  - sbv-8.6
+  - sbv-8.7
 
   # --- Forced Downgrades --- #
   - neat-interpolation-0.3.2.6  # >= 0.4 changes gas model output


### PR DESCRIPTION
* [x] set lower bound on sbv to `>=8.7`
* [x] update stack.yaml
* [x] remove all use of SMTValue from code base as indicated by https://hackage.haskell.org/package/sbv-8.7/changelog:

    > Removed the 'SMTValue' class. It's functionality was not really needed. If you ever used this class, removing it from your type signatures should fix the issue.

    This also allows to get rid of `withSMTValue`.
* [x] update nix pin
    * [x] Create PR for kpkgs that updated sbv and z3: https://github.com/kadena-io/kpkgs/pull/19
    * [x] update pact nix pin to point to that branch

# TODO

* [ ] merge https://github.com/kadena-io/kpkgs/pull/19
* [ ] update pact pin to point to kpkgs master