### PR TITLE
Remove setup from gas results

### DIFF
--- a/golden/gas-model/golden
+++ b/golden/gas-model/golden
@@ -1,297 +1,297 @@
 - - (< longNumber longNumber)
-  - 140
+  - 2
 - - (< medNumber medNumber)
-  - 140
+  - 2
 - - (< smallNumber smallNumber)
-  - 140
+  - 2
 - - (< longNumber.0 longNumber.0)
-  - 140
+  - 2
 - - (< medNumber.0 medNumber.0)
-  - 140
+  - 2
 - - (< smallNumber.0 smallNumber.0)
-  - 140
+  - 2
 - - (< longString longString)
-  - 140
+  - 2
 - - (< medString medString)
-  - 140
+  - 2
 - - (< smallString smallString)
-  - 140
+  - 2
 - - (< (time "2016-07-22T12:00:00Z") (time "2018-07-22T12:00:00Z"))
-  - 144
+  - 6
 - - (log 2 longNumber)
-  - 141
+  - 3
 - - (log 2 medNumber)
-  - 141
+  - 3
 - - (log 2 smallNumber)
-  - 141
+  - 3
 - - (log 2 longNumber.1)
-  - 141
+  - 3
 - - (log 2 medNumber.1)
-  - 141
+  - 3
 - - (log 2 smallNumber.1)
-  - 141
+  - 3
 - - (length longNumberList)
-  - 139
+  - 1
 - - (length medNumberList)
-  - 139
+  - 1
 - - (length smallNumberList)
-  - 139
+  - 1
 - - (length longString)
-  - 139
+  - 1
 - - (length medString)
-  - 139
+  - 1
 - - (length smallString)
-  - 139
+  - 1
 - - (length longOjectMap)
-  - 139
+  - 1
 - - (length medOjectMap)
-  - 139
+  - 1
 - - (length smallOjectMap)
-  - 139
+  - 1
 - - (and? (identity) (identity) true)
-  - 143
+  - 5
 - - (install-capability (accounts.MANAGEDCAP "" ""))
-  - 141
+  - 3
 - - (read-decimal "amount") with amount=longDecimal
-  - 139
+  - 1
 - - (read-decimal "amount") with amount=medDecimal
-  - 139
+  - 1
 - - (read-decimal "amount") with amount=smallDecimal
-  - 139
+  - 1
 - - (base64-decode "YWFhYWFhYWFhYQ")
-  - 139
+  - 1
 - - (base64-decode "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ")
-  - 139
+  - 1
 - - (base64-decode "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ")
-  - 139
+  - 1
 - - (| 2 longNumber)
-  - 139
+  - 1
 - - (| 2 medNumber)
-  - 139
+  - 1
 - - (| 2 smallNumber)
-  - 139
+  - 1
 - - (sqrt longNumber)
-  - 144
+  - 6
 - - (sqrt medNumber)
-  - 144
+  - 6
 - - (sqrt smallNumber)
-  - 144
+  - 6
 - - (sqrt longNumber.1)
-  - 144
+  - 6
 - - (sqrt medNumber.1)
-  - 144
+  - 6
 - - (sqrt smallNumber.1)
-  - 144
+  - 6
 - - (days longNumber)
-  - 142
+  - 4
 - - (days medNumber)
-  - 142
+  - 4
 - - (days smallNumber)
-  - 142
+  - 4
 - - (enforce-one "some-error-message" longEnforceList)
-  - 145
+  - 7
 - - (enforce-one "some-error-message" medEnforceList)
-  - 145
+  - 7
 - - (enforce-one "some-error-message" smallEnforceList)
-  - 145
+  - 7
 - - (create-table accounts.accounts-for-testing-table-creation)
-  - 402
+  - 264
 - - (if true "then-clause" "else-clause")
-  - 139
+  - 1
 - - (keys-any 10 1)
-  - 139
+  - 1
 - - |-
     (insert accounts.accounts
             "some-id-that-is-not-present"
             { "balance": 0.0 }
     )
-  - 268
+  - 130
 - - (hash longString)
-  - 143
+  - 5
 - - (hash medString)
-  - 143
+  - 5
 - - (hash smallString)
-  - 143
+  - 5
 - - (hash longOjectMap)
-  - 143
+  - 5
 - - (hash medOjectMap)
-  - 143
+  - 5
 - - (hash smallOjectMap)
-  - 143
+  - 5
 - - (* longNumber longNumber)
-  - 141
+  - 3
 - - (* medNumber medNumber)
-  - 141
+  - 3
 - - (* smallNumber smallNumber)
-  - 141
+  - 3
 - - (* longNumber.0 longNumber.0)
-  - 141
+  - 3
 - - (* medNumber.0 medNumber.0)
-  - 141
+  - 3
 - - (* smallNumber.0 smallNumber.0)
-  - 141
+  - 3
 - - (* longNumber.0 longNumber)
-  - 141
+  - 3
 - - (* medNumber.0 medNumber)
-  - 141
+  - 3
 - - (* smallNumber.0 smallNumber)
-  - 141
+  - 3
 - - (read accounts.accounts "someId")
-  - 149
+  - 11
 - - (read-string "name") with name=longString
-  - 139
+  - 1
 - - (read-string "name") with name=medString
-  - 139
+  - 1
 - - (read-string "name") with name=smallString
-  - 139
+  - 1
 - - (read-keyset 'my-keyset)
-  - 139
+  - 1
 - - (round longNumber.12345)
-  - 139
+  - 1
 - - (round medNumber.12345)
-  - 139
+  - 1
 - - (round smallNumber.12345)
-  - 139
+  - 1
 - - (round longNumber.12345 4)
-  - 139
+  - 1
 - - (round medNumber.12345 4)
-  - 139
+  - 1
 - - (round smallNumber.12345 4)
-  - 139
+  - 1
 - - (not? (identity) true)
-  - 141
+  - 3
 - - |-
     (write accounts.accounts
            "some-id-that-is-not-present"
            { "balance": 0.0 }
     )
-  - 268
+  - 130
 - - (where "a1" (constantly true) longOjectMap)
-  - 141
+  - 3
 - - (where "a1" (constantly true) medOjectMap)
-  - 141
+  - 3
 - - (where "a1" (constantly true) smallOjectMap)
-  - 141
+  - 3
 - - (not true)
-  - 139
+  - 1
 - - (time "2016-07-22T12:00:00Z")
-  - 140
+  - 2
 - - (at 9999 longEscapedStrList)
-  - 140
+  - 2
 - - (at 99 medEscapedStrList)
-  - 140
+  - 2
 - - (at 9 smallEscapedStrList)
-  - 140
+  - 2
 - - (at "a1" longOjectMap)
-  - 140
+  - 2
 - - (at "a1" medOjectMap)
-  - 140
+  - 2
 - - (at "a1" smallOjectMap)
-  - 140
+  - 2
 - - (str-to-int "10000")
-  - 139
+  - 1
 - - (str-to-int "100")
-  - 139
+  - 1
 - - (str-to-int "10")
-  - 139
+  - 1
 - - (str-to-int 16 "186A0")
-  - 139
+  - 1
 - - (str-to-int 16 "64")
-  - 139
+  - 1
 - - (str-to-int 16 "a")
-  - 139
+  - 1
 - - (str-to-int 2 "11000011010100000")
-  - 139
+  - 1
 - - (str-to-int 2 "1100100")
-  - 139
+  - 1
 - - (str-to-int 2 "1010")
-  - 139
+  - 1
 - - (str-to-int 64 "AYag")
-  - 139
+  - 1
 - - (str-to-int 64 "ZA")
-  - 139
+  - 1
 - - (str-to-int 64 "Cg")
-  - 139
+  - 1
 - - (exp 1)
-  - 143
+  - 5
 - - (exp 10)
-  - 143
+  - 5
 - - (exp 100)
-  - 143
+  - 5
 - - (- longNumber longNumber)
-  - 139
+  - 1
 - - (- medNumber medNumber)
-  - 139
+  - 1
 - - (- smallNumber smallNumber)
-  - 139
+  - 1
 - - (- longNumber.0 longNumber.0)
-  - 139
+  - 1
 - - (- medNumber.0 medNumber.0)
-  - 139
+  - 1
 - - (- smallNumber.0 smallNumber.0)
-  - 139
+  - 1
 - - (- longNumber.0 longNumber)
-  - 139
+  - 1
 - - (- medNumber.0 medNumber)
-  - 139
+  - 1
 - - (- smallNumber.0 smallNumber)
-  - 139
+  - 1
 - - (- longNumber)
-  - 139
+  - 1
 - - (- medNumber)
-  - 139
+  - 1
 - - (- smallNumber)
-  - 139
+  - 1
 - - (- longNumber.0)
-  - 139
+  - 1
 - - (- medNumber.0)
-  - 139
+  - 1
 - - (- smallNumber.0)
-  - 139
+  - 1
 - - (xor 2 longNumber)
-  - 139
+  - 1
 - - (xor 2 medNumber)
-  - 139
+  - 1
 - - (xor 2 smallNumber)
-  - 139
+  - 1
 - - (compose-capability (accounts.GOV))
-  - 141
+  - 3
 - - '(define-keyset "some-loaded-keyset" some-loaded-keyset): rotating keyset'
-  - 198
+  - 60
 - - (define-keyset "some-keyset-name-not-present-already" some-loaded-keyset)
-  - 200
+  - 62
 - - (= longNumber longNumber)
-  - 140
+  - 2
 - - (= medNumber medNumber)
-  - 140
+  - 2
 - - (= smallNumber smallNumber)
-  - 140
+  - 2
 - - (= longNumber.0 longNumber.0)
-  - 140
+  - 2
 - - (= medNumber.0 medNumber.0)
-  - 140
+  - 2
 - - (= smallNumber.0 smallNumber.0)
-  - 140
+  - 2
 - - (= longString longString)
-  - 140
+  - 2
 - - (= medString medString)
-  - 140
+  - 2
 - - (= smallString smallString)
-  - 140
+  - 2
 - - (= longOjectMap longOjectMap)
-  - 140
+  - 2
 - - (= medOjectMap medOjectMap)
-  - 140
+  - 2
 - - (= smallOjectMap smallOjectMap)
-  - 140
+  - 2
 - - (= longNumberList longNumberList)
-  - 140
+  - 2
 - - (= medNumberList medNumberList)
-  - 140
+  - 2
 - - (= smallNumberList smallNumberList)
-  - 140
+  - 2
 - - (= (time "2016-07-22T12:00:00Z") (time "2018-07-22T12:00:00Z"))
-  - 144
+  - 6
 - - |-
     (with-read
        accounts.accounts
@@ -299,466 +299,466 @@
        { "balance":= bal }
        bal
     )
-  - 152
+  - 14
 - - (parse-time "%F" "2016-07-22")
-  - 140
+  - 2
 - - (parse-time "%Y-%m-%dT%H:%M:%S%N" "2016-07-23T13:30:45+00:00")
-  - 140
+  - 2
 - - (int-to-str 64 10000)
-  - 139
+  - 1
 - - (int-to-str 2 10000)
-  - 139
+  - 1
 - - (int-to-str 3 10000)
-  - 139
+  - 1
 - - (int-to-str 4 10000)
-  - 139
+  - 1
 - - (int-to-str 5 10000)
-  - 139
+  - 1
 - - (int-to-str 6 10000)
-  - 139
+  - 1
 - - (int-to-str 7 10000)
-  - 139
+  - 1
 - - (int-to-str 8 10000)
-  - 139
+  - 1
 - - (int-to-str 9 10000)
-  - 139
+  - 1
 - - (int-to-str 10 10000)
-  - 139
+  - 1
 - - (int-to-str 11 10000)
-  - 139
+  - 1
 - - (int-to-str 12 10000)
-  - 139
+  - 1
 - - (int-to-str 13 10000)
-  - 139
+  - 1
 - - (int-to-str 14 10000)
-  - 139
+  - 1
 - - (int-to-str 15 10000)
-  - 139
+  - 1
 - - (int-to-str 16 10000)
-  - 139
+  - 1
 - - (int-to-str 64 100)
-  - 139
+  - 1
 - - (int-to-str 2 100)
-  - 139
+  - 1
 - - (int-to-str 3 100)
-  - 139
+  - 1
 - - (int-to-str 4 100)
-  - 139
+  - 1
 - - (int-to-str 5 100)
-  - 139
+  - 1
 - - (int-to-str 6 100)
-  - 139
+  - 1
 - - (int-to-str 7 100)
-  - 139
+  - 1
 - - (int-to-str 8 100)
-  - 139
+  - 1
 - - (int-to-str 9 100)
-  - 139
+  - 1
 - - (int-to-str 10 100)
-  - 139
+  - 1
 - - (int-to-str 11 100)
-  - 139
+  - 1
 - - (int-to-str 12 100)
-  - 139
+  - 1
 - - (int-to-str 13 100)
-  - 139
+  - 1
 - - (int-to-str 14 100)
-  - 139
+  - 1
 - - (int-to-str 15 100)
-  - 139
+  - 1
 - - (int-to-str 16 100)
-  - 139
+  - 1
 - - (int-to-str 64 10)
-  - 139
+  - 1
 - - (int-to-str 2 10)
-  - 139
+  - 1
 - - (int-to-str 3 10)
-  - 139
+  - 1
 - - (int-to-str 4 10)
-  - 139
+  - 1
 - - (int-to-str 5 10)
-  - 139
+  - 1
 - - (int-to-str 6 10)
-  - 139
+  - 1
 - - (int-to-str 7 10)
-  - 139
+  - 1
 - - (int-to-str 8 10)
-  - 139
+  - 1
 - - (int-to-str 9 10)
-  - 139
+  - 1
 - - (int-to-str 10 10)
-  - 139
+  - 1
 - - (int-to-str 11 10)
-  - 139
+  - 1
 - - (int-to-str 12 10)
-  - 139
+  - 1
 - - (int-to-str 13 10)
-  - 139
+  - 1
 - - (int-to-str 14 10)
-  - 139
+  - 1
 - - (int-to-str 15 10)
-  - 139
+  - 1
 - - (int-to-str 16 10)
-  - 139
+  - 1
 - - (describe-keyset "some-loaded-keyset")
-  - 239
+  - 101
 - - (create-user-guard (accounts.enforce-true))
-  - 139
+  - 1
 - - (txlog accounts.accounts 0)
-  - 100138
+  - 100000
 - - (abs -longNumber)
-  - 139
+  - 1
 - - (abs -medNumber)
-  - 139
+  - 1
 - - (abs -smallNumber)
-  - 139
+  - 1
 - - (abs -longNumber.0)
-  - 139
+  - 1
 - - (abs -medNumber.0)
-  - 139
+  - 1
 - - (abs -smallNumber.0)
-  - 139
+  - 1
 - - (require-capability (accounts.GOV))
-  - 139
+  - 1
 - - (chain-data)
-  - 139
+  - 1
 - - (shift 2 longNumber)
-  - 139
+  - 1
 - - (shift 2 medNumber)
-  - 139
+  - 1
 - - (shift 2 smallNumber)
-  - 139
+  - 1
 - - (shift -2 longNumber)
-  - 139
+  - 1
 - - (shift -2 medNumber)
-  - 139
+  - 1
 - - (shift -2 smallNumber)
-  - 139
+  - 1
 - - (keys-all 3 3)
-  - 139
+  - 1
 - - (floor longNumber.12345)
-  - 139
+  - 1
 - - (floor medNumber.12345)
-  - 139
+  - 1
 - - (floor smallNumber.12345)
-  - 139
+  - 1
 - - (floor longNumber.12345 4)
-  - 139
+  - 1
 - - (floor medNumber.12345 4)
-  - 139
+  - 1
 - - (floor smallNumber.12345 4)
-  - 139
+  - 1
 - - (+ longNumber longNumber)
-  - 139
+  - 1
 - - (+ medNumber medNumber)
-  - 139
+  - 1
 - - (+ smallNumber smallNumber)
-  - 139
+  - 1
 - - (+ longNumber.0 longNumber.0)
-  - 139
+  - 1
 - - (+ medNumber.0 medNumber.0)
-  - 139
+  - 1
 - - (+ smallNumber.0 smallNumber.0)
-  - 139
+  - 1
 - - (+ longNumber.0 longNumber)
-  - 139
+  - 1
 - - (+ medNumber.0 medNumber)
-  - 139
+  - 1
 - - (+ smallNumber.0 smallNumber)
-  - 139
+  - 1
 - - (+ longString longString)
-  - 20139
+  - 20001
 - - (+ medString medString)
-  - 339
+  - 201
 - - (+ smallString smallString)
-  - 159
+  - 21
 - - (+ longOjectMap longOjectMap)
-  - 20139
+  - 20001
 - - (+ medOjectMap medOjectMap)
-  - 339
+  - 201
 - - (+ smallOjectMap smallOjectMap)
-  - 159
+  - 21
 - - (define-namespace 'some-other-namespace some-loaded-keyset some-loaded-keyset)
-  - 227
+  - 89
 - - '(define-namespace ''my-namespace some-loaded-keyset some-loaded-keyset): Defining
     namespace with the same name as one already defined.'
-  - 226
+  - 88
 - - (use accounts)
-  - 139
+  - 1
 - - (format "{}...{}" longEscapedStrList)
-  - 142
+  - 4
 - - (format "{}...{}" medEscapedStrList)
-  - 142
+  - 4
 - - (format "{}...{}" smallEscapedStrList)
-  - 142
+  - 4
 - - (format "{}...{}" longNumberList)
-  - 142
+  - 4
 - - (format "{}...{}" medNumberList)
-  - 142
+  - 4
 - - (format "{}...{}" smallNumberList)
-  - 142
+  - 4
 - - (tx-hash)
-  - 139
+  - 1
 - - (and false true)
-  - 139
+  - 1
 - - (keylog accounts.accounts "someId" 0)
-  - 100138
+  - 100000
 - - (ceiling longNumber.12345)
-  - 139
+  - 1
 - - (ceiling medNumber.12345)
-  - 139
+  - 1
 - - (ceiling smallNumber.12345)
-  - 139
+  - 1
 - - (ceiling longNumber.12345 4)
-  - 139
+  - 1
 - - (ceiling medNumber.12345 4)
-  - 139
+  - 1
 - - (ceiling smallNumber.12345 4)
-  - 139
+  - 1
 - - (hours longNumber)
-  - 142
+  - 4
 - - (hours medNumber)
-  - 142
+  - 4
 - - (hours smallNumber)
-  - 142
+  - 4
 - - (namespace 'my-namespace)
-  - 151
+  - 13
 - - (~ longNumber)
-  - 139
+  - 1
 - - (~ medNumber)
-  - 139
+  - 1
 - - (~ smallNumber)
-  - 139
+  - 1
 - - (mod longNumber 2)
-  - 139
+  - 1
 - - (mod medNumber 2)
-  - 139
+  - 1
 - - (mod smallNumber 2)
-  - 139
+  - 1
 - - (> longNumber longNumber)
-  - 140
+  - 2
 - - (> medNumber medNumber)
-  - 140
+  - 2
 - - (> smallNumber smallNumber)
-  - 140
+  - 2
 - - (> longNumber.0 longNumber.0)
-  - 140
+  - 2
 - - (> medNumber.0 medNumber.0)
-  - 140
+  - 2
 - - (> smallNumber.0 smallNumber.0)
-  - 140
+  - 2
 - - (> longString longString)
-  - 140
+  - 2
 - - (> medString medString)
-  - 140
+  - 2
 - - (> smallString smallString)
-  - 140
+  - 2
 - - (> (time "2016-07-22T12:00:00Z") (time "2018-07-22T12:00:00Z"))
-  - 144
+  - 6
 - - |-
     (validate-keypair
     "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a"
     "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a")
-  - 167
+  - 29
 - - (^ 2 longNumber)
-  - 142
+  - 4
 - - (^ 2 medNumber)
-  - 142
+  - 4
 - - (^ 2 smallNumber)
-  - 142
+  - 4
 - - (^ 2.1 longNumber.1)
-  - 142
+  - 4
 - - (^ 2.1 medNumber.1)
-  - 142
+  - 4
 - - (^ 2.1 smallNumber.1)
-  - 142
+  - 4
 - - (^ 2.1 longNumber)
-  - 142
+  - 4
 - - (^ 2.1 medNumber)
-  - 142
+  - 4
 - - (^ 2.1 smallNumber)
-  - 142
+  - 4
 - - (read-msg) with msg=longObjectMap
-  - 148
+  - 10
 - - (read-msg) with msg=medObjectMap
-  - 148
+  - 10
 - - (read-msg) with msg=smallObjectMap
-  - 148
+  - 10
 - - (remove "a1" longOjectMap)
-  - 140
+  - 2
 - - (remove "a1" medOjectMap)
-  - 140
+  - 2
 - - (remove "a1" smallOjectMap)
-  - 140
+  - 2
 - - (list-modules)
-  - 238
+  - 100
 - - (base64-encode "aaaaaaaaaa")
-  - 139
+  - 1
 - - (base64-encode "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-  - 139
+  - 1
 - - (base64-encode "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-  - 139
+  - 1
 - - (enforce-guard "some-loaded-keyset")
-  - 147
+  - 9
 - - (drop 1 longNumberList)
-  - 141
+  - 3
 - - (drop 1 medNumberList)
-  - 141
+  - 3
 - - (drop 1 smallNumberList)
-  - 141
+  - 3
 - - (drop -1 longNumberList)
-  - 141
+  - 3
 - - (drop -1 medNumberList)
-  - 141
+  - 3
 - - (drop -1 smallNumberList)
-  - 141
+  - 3
 - - (drop longEscapedStrList longOjectMap)
-  - 141
+  - 3
 - - (drop medEscapedStrList medOjectMap)
-  - 141
+  - 3
 - - (drop smallEscapedStrList smallOjectMap)
-  - 141
+  - 3
 - - (drop ["a1"] longOjectMap)
-  - 141
+  - 3
 - - (drop ["a1"] medOjectMap)
-  - 141
+  - 3
 - - (drop ["a1"] smallOjectMap)
-  - 141
+  - 3
 - - (<= longNumber longNumber)
-  - 140
+  - 2
 - - (<= medNumber medNumber)
-  - 140
+  - 2
 - - (<= smallNumber smallNumber)
-  - 140
+  - 2
 - - (<= longNumber.0 longNumber.0)
-  - 140
+  - 2
 - - (<= medNumber.0 medNumber.0)
-  - 140
+  - 2
 - - (<= smallNumber.0 smallNumber.0)
-  - 140
+  - 2
 - - (<= longString longString)
-  - 140
+  - 2
 - - (<= medString medString)
-  - 140
+  - 2
 - - (<= smallString smallString)
-  - 140
+  - 2
 - - (<= (time "2016-07-22T12:00:00Z") (time "2018-07-22T12:00:00Z"))
-  - 144
+  - 6
 - - (fold (constantly 0) 1 longNumberList)
-  - 10141
+  - 10003
 - - (fold (constantly 0) 1 medNumberList)
-  - 241
+  - 103
 - - (fold (constantly 0) 1 smallNumberList)
-  - 151
+  - 13
 - - (bind longOjectMap longBinding a1)
-  - 142
+  - 4
 - - (bind medOjectMap medBinding a1)
-  - 142
+  - 4
 - - (bind smallOjectMap smallBinding a1)
-  - 142
+  - 4
 - - (keys accounts.accounts)
-  - 339
+  - 201
 - - (!= longNumber longNumber)
-  - 140
+  - 2
 - - (!= medNumber medNumber)
-  - 140
+  - 2
 - - (!= smallNumber smallNumber)
-  - 140
+  - 2
 - - (!= longString longString)
-  - 140
+  - 2
 - - (!= medString medString)
-  - 140
+  - 2
 - - (!= smallString smallString)
-  - 140
+  - 2
 - - (!= longNumber.0 longNumber.0)
-  - 140
+  - 2
 - - (!= medNumber.0 medNumber.0)
-  - 140
+  - 2
 - - (!= smallNumber.0 smallNumber.0)
-  - 140
+  - 2
 - - (!= longNumberList longNumberList)
-  - 140
+  - 2
 - - (!= medNumberList medNumberList)
-  - 140
+  - 2
 - - (!= smallNumberList smallNumberList)
-  - 140
+  - 2
 - - (!= longOjectMap longOjectMap)
-  - 140
+  - 2
 - - (!= medOjectMap medOjectMap)
-  - 140
+  - 2
 - - (!= smallOjectMap smallOjectMap)
-  - 140
+  - 2
 - - (map (identity) longNumberList)
-  - 20142
+  - 20004
 - - (map (identity) medNumberList)
-  - 342
+  - 204
 - - (map (identity) smallNumberList)
-  - 162
+  - 24
 - - (accounts.test-with-cap-func)
-  - 142
+  - 4
 - - (create-pact-guard "test")
-  - 139
+  - 1
 - - (try true (enforce true "this will definitely pass"))
-  - 140
+  - 2
 - - (try true (enforce false "this will definitely fail"))
-  - 139
+  - 1
 - - (/ longNumber longNumber)
-  - 141
+  - 3
 - - (/ medNumber medNumber)
-  - 141
+  - 3
 - - (/ smallNumber smallNumber)
-  - 141
+  - 3
 - - (/ longNumber.0 longNumber.0)
-  - 141
+  - 3
 - - (/ medNumber.0 medNumber.0)
-  - 141
+  - 3
 - - (/ smallNumber.0 smallNumber.0)
-  - 141
+  - 3
 - - (/ longNumber.0 longNumber)
-  - 141
+  - 3
 - - (/ medNumber.0 medNumber)
-  - 141
+  - 3
 - - (/ smallNumber.0 smallNumber)
-  - 141
+  - 3
 - - (enforce-pact-version "3.0")
-  - 139
+  - 1
 - - |-
     (module some-random-module GOV
       (defcap GOV ()
         true ))
-  - 169
+  - 31
 - - (module accounts GOV [...some module code ...]) update module
-  - 276
+  - 138
 - - (txids accounts.accounts 0)
-  - 100138
+  - 100000
 - - (ln longNumber)
-  - 144
+  - 6
 - - (ln medNumber)
-  - 144
+  - 6
 - - (ln smallNumber)
-  - 144
+  - 6
 - - (ln longNumber.1)
-  - 144
+  - 6
 - - (ln medNumber.1)
-  - 144
+  - 6
 - - (ln smallNumber.1)
-  - 144
+  - 6
 - - (or? (identity) (identity) true)
-  - 141
+  - 3
 - - (sort longNumberList)
-  - 1165
+  - 1027
 - - (sort medNumberList)
-  - 142
+  - 4
 - - (sort smallNumberList)
-  - 141
+  - 3
 - - (describe-module "accounts")
-  - 238
+  - 100
 - - (is-charset CHARSET_ASCII "hello world")
-  - 139
+  - 1
 - - (is-charset CHARSET_ASCII "I am nÖt ascii")
-  - 139
+  - 1
 - - (is-charset CHARSET_LATIN1 "I am nÖt ascii, but I am latin1!")
-  - 139
+  - 1
 - - |-
     (interface my-interface
       (defun say-hello:string (name:string))
@@ -773,9 +773,9 @@
       (defun say-hello:string (name:string)
         name)
     )
-  - 218
+  - 80
 - - (or false false)
-  - 139
+  - 1
 - - |-
     (decrypt-cc20p1305
     "Zi1REj5-iA"
@@ -784,13 +784,13 @@
     "FYP6lG7xq7aExvoaHIH8Jg"
     "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a"
     "5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb")
-  - 171
+  - 33
 - - (yield longOjectMap)
-  - 138919
+  - 138781
 - - (yield medOjectMap)
-  - 1489
+  - 1351
 - - (yield smallOjectMap)
-  - 274
+  - 136
 - - (yield longOjectMap "some-chain-id")
   - 138781
 - - (yield medOjectMap "some-chain-id")
@@ -798,114 +798,114 @@
 - - (yield smallOjectMap "some-chain-id")
   - 136
 - - (minutes longNumber)
-  - 142
+  - 4
 - - (minutes medNumber)
-  - 142
+  - 4
 - - (minutes smallNumber)
-  - 142
+  - 4
 - - |-
     (diff-time (time "2016-07-22T12:00:00Z")
     (time "2018-07-22T12:00:00Z"))
-  - 150
+  - 12
 - - (make-list longNumber true)
-  - 1164
+  - 1026
 - - (make-list medNumber true)
-  - 141
+  - 3
 - - (make-list smallNumber true)
-  - 140
+  - 2
 - - (filter (constantly true) longNumberList)
-  - 10141
+  - 10003
 - - (filter (constantly true) medNumberList)
-  - 241
+  - 103
 - - (filter (constantly true) smallNumberList)
-  - 151
+  - 13
 - - (compose (+ 0) (+ 0) 0)
-  - 141
+  - 3
 - - |-
     (select accounts.accounts
       (where "balance" (constantly true))
     )
-  - 343
+  - 205
 - - (reverse longNumberList)
-  - 140
+  - 2
 - - (reverse medNumberList)
-  - 140
+  - 2
 - - (reverse smallNumberList)
-  - 140
+  - 2
 - - (keys-2 3 1)
-  - 139
+  - 1
 - - (contains longNumber longNumberList)
-  - 140
+  - 2
 - - (contains medNumber medNumberList)
-  - 140
+  - 2
 - - (contains smallNumber smallNumberList)
-  - 140
+  - 2
 - - (contains "a1" longOjectMap)
-  - 140
+  - 2
 - - (contains "a1" medOjectMap)
-  - 140
+  - 2
 - - (contains "a1" smallOjectMap)
-  - 140
+  - 2
 - - (contains "alongNumber" longString)
-  - 140
+  - 2
 - - (contains "amedNumber" medString)
-  - 140
+  - 2
 - - (contains "asmallNumber" smallString)
-  - 140
+  - 2
 - - (format-time "%F" (time "2016-07-22T12:00:00Z"))
-  - 144
+  - 6
 - - (format-time "%Y-%m-%dT%H:%M:%S%N" (time "2016-07-23T13:30:45Z"))
-  - 144
+  - 6
 - - (>= longNumber longNumber)
-  - 140
+  - 2
 - - (>= medNumber medNumber)
-  - 140
+  - 2
 - - (>= smallNumber smallNumber)
-  - 140
+  - 2
 - - (>= longNumber.0 longNumber.0)
-  - 140
+  - 2
 - - (>= medNumber.0 medNumber.0)
-  - 140
+  - 2
 - - (>= smallNumber.0 smallNumber.0)
-  - 140
+  - 2
 - - (>= longString longString)
-  - 140
+  - 2
 - - (>= medString medString)
-  - 140
+  - 2
 - - (>= smallString smallString)
-  - 140
+  - 2
 - - (>= (time "2016-07-22T12:00:00Z") (time "2018-07-22T12:00:00Z"))
-  - 144
+  - 6
 - - (take 1 longNumberList)
-  - 141
+  - 3
 - - (take 1 medNumberList)
-  - 141
+  - 3
 - - (take 1 smallNumberList)
-  - 141
+  - 3
 - - (take -1 longNumberList)
-  - 141
+  - 3
 - - (take -1 medNumberList)
-  - 141
+  - 3
 - - (take -1 smallNumberList)
-  - 141
+  - 3
 - - (take longEscapedStrList longOjectMap)
-  - 141
+  - 3
 - - (take medEscapedStrList medOjectMap)
-  - 141
+  - 3
 - - (take smallEscapedStrList smallOjectMap)
-  - 141
+  - 3
 - - (take ["a1"] longOjectMap)
-  - 141
+  - 3
 - - (take ["a1"] medOjectMap)
-  - 141
+  - 3
 - - (take ["a1"] smallOjectMap)
-  - 141
+  - 3
 - - (constantly 0 "firstIgnore")
-  - 139
+  - 1
 - - (constantly 0 "firstIgnore" "secondIgnore")
-  - 139
+  - 1
 - - (constantly 0 "firstIgnore" "secondIgnore" "thirdIgnore")
-  - 139
+  - 1
 - - |-
     (with-default-read
        accounts.accounts
@@ -914,35 +914,35 @@
        { "balance":= bal }
        bal
     )
-  - 153
+  - 15
 - - (create-module-guard "test")
-  - 139
+  - 1
 - - (pact-id)
-  - 139
+  - 1
 - - (enforce true "some-error-message")
-  - 139
+  - 1
 - - (describe-table accounts.accounts)
-  - 238
+  - 100
 - - (identity longNumberList)
-  - 140
+  - 2
 - - (identity medNumberList)
-  - 140
+  - 2
 - - (identity smallNumberList)
-  - 140
+  - 2
 - - (enforce-keyset 'some-loaded-keyset)
-  - 147
+  - 9
 - - (& longNumber longNumber)
-  - 139
+  - 1
 - - (& medNumber medNumber)
-  - 139
+  - 1
 - - (& smallNumber smallNumber)
-  - 139
+  - 1
 - - |-
     (update accounts.accounts
             "someId"
             { "balance": 10.0 }
     )
-  - 263
+  - 125
 - - (resume longBinding a1)
   - 10002
 - - (resume medBinding a1)
@@ -950,44 +950,44 @@
 - - (resume smallBinding a1)
   - 12
 - - (resume longBinding a1) with provenance
-  - 10140
+  - 10002
 - - (resume medBinding a1) with provenance
-  - 240
+  - 102
 - - (resume smallBinding a1) with provenance
-  - 150
+  - 12
 - - (keyset-ref-guard "some-loaded-keyset")
-  - 145
+  - 7
 - - (add-time (time "2016-07-22T12:00:00Z") 15)
-  - 143
+  - 5
 - - (read-integer "amount") with amount=longNumber
-  - 139
+  - 1
 - - (read-integer "amount") with amount=medNumber
-  - 139
+  - 1
 - - (read-integer "amount") with amount=smallNumber
-  - 139
+  - 1
 - - (typeof longOjectMap)
-  - 140
+  - 2
 - - (typeof medOjectMap)
-  - 140
+  - 2
 - - (typeof smallOjectMap)
-  - 140
+  - 2
 - - (typeof longString)
-  - 140
+  - 2
 - - (typeof medString)
-  - 140
+  - 2
 - - (typeof smallString)
-  - 140
+  - 2
 - - (typeof longNumberList)
-  - 140
+  - 2
 - - (typeof medNumberList)
-  - 140
+  - 2
 - - (typeof smallNumberList)
-  - 140
+  - 2
 - - (typeof longNumber)
-  - 140
+  - 2
 - - (typeof medNumber)
-  - 140
+  - 2
 - - (typeof smallNumber)
-  - 140
+  - 2
 - - (pact-version)
-  - 139
+  - 1

--- a/pact.cabal
+++ b/pact.cabal
@@ -337,7 +337,6 @@ test-suite hspec
               , transformers
               , unordered-containers
               , vector
-              , yaml
   other-modules:
                 Blake2Spec
                 KeysetSpec
@@ -350,6 +349,7 @@ test-suite hspec
                 , cryptonite
                 , http-client
                 , servant-client
+                , yaml
     other-modules:
                   DocgenSpec
                 , PactTestsSpec

--- a/src-ghc/Pact/GasModel/Types.hs
+++ b/src-ghc/Pact/GasModel/Types.hs
@@ -203,7 +203,9 @@ defEvalState = do
   stateWithModule <- getLoadedState (accountsModule acctModuleName)
   let loaded = HM.singleton (Name $ BareName sampleLoadedKeysetName def)
                (Direct $ TGuard (GKeySet sampleKeyset) def)
-  return $ set (evalRefs . rsLoaded) loaded stateWithModule
+  return
+      $ set (evalRefs . rsLoaded) loaded
+      $ set evalGas 0 stateWithModule
 
 getLoadedState
   :: T.Text

--- a/tests/GasModelSpec.hs
+++ b/tests/GasModelSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module GasModelSpec (spec) where
 
@@ -8,6 +9,7 @@ import Test.Hspec.Golden as G
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Set as S
+import qualified Data.Text as T
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map as Map
 import qualified Data.Yaml as Y
@@ -206,3 +208,12 @@ genWithSeed i (MkGen g) = MkGen (\_ n -> g (mkQCGen i) n)
 -- | Random seed used to generate the pact values in the sizeOf golden tests
 seed :: Int
 seed = 10000000000
+
+
+_diffGoldens :: FilePath -> FilePath -> IO ()
+_diffGoldens g1 g2 = do
+  (y1 :: Map.Map T.Text [Int]) <- fmap pure . Map.fromList <$> Y.decodeFileThrow g1
+  (y2 :: Map.Map T.Text [Int]) <- fmap pure . Map.fromList <$> Y.decodeFileThrow g2
+  let merge [c1] [c2] = [c1,c2,c2-c1]
+      merge _ _ = []
+  Y.encodeFile "diff.yaml" $ Map.unionWith merge y1 y2


### PR DESCRIPTION
Gas results included setup module load etc. I prepared a diff which shows that the change is uniformly -138, which is the cost of loading the psuedo-accounts module. It makes the results actually informative.

It also fixes the gitlab build (`yaml` in the proper test stanza location).