### PR TITLE
Direct tx management in repl, test name enrichment

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1556,7 +1556,8 @@ The following functions are loaded automatically into the interactive REPL, or w
 
 Begin transaction with optional NAME.
 ```lisp
-(begin-tx "load module")
+pact> (begin-tx "load module")
+"Begin Tx 0: load module"
 ```
 
 
@@ -1578,7 +1579,8 @@ Benchmark execution of EXPRS.
 
 Commit transaction.
 ```lisp
-(commit-tx)
+pact> (begin-tx) (commit-tx)
+"Commit Tx 0"
 ```
 
 
@@ -1882,7 +1884,8 @@ Output VALUE to terminal as unquoted, unescaped text.
 
 Rollback transaction.
 ```lisp
-(rollback-tx)
+pact> (begin-tx "Third Act") (rollback-tx)
+"Rollback Tx 0: Third Act"
 ```
 
 

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -23,8 +23,9 @@ module Pact.Repl.Lib where
 import Control.Arrow ((&&&))
 import Control.Concurrent.MVar
 import Control.Lens
-import Control.Monad.Reader
 import Control.Monad.Catch
+import Control.Monad.Reader
+import Control.Monad.State.Strict (get,put)
 
 import Data.Aeson (eitherDecode,toJSON)
 import qualified Data.ByteString.Lazy as BSL
@@ -39,6 +40,7 @@ import Data.Thyme.Time.Core
 import qualified Data.Vector as V
 import Data.List (isInfixOf)
 
+
 #if defined(ghcjs_HOST_OS)
 import qualified Pact.Analyze.Remote.Client as RemoteClient
 import Data.Maybe
@@ -46,8 +48,6 @@ import Data.Maybe
 
 import Criterion
 import Criterion.Types
-
-import Control.Monad.State.Strict (get,put)
 
 import Statistics.Types (Estimate(..))
 

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -503,6 +503,8 @@ expectFail i as = case as of
                                     <> "', got '" <> pack e <> "'"
       _ -> argsError' i as
 
+-- | Use stack frames for 'FunApp's to enrich test name, using
+-- presence of module name as a heuristic of the "user stack".
 enrichTestName :: Text -> Eval e Text
 enrichTestName msg= use evalCallStack >>= return . foldl' go msg
   where

--- a/src/Pact/Repl/Types.hs
+++ b/src/Pact/Repl/Types.hs
@@ -6,7 +6,7 @@ module Pact.Repl.Types
   , TestResult(..)
   , Repl
   , LibOp(..)
-  , LibState(..),rlsPure,rlsOp,rlsTxName,rlsTests,rlsVerifyUri,rlsMockSPV,rlsPacts
+  , LibState(..),rlsPure,rlsOp,rlsTx,rlsTests,rlsVerifyUri,rlsMockSPV,rlsPacts
   , Tx(..)
   , SPVMockKey(..)
   , getAllModules
@@ -83,7 +83,7 @@ instance Ord SPVMockKey where
 data LibState = LibState
   { _rlsPure :: MVar (DbEnv PureDb)
   , _rlsOp :: LibOp
-  , _rlsTxName :: Maybe Text
+  , _rlsTx :: (Maybe TxId, Maybe Text)
   , _rlsTests :: [TestResult]
   , _rlsVerifyUri :: Maybe String
   , _rlsMockSPV :: M.Map SPVMockKey (Object Name)

--- a/src/Pact/Repl/Types.hs
+++ b/src/Pact/Repl/Types.hs
@@ -2,7 +2,7 @@
 module Pact.Repl.Types
   ( ReplMode(..)
   , Hdl(..)
-  , ReplState(..),rEnv,rEvalState,rMode,rOut,rFile,rTermOut,rTxId
+  , ReplState(..),rEnv,rEvalState,rMode,rOut,rFile,rTermOut
   , TestResult(..)
   , Repl
   , LibOp(..)
@@ -52,21 +52,24 @@ data ReplState = ReplState {
     , _rOut :: String
     , _rTermOut :: [Term Name]
     , _rFile :: Maybe FilePath
-    , _rTxId :: Maybe TxId
     }
 
 type Repl a = StateT ReplState IO a
 
-
-data LibOp =
-    Noop |
-    UpdateEnv (Endo (EvalEnv LibState)) |
-    Load FilePath Bool |
-    Tx Info Tx (Maybe Text) |
-    Print (Term Name) |
-    TcErrors [String]
+-- | A REPL operation that requires top-level evaluation.
+data LibOp
+    = Noop
+    | UpdateEnv (Endo (EvalEnv LibState))
+      -- ^ mutate the read-only environment
+    | Load FilePath Bool
+      -- ^ load a filepath script
+    | Print (Term Name)
+      -- ^ print to terminal
+    | TcErrors [String]
+      -- ^ special output for typechecker
 instance Default LibOp where def = Noop
 
+-- | Transaction action type.
 data Tx = Begin|Commit|Rollback deriving (Eq,Show,Bounded,Enum,Ord)
 
 newtype SPVMockKey = SPVMockKey (Text, (Object Name))

--- a/src/Pact/Types/Util.hs
+++ b/src/Pact/Types/Util.hs
@@ -207,8 +207,8 @@ tShow :: Show a => a -> Text
 tShow = pack . show
 
 -- | Show with prepended delimter if not 'Nothing'
-maybeDelim :: Show a => Text -> Maybe a -> Text
-maybeDelim d t = maybe "" ((d <>) . tShow) t
+maybeDelim :: AsString a => Text -> Maybe a -> Text
+maybeDelim d t = maybe "" ((d <>) . asString) t
 
 -- | Re-wrapping lens.
 rewrapping :: (Profunctor p, Functor f, Wrapped b, Wrapped a,

--- a/src/Pact/Types/Util.hs
+++ b/src/Pact/Types/Util.hs
@@ -207,8 +207,8 @@ tShow :: Show a => a -> Text
 tShow = pack . show
 
 -- | Show with prepended delimter if not 'Nothing'
-maybeDelim :: Show a => String -> Maybe a -> String
-maybeDelim d t = maybe "" ((d ++) . show) t
+maybeDelim :: Show a => Text -> Maybe a -> Text
+maybeDelim d t = maybe "" ((d <>) . tShow) t
 
 -- | Re-wrapping lens.
 rewrapping :: (Profunctor p, Functor f, Wrapped b, Wrapped a,

--- a/tests/pact/db.repl
+++ b/tests/pact/db.repl
@@ -166,3 +166,26 @@
 (expect-failure
  "create-table protected by admin key in local" "Keyset failure (=): 'dbtest-admin"
  (create-table persons2))
+
+;; test nested commits
+
+(begin-tx)
+(env-enable-repl-natives true)
+(module nested-tx G
+  (defcap G () true)
+  (defschema s x:integer)
+  (deftable t:{s})
+  (defun test-nested-tx ()
+    (begin-tx)
+    (insert t "a" { 'x: 1 })
+    (commit-tx)
+    (begin-tx)
+    (insert t "b" { 'x: 2 })
+    (rollback-tx)
+    (expect "2nd insert rolled back" ["a"]
+            (keys t))))
+
+(create-table t)
+(commit-tx)
+
+(nested-tx.test-nested-tx)


### PR DESCRIPTION
Makes `begin-tx`, `commit-tx`, `rollback-tx` no longer a deferred top-level action like `envKeys` etc but instead directly performs the action with immediate effect at any scope.