### PR TITLE
Fix arg equality in interface check.

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -5,14 +5,14 @@
 
 Constant denoting the ASCII charset
 
-Constant:
+Constant: 
 &nbsp;&nbsp;`CHARSET_ASCII:integer = 0`
 
 ### CHARSET_LATIN1 {#CHARSET_LATIN1}
 
 Constant denoting the Latin-1 charset ISO-8859-1
 
-Constant:
+Constant: 
 &nbsp;&nbsp;`CHARSET_LATIN1:integer = 1`
 
 ### at {#at}
@@ -437,7 +437,7 @@ Return ID if called during current pact execution, failing if not.
 Obtain current pact build version.
 ```lisp
 pact> (pact-version)
-"4.1.1"
+"4.1.3"
 ```
 
 Top level only: this function will fail if used in module code.
@@ -882,7 +882,7 @@ pact> (add-time (time "2016-07-22T12:00:00Z") 15)
 *n*&nbsp;`integer` *&rarr;*&nbsp;`decimal`
 
 
-N days, for use with 'add-time'
+N days, for use with 'add-time' 
 ```lisp
 pact> (add-time (time "2016-07-22T12:00:00Z") (days 1))
 "2016-07-23T12:00:00Z"
@@ -920,7 +920,7 @@ pact> (format-time "%F" (time "2016-07-22T12:00:00Z"))
 *n*&nbsp;`integer` *&rarr;*&nbsp;`decimal`
 
 
-N hours, for use with 'add-time'
+N hours, for use with 'add-time' 
 ```lisp
 pact> (add-time (time "2016-07-22T12:00:00Z") (hours 1))
 "2016-07-22T13:00:00Z"
@@ -934,7 +934,7 @@ pact> (add-time (time "2016-07-22T12:00:00Z") (hours 1))
 *n*&nbsp;`integer` *&rarr;*&nbsp;`decimal`
 
 
-N minutes, for use with 'add-time'.
+N minutes, for use with 'add-time'. 
 ```lisp
 pact> (add-time (time "2016-07-22T12:00:00Z") (minutes 1))
 "2016-07-22T12:01:00Z"
@@ -958,7 +958,7 @@ pact> (parse-time "%F" "2016-09-12")
 *utcval*&nbsp;`string` *&rarr;*&nbsp;`time`
 
 
-Construct time from UTCVAL using ISO8601 format (%Y-%m-%dT%H:%M:%SZ).
+Construct time from UTCVAL using ISO8601 format (%Y-%m-%dT%H:%M:%SZ). 
 ```lisp
 pact> (time "2016-07-22T11:26:35Z")
 "2016-07-22T11:26:35Z"

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -5,14 +5,14 @@
 
 Constant denoting the ASCII charset
 
-Constant: 
+Constant:
 &nbsp;&nbsp;`CHARSET_ASCII:integer = 0`
 
 ### CHARSET_LATIN1 {#CHARSET_LATIN1}
 
 Constant denoting the Latin-1 charset ISO-8859-1
 
-Constant: 
+Constant:
 &nbsp;&nbsp;`CHARSET_LATIN1:integer = 1`
 
 ### at {#at}
@@ -437,7 +437,7 @@ Return ID if called during current pact execution, failing if not.
 Obtain current pact build version.
 ```lisp
 pact> (pact-version)
-"4.1.3"
+"4.1.1"
 ```
 
 Top level only: this function will fail if used in module code.
@@ -882,7 +882,7 @@ pact> (add-time (time "2016-07-22T12:00:00Z") 15)
 *n*&nbsp;`integer` *&rarr;*&nbsp;`decimal`
 
 
-N days, for use with 'add-time' 
+N days, for use with 'add-time'
 ```lisp
 pact> (add-time (time "2016-07-22T12:00:00Z") (days 1))
 "2016-07-23T12:00:00Z"
@@ -920,7 +920,7 @@ pact> (format-time "%F" (time "2016-07-22T12:00:00Z"))
 *n*&nbsp;`integer` *&rarr;*&nbsp;`decimal`
 
 
-N hours, for use with 'add-time' 
+N hours, for use with 'add-time'
 ```lisp
 pact> (add-time (time "2016-07-22T12:00:00Z") (hours 1))
 "2016-07-22T13:00:00Z"
@@ -934,7 +934,7 @@ pact> (add-time (time "2016-07-22T12:00:00Z") (hours 1))
 *n*&nbsp;`integer` *&rarr;*&nbsp;`decimal`
 
 
-N minutes, for use with 'add-time'. 
+N minutes, for use with 'add-time'.
 ```lisp
 pact> (add-time (time "2016-07-22T12:00:00Z") (minutes 1))
 "2016-07-22T12:01:00Z"
@@ -958,7 +958,7 @@ pact> (parse-time "%F" "2016-09-12")
 *utcval*&nbsp;`string` *&rarr;*&nbsp;`time`
 
 
-Construct time from UTCVAL using ISO8601 format (%Y-%m-%dT%H:%M:%SZ). 
+Construct time from UTCVAL using ISO8601 format (%Y-%m-%dT%H:%M:%SZ).
 ```lisp
 pact> (time "2016-07-22T11:26:35Z")
 "2016-07-22T11:26:35Z"

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -437,7 +437,7 @@ Return ID if called during current pact execution, failing if not.
 Obtain current pact build version.
 ```lisp
 pact> (pact-version)
-"4.1.1"
+"4.1.3"
 ```
 
 Top level only: this function will fail if used in module code.

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -1496,8 +1496,7 @@ termEq1 eq (TObject (Object (ObjectMap a) _ _ _) _) (TObject (Object (ObjectMap 
 termEq1 _ (TLiteral a _) (TLiteral b _) = a == b
 termEq1 eq (TGuard a _) (TGuard b _) = liftEq (termEq1 eq) a b
 termEq1 eq (TTable a b c d x _) (TTable e f g h y _) = a == e && b == f && c == g && liftEq (termEq1 eq) d h && x == y
-termEq1 eq (TSchema a b c d _) (TSchema e f g h _) = a == e && b == f && c == g && argEq d h
-  where argEq = liftEq (liftEq (termEq1 eq))
+termEq1 eq (TSchema a b c d _) (TSchema e f g h _) = a == e && b == f && c == g && length d == length h && and (zipWith (argEq1 (termEq1 eq)) d h)
 termEq1 eq (TVar a _) (TVar b _) = eq a b
 termEq1 _ (TModRef (ModRef am as _) _) (TModRef (ModRef bm bs _) _) = am == bm && as == bs
 termEq1 _ _ _ = False

--- a/src/Pact/Types/Type.hs
+++ b/src/Pact/Types/Type.hs
@@ -65,7 +65,7 @@ module Pact.Types.Type
   , tyObject
   , tyKeySet
   , tyTable
-
+  , argEq1
   ) where
 
 
@@ -104,6 +104,10 @@ data Arg o = Arg {
   _aType :: Type o,
   _aInfo :: Info
   } deriving (Eq,Ord,Functor,Foldable,Traversable,Generic,Show)
+
+argEq1 :: (n -> n -> Bool) -> Arg n -> Arg n -> Bool
+argEq1 eq (Arg n t _) (Arg n' t' _) =
+  n == n' && liftEq eq t t'
 
 instance NFData o => NFData (Arg o)
 instance Pretty o => Pretty (Arg o) where

--- a/src/Pact/Types/Type.hs
+++ b/src/Pact/Types/Type.hs
@@ -105,10 +105,6 @@ data Arg o = Arg {
   _aInfo :: Info
   } deriving (Eq,Ord,Functor,Foldable,Traversable,Generic,Show)
 
-argEq1 :: (n -> n -> Bool) -> Arg n -> Arg n -> Bool
-argEq1 eq (Arg n t _) (Arg n' t' _) =
-  n == n' && liftEq eq t t'
-
 instance NFData o => NFData (Arg o)
 instance Pretty o => Pretty (Arg o) where
   pretty (Arg n t _) = pretty n <> colon <> pretty t
@@ -448,3 +444,6 @@ instance Eq1 FunType where
 instance Eq1 Arg where
     liftEq = $(makeLiftEq ''Arg)
 
+argEq1 :: (n -> n -> Bool) -> Arg n -> Arg n -> Bool
+argEq1 eq (Arg n t _) (Arg n' t' _) =
+  n == n' && liftEq eq t t'

--- a/tests/pact/upgrades.repl
+++ b/tests/pact/upgrades.repl
@@ -1,0 +1,7 @@
+(module m g (defcap g () 2) (defschema s a:integer b:string))
+
+(interface i (defun foo:object{m.s} (o:object{m.s})))
+
+(module m g (defcap g () 1) (defschema s a:integer b:string))
+
+(module n g (defcap g () 1) (implements i) (defun foo:object{m.s} (o:object{m.s}) o))

--- a/tests/pact/upgrades.repl
+++ b/tests/pact/upgrades.repl
@@ -1,7 +1,11 @@
-(module m g (defcap g () 2) (defschema s a:integer b:string))
+(module schema-mod g (defcap g () 2) (defschema s a:integer b:string))
 
-(interface i (defun foo:object{m.s} (o:object{m.s})))
+(interface schema-ref-iface (defun foo:object{m.s} (o:object{m.s})))
 
-(module m g (defcap g () 1) (defschema s a:integer b:string))
+;; upgrade schema module with identical schema
+(module schema-mod g (defcap g () 1) (defschema s a:integer b:string))
 
+;; implement iface defined with pre-upgraded schema to exercise module unification holds across upgrade
 (module n g (defcap g () 1) (implements i) (defun foo:object{m.s} (o:object{m.s}) o))
+
+

--- a/tests/pact/upgrades.repl
+++ b/tests/pact/upgrades.repl
@@ -1,11 +1,11 @@
 (module schema-mod g (defcap g () 2) (defschema s a:integer b:string))
 
-(interface schema-ref-iface (defun foo:object{m.s} (o:object{m.s})))
+(interface schema-ref-iface (defun foo:object{schema-mod.s} (o:object{schema-mod.s})))
 
 ;; upgrade schema module with identical schema
 (module schema-mod g (defcap g () 1) (defschema s a:integer b:string))
 
 ;; implement iface defined with pre-upgraded schema to exercise module unification holds across upgrade
-(module n g (defcap g () 1) (implements i) (defun foo:object{m.s} (o:object{m.s}) o))
+(module n g (defcap g () 1) (implements schema-ref-iface) (defun foo:object{schema-mod.s} (o:object{schema-mod.s}) o))
 
 


### PR DESCRIPTION
```lisp
(module m g (defcap g () 2) (defschema s a:integer b:string))
(interface i (defun foo:object{m.s} (o:object{m.s})))
(module m g (defcap g () 1) (defschema s a:integer b:string))
(module n g (defcap g () 1) (implements i) (defun foo:object{m.s} (o:object{m.s}) o))
```
works now as intended, while

```lisp
(module m g (defcap g () 2) (defschema s a:integer b:string))
(interface i (defun foo:object{m.s} (o:object{m.s})))
(module m g (defcap g () 1) (defschema s a:integer b:integer))
(module n g (defcap g () 1) (implements i) (defun foo:object{m.s} (o:object{m.s}) o))
```
Does not unify.