### PR TITLE
Write `coverage/lcov.info` relative to loaded file

### DIFF
--- a/src-ghc/Pact/Main.hs
+++ b/src-ghc/Pact/Main.hs
@@ -191,7 +191,7 @@ main = O.execParser argParser >>= \as -> case as of
     runScript dolog fp coverage = do
       (ref,coverF) <- handleCov coverage
       r <- execScriptF dolog fp coverF
-      withCurrentDirectory (takeDirectory fp) $ void $ traverse writeCovReport ref
+      withCurrentDirectory (takeDirectory fp) $ mapM_ writeCovReport ref
       exitLoad r
         where
           handleCov False = return (Nothing,id)

--- a/src-ghc/Pact/Main.hs
+++ b/src-ghc/Pact/Main.hs
@@ -191,7 +191,7 @@ main = O.execParser argParser >>= \as -> case as of
     runScript dolog fp coverage = do
       (ref,coverF) <- handleCov coverage
       r <- execScriptF dolog fp coverF
-      void $ traverse writeCovReport ref
+      withCurrentDirectory (takeDirectory fp) $ void $ traverse writeCovReport ref
       exitLoad r
         where
           handleCov False = return (Nothing,id)


### PR DESCRIPTION
Coverage in Pact 4.0.1 writes report relative to where `pact` was invoked, this writes to the directory of the loaded file being covered.