### PR TITLE
Allow pact continuations below top level

### DIFF
--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -204,10 +204,6 @@ pureEval ei e = do
   case r of
     Right a -> do
         doOut ei mode a
-        case _evalPactExec es of
-          Nothing -> return ()
-          Just pe -> do
-            use (rEnv.eePactDbVar) >>= \mv -> liftIO $ modifyMVar_ mv $ return . over rlsPacts (M.insert (_pePactId pe) pe)
         rEvalState .= es
         updateForOp ei a
     Left err -> do

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -82,7 +82,7 @@ initLibState loggers verifyUri = do
                 (newLogger loggers "Repl")
                 def 0 def)
   createSchema m
-  return (LibState m Noop def def verifyUri M.empty M.empty)
+  return (LibState m Noop def def verifyUri M.empty)
 
 -- | Native function with no gas consumption.
 type ZNativeFun e = FunApp -> [Term Ref] -> Eval e (Term Name)
@@ -391,12 +391,8 @@ continuePact i as = case as of
       (pactId, y) <- unwrapExec pid userResume pe
 
       let pactStep = PactStep (fromIntegral step) rollback pactId y
-      viewLibState (view rlsPacts) >>= \pacts ->
-        case M.lookup pactId pacts of
-          Nothing -> evalError' i $ "Invalid pact id: " <> pretty pactId
-          Just PactExec{} -> do
-            evalPactExec .= Nothing
-            local (set eePactStep $ Just pactStep) $ resumePact (_faInfo i) Nothing
+      evalPactExec .= Nothing
+      local (set eePactStep $ Just pactStep) $ resumePact (_faInfo i) Nothing
 
     unwrapExec mpid mobj Nothing = do
       pid <- case mpid of

--- a/src/Pact/Repl/Types.hs
+++ b/src/Pact/Repl/Types.hs
@@ -6,7 +6,7 @@ module Pact.Repl.Types
   , TestResult(..)
   , Repl
   , LibOp(..)
-  , LibState(..),rlsPure,rlsOp,rlsTx,rlsTests,rlsVerifyUri,rlsMockSPV,rlsPacts
+  , LibState(..),rlsPure,rlsOp,rlsTx,rlsTests,rlsVerifyUri,rlsMockSPV
   , Tx(..)
   , SPVMockKey(..)
   , getAllModules
@@ -98,7 +98,6 @@ data LibState = LibState
   , _rlsTests :: [TestResult]
   , _rlsVerifyUri :: Maybe String
   , _rlsMockSPV :: M.Map SPVMockKey (Object Name)
-  , _rlsPacts :: M.Map PactId PactExec
   }
 
 

--- a/tests/pact/lib.repl
+++ b/tests/pact/lib.repl
@@ -43,3 +43,16 @@
 (expect-failure
  "applied env gone"
  (read-keyset 'k))
+
+
+;; run pacts non-toplevel
+(env-enable-repl-natives true)
+(module f g
+  (defcap g () true)
+  (defpact p ()
+    (step 1)
+    (step 2))
+  (defun go ()
+    (p)
+    (continue-pact 1)))
+(expect "non-toplevel pact continuation succeeds" 2 (go))


### PR DESCRIPTION
Really, remove vestigial pact infra in `Repl`/`Lib`