### PR TITLE
Placeholder syntax for lambdas

### DIFF
--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -942,9 +942,6 @@ compose i as@[appA@TApp {},appB@TApp {},v] = gasUnreduced i as $ do
   apply (_tApp appB) [a']
 compose i as = argsError' i as
 
-
-
-
 readMsg :: RNativeFun e
 readMsg i [TLitString key] = fromPactValue <$> parseMsgKey i "read-msg" key
 readMsg i [] = fromPactValue <$> parseMsgKey' i "read-msg" Nothing


### PR DESCRIPTION
e.g:

```
(filter (< _ 1) [1 2 3])
```
roughly translates to
```
(filter (lambda (_af1) (< _af1 1)) [1 2 3])
```