### PR TITLE
Update applications.yml

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.6.5', '8.8.3', '8.10.1']
+        ghc: ['8.6.5', '8.8.4', '8.10.2']
         cabal: ['3.2']
         os: ['ubuntu-16.04', 'ubuntu-18.04', 'macOS-latest', 'windows-latest']
         cabalcache: ['true']

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -21,9 +21,9 @@ jobs:
         exclude:
         - os: 'windows-latest'
           ghc: '8.6.5'
-        include:
-        - os: 'windows-latest'
-          storepath: '--store-path=${HOME}/AppData/Roaming/cabal/store'
+        # include:
+        # - os: 'windows-latest'
+        #   storepath: '--store-path=${HOME}/AppData/Roaming/cabal/store'
 
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.kadena_cabal_cache_aws_access_key_id }}

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -66,8 +66,9 @@ jobs:
     - name: Install non-Haskell dependencies (macOS)
       if: contains(matrix.os, 'mac')
       run: |
-        brew update
-        brew unlink python@2
+        # brew update
+        # brew unlink python@2
+        echo 'skip unlinking python@2'
     - name: Install non-Haskell dependencies (windows)
       if: contains(matrix.os, 'windows')
       run: choco install -y -r awscli
@@ -121,6 +122,8 @@ jobs:
         documentation: False
         package thyme
           tests: False
+        constraints:
+          base16-bytestring <1
         EOF
     - name: Append cabal.project (only ghc-8.10)
       if: startsWith(matrix.ghc, '8.10')

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         ghc: ['8.6.5', '8.8.4', '8.10.2']
         cabal: ['3.2']
-        os: ['ubuntu-16.04', 'ubuntu-18.04', 'macOS-latest', 'windows-latest']
+        os: ['ubuntu-16.04', 'ubuntu-18.04', 'macOS-latest' ] # windows-latest is temporarily disabled
         cabalcache: ['true']
         exclude:
         - os: 'windows-latest'

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -90,8 +90,8 @@ jobs:
       shell: bash
       run: |
         mkdir -p /c/tools/msys64/mingw64/lib
-        choco install -r -y cabal --version 3.2.0.0
-        choco install -r -y ghc --version ${{ matrix.ghc }}
+        choco install -r -y cabal --version 3.2.0.0 --allow-downgrade
+        choco install -r -y ghc --version ${{ matrix.ghc }} --allow-downgrade
     - name: Set GHC and Cabal version (ubuntu, macOS)
       if: "!contains(matrix.os, 'windows')"
       uses: actions/setup-haskell@v1

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -66,9 +66,7 @@ jobs:
     - name: Install non-Haskell dependencies (macOS)
       if: contains(matrix.os, 'mac')
       run: |
-        # brew update
-        # brew unlink python@2
-        echo 'skip unlinking python@2'
+        echo 'skip'
     - name: Install non-Haskell dependencies (windows)
       if: contains(matrix.os, 'windows')
       run: choco install -y -r awscli


### PR DESCRIPTION
* [x] update GHC minor versions to match what is available upstream
* [x] temporarily disable windows builds (chocolatey fails to downgrade ghc and libz fails to link)
* [x] remove redundant unlinking of python2 for macOS-latest
* [x] add upper bound `base16-bytestring <1`