### PR TITLE
Changes toward upgrading pact to reflex-platform/nixpkgs-21.05

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -114,7 +114,7 @@ library
     , aeson >= 0.11.3.0 && < 1.6
     , attoparsec >= 0.13.0.2 && < 0.15
     , base >=4.9.0.0 && < 4.17
-    , base16-bytestring >=0.1.1.6 && < 0.2
+    , base16-bytestring >=0.1.1.6 && < 1.1
     , base64-bytestring >= 1.0.0.1 && < 1.2.0.0
         -- base64-bytestring >= 1.2.0.0 is less lenient then previous versions, which can cause pact failures (e.g. (env-hash "aa"))
     , bound >= 2 && < 2.1
@@ -162,7 +162,7 @@ library
       , ghcjs-base
       , ghcjs-dom
       , ghcjs-prim
-      , optparse-applicative >= 0.12.1.0 && < 0.16
+      , optparse-applicative >= 0.12.1.0 && < 0.18
 
   -- Normal GHC
   else
@@ -255,7 +255,7 @@ library
         , haskeline >= 0.7.3 && < 0.9
         , mmorph >= 1.1 && < 1.2
         , neat-interpolation >= 0.4
-        , optparse-applicative >= 0.12.1.0 && < 0.16
+        , optparse-applicative >= 0.12.1.0 && < 0.18
         , sbv >= 8.8
         , servant-server
         , wai-cors

--- a/project.nix
+++ b/project.nix
@@ -10,6 +10,47 @@ in {
     kpkgs.rp.project ({ pkgs, hackGet, ... }: with pkgs.haskell.lib; {
       name = "pact";
       overrides = self: super: {
+        hedgehog = doJailbreak super.hedgehog;
+        tasty-hedgehog = doJailbreak super.tasty-hedgehog;
+        retry = doJailbreak super.retry;
+        bifunctors = doJailbreak super.bifunctors;
+        http-media = doJailbreak super.http-media;
+        semigroupoids = doJailbreak super.semigroupoids;
+        dec = doJailbreak super.dec;
+        aeson = doJailbreak super.aeson;
+        attoparsec = doJailbreak super.attoparsec;
+        attoparsec-iso8601 = doJailbreak super.attoparsec-iso8601;
+        singleton-bool = doJailbreak super.singleton-bool;
+        bool = doJailbreak super.bool;
+        quickcheck-instances = doJailbreak super.quickcheck-instances;
+        trifecta = doJailbreak super.trifecta;
+        http-api-data = doJailbreak super.http-api-data;
+        servant = doJailbreak super.servant;
+        servant-client = doJailbreak super.servant-client;
+        servant-client-core = doJailbreak super.servant-client-core;
+        servant-server = doJailbreak super.servant-server;
+        wai-extra = doJailbreak super.wai-extra;
+        wai-app-static = doJailbreak (self.callHackageDirect {
+          pkg = "wai-app-static";
+          ver = "3.1.7.4";
+          sha256 = "1vbblkgdna1cli6nr05fmd2p47xnrnnkbqdb9zxlzxdshxkblsry";
+        } {});
+        these = doJailbreak (self.callHackageDirect {
+          pkg = "these";
+          ver = "1.1.1.1";
+          sha256 = "1i1nfh41vflvqxi8w8n2s35ymx2z9119dg5zmd2r23ya7vwvaka1";
+        } {});
+        http2 = doJailbreak (self.callHackageDirect {
+          pkg = "http2";
+          ver = "2.0.6";
+          sha256 = "05f9hrgs0v3h99pqv948xaysvndxccb5m6mm2mayn0yv8djryhqi";
+        } {});
+        time-compat = doJailbreak (self.callHackageDirect {
+          pkg = "time-compat";
+          ver = "1.9.6.1";
+          sha256 = "0ika8xx9zff8rwaabs17q5c30c1b9ii89jhbvahi5nk7rs0cd5fs";
+        } {});
+
         direct-sqlite = dontCheck (self.callHackageDirect {
           pkg = "direct-sqlite";
           ver = "2.3.26";


### PR DESCRIPTION
Note that this requiring updating `kpkgs` to use `reflex-platform` branch `nixpkgs-21.05`. Also, although all of the dependencies now build, pact itself is failing partway in due to an API change in `base16-bytestring` it looks like:
```
[ 12 of 126] Compiling Pact.Types.Util  ( src/Pact/Types/Util.hs, dist/build/Pact/Types/Util.o, dis>

src/Pact/Types/Util.hs:151:18: error:
    • Couldn't match expected type ‘Either String ByteString’
                  with actual type ‘(ByteString, ByteString)’
    • In the pattern: (s, leftovers)
      In a case alternative:
          (s, leftovers)
            | leftovers == B.empty -> return s
            | otherwise -> fail $ "Base16 decode failed: " ++ show t
      In the expression:
        case B16.decode (encodeUtf8 t) of {
          (s, leftovers)
            | leftovers == B.empty -> return s
            | otherwise -> fail $ "Base16 decode failed: " ++ show t }
    |
151 |                  (s,leftovers) | leftovers == B.empty -> return s
    |                  ^^^^^^^^^^^^^
[ 95 of 126] Compiling Pact.Types.Version ( src/Pact/Types/Version.hs, dist/build/Pact/Types/Versio>
```