### PR TITLE
add script to ensure z3 is in PATH when running pact from cml

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,5 +6,5 @@ let
 in kpkgs.pkgs.writeScriptBin "pact" ''
   #!/usr/bin/env bash
   export PATH=${z3}/bin:$PATH
-  exec ${pactExe}/bin/pact "${"$" + "{@:2}" }"
+  exec ${pactExe}/bin/pact "''${@:2}"
 ''

--- a/default.nix
+++ b/default.nix
@@ -6,5 +6,5 @@ let
 in kpkgs.pkgs.writeScriptBin "pact" ''
   #!/usr/bin/env bash
   export PATH=${z3}/bin:$PATH
-  exec ${pactExe}/bin/pact "''${@:2}"
+  exec ${pactExe}/bin/pact "$@"
 ''

--- a/default.nix
+++ b/default.nix
@@ -1,1 +1,10 @@
-(import ./project.nix {}).proj.ghc.pact
+let 
+  pactProj = import ./project.nix {};
+  inherit (pactProj) kpkgs proj;
+  z3 = proj.passthru.z3;
+  pactExe = proj.ghc.pact;
+in kpkgs.pkgs.writeScriptBin "pact" ''
+  #!/usr/bin/env bash
+  export PATH=${z3}/bin:$PATH
+  exec ${pactExe}/bin/pact "${"$" + "{@:2}" }"
+''

--- a/project.nix
+++ b/project.nix
@@ -42,5 +42,7 @@ in {
         ghc = ["pact"];
         ghcjs = ["pact"];
       };
+
+      passthru = { inherit (pkgs) z3;};
     });
 }


### PR DESCRIPTION
Wraps pact in a script that add z3 to path, so that `(verify "my-mod")` works without needing to additionally install z3

If you have a better way of doing this, im open to suggestions