### PR TITLE
Prune cereal as a dependency

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -135,7 +135,6 @@ library
         -- base64-bytestring >= 1.2.0.0 is less lenient then previous versions, which can cause pact failures (e.g. (env-hash "aa"))
     , bound >= 2 && < 2.1
     , bytestring >=0.10.8.1 && < 0.12
-    , cereal >=0.5.4.0 && < 0.6
     , containers >= 0.5.7 && < 0.7
     , data-default >= 0.7.1.1 && < 0.8
     , deepseq >= 1.4.2.0 && < 1.5

--- a/src-ghc/Pact/Types/Crypto.hs
+++ b/src-ghc/Pact/Types/Crypto.hs
@@ -57,8 +57,6 @@ import qualified Data.Text.Encoding as T
 import Data.Aeson                        as A
 import Data.Aeson.Types                  as A
 import Data.Hashable
-import Data.Serialize                    as SZ
-import qualified Data.Serialize          as S
 
 import Pact.Types.Util
 import Pact.Types.Hash
@@ -413,27 +411,14 @@ ed25519GetPublicKey = Ed25519.toPublic
 
 instance Ord Ed25519.PublicKey where
   b <= b' = (B.convert b :: ByteString) <= (B.convert b' :: ByteString)
-instance Serialize Ed25519.PublicKey where
-  put s = S.putByteString (B.convert s :: ByteString)
-  get = maybe (fail "Invalid ED25519 Public Key") return =<<
-        (E.maybeCryptoError . Ed25519.publicKey <$> S.getByteString 32)
-
 
 instance Ord Ed25519.SecretKey where
   b <= b' = (B.convert b :: ByteString) <= (B.convert b' :: ByteString)
-instance Serialize Ed25519.SecretKey where
-  put s = S.putByteString (B.convert s :: ByteString)
-  get = maybe (fail "Invalid ED25519 Private Key") return =<<
-        (E.maybeCryptoError . Ed25519.secretKey <$> S.getByteString 32)
-
 
 
 instance Ord Ed25519.Signature where
   b <= b' = (B.convert b :: ByteString) <= (B.convert b' :: ByteString)
-instance Serialize Ed25519.Signature where
-  put s = S.put (B.convert s :: ByteString)
-  get = maybe (fail "Invalide ED25519 Signature") return =<<
-        (E.maybeCryptoError . Ed25519.signature <$> (S.get >>= S.getByteString))
+
 #else
 ed25519GenKeyPair :: IO (Ed25519.PublicKey, Ed25519.PrivateKey)
 ed25519GenKeyPair = do
@@ -453,27 +438,15 @@ instance Eq Ed25519.PublicKey where
   b == b' = (Ed25519.exportPublic b) == (Ed25519.exportPublic b')
 instance Ord Ed25519.PublicKey where
   b <= b' = (Ed25519.exportPublic b) <= (Ed25519.exportPublic b')
-instance Serialize Ed25519.PublicKey where
-  put s = S.putByteString (Ed25519.exportPublic s)
-  get = maybe (fail "Invalid ED25519 Public Key") return =<<
-        (Ed25519.importPublic <$> S.getByteString 32)
-
 
 
 instance Eq Ed25519.PrivateKey where
   b == b' = (Ed25519.exportPrivate b) == (Ed25519.exportPrivate b')
 instance Ord Ed25519.PrivateKey where
   b <= b' = (Ed25519.exportPrivate b) <= (Ed25519.exportPrivate b')
-instance Serialize Ed25519.PrivateKey where
-  put s = S.putByteString (Ed25519.exportPrivate s)
-  get = maybe (fail "Invalid ED25519 Private Key") return =<<
-        (Ed25519.importPrivate <$> S.getByteString 32)
-
 
 
 deriving instance Eq Ed25519.Signature
 deriving instance Ord Ed25519.Signature
-instance Serialize Ed25519.Signature where
-  put (Ed25519.Sig s) = S.put s
-  get = Ed25519.Sig <$> (S.get >>= S.getByteString)
 #endif
+

--- a/src/Pact/Parse.hs
+++ b/src/Pact/Parse.hs
@@ -40,7 +40,6 @@ import qualified Data.ByteString as BS
 import Data.Char (digitToInt)
 import Data.Decimal
 import Data.List
-import Data.Serialize (Serialize)
 import Data.Text (Text, unpack)
 import Data.Text.Encoding
 import GHC.Generics (Generic)
@@ -137,7 +136,7 @@ exprsOnly = unPactParser $ whiteSpace *> exprs <* TF.eof
 -- accepts both a String version (parsed as a Pact decimal) or
 -- a Number.
 newtype ParsedDecimal = ParsedDecimal Decimal
-  deriving (Eq,Ord,Num,Real,RealFrac,Fractional,Generic,NFData,Serialize,ToTerm)
+  deriving (Eq,Ord,Num,Real,RealFrac,Fractional,Generic,NFData,ToTerm)
 
 instance A.FromJSON ParsedDecimal where
   parseJSON (A.String s) =
@@ -163,7 +162,7 @@ instance Wrapped ParsedDecimal
 -- accepts both a String version (parsed as a Pact integer),
 -- a Number, or a PactValue { "int": ... } integer
 newtype ParsedInteger = ParsedInteger Integer
-  deriving (Eq,Show,Ord,Num,Real,Enum,Integral,Generic,NFData,Serialize,ToTerm,Pretty)
+  deriving (Eq,Show,Ord,Num,Real,Enum,Integral,Generic,NFData,ToTerm,Pretty)
 
 instance A.FromJSON ParsedInteger where
   parseJSON (A.String s) =

--- a/src/Pact/Types/ChainId.hs
+++ b/src/Pact/Types/ChainId.hs
@@ -27,7 +27,6 @@ import Control.DeepSeq
 import Control.Lens
 
 import Data.Aeson (FromJSON, ToJSON)
-import Data.Serialize (Serialize)
 import Data.String (IsString)
 import Data.Text
 import Test.QuickCheck (Arbitrary(..))
@@ -46,7 +45,7 @@ newtype ChainId = ChainId { _chainId :: Text }
   deriving newtype
     ( Show, Pretty, IsString
     , ToJSON, FromJSON
-    , Serialize, ToTerm, NFData
+    , ToTerm, NFData
     , SizeOf, AsString
     )
 
@@ -70,7 +69,7 @@ newtype NetworkId = NetworkId { _networkId :: Text }
   deriving newtype
     ( Show, Pretty, IsString
     , ToJSON, FromJSON
-    , Serialize, ToTerm, NFData
+    , ToTerm, NFData
     )
 
 instance Wrapped NetworkId

--- a/src/Pact/Types/ChainMeta.hs
+++ b/src/Pact/Types/ChainMeta.hs
@@ -38,7 +38,6 @@ import Data.Aeson
 import Data.Default (Default, def)
 import Data.Hashable (Hashable)
 import Data.Int (Int64)
-import Data.Serialize (Serialize)
 import Data.Set (Set)
 import Data.String (IsString)
 import Data.Text
@@ -55,19 +54,19 @@ import Pact.Types.Util (AsString, lensyToJSON, lensyParseJSON)
 -- | Name of "entity", ie confidential counterparty in an encrypted exchange, in privacy-supporting platforms.
 newtype EntityName = EntityName Text
   deriving stock (Eq, Ord, Generic)
-  deriving newtype (Show, NFData, Hashable, Serialize, Default, ToJSON, FromJSON, IsString, AsString)
+  deriving newtype (Show, NFData, Hashable, Default, ToJSON, FromJSON, IsString, AsString)
 
 -- | Wrapper for 'PublicMeta' ttl field in seconds since offset
 --
 newtype TTLSeconds = TTLSeconds ParsedInteger
   deriving stock (Eq, Ord, Generic)
-  deriving newtype (Show, Num, NFData, ToJSON, FromJSON, Serialize)
+  deriving newtype (Show, Num, NFData, ToJSON, FromJSON)
 
 -- | Wrapper for 'PublicMeta' creation time field in seconds since POSIX epoch
 --
 newtype TxCreationTime = TxCreationTime ParsedInteger
   deriving stock (Eq, Ord, Generic)
-  deriving newtype (Show, Num, NFData, ToJSON, FromJSON, Serialize)
+  deriving newtype (Show, Num, NFData, ToJSON, FromJSON)
 
 -- | Get current time as TxCreationTime
 getCurrentCreationTime :: IO TxCreationTime
@@ -84,7 +83,6 @@ data Address = Address
   } deriving (Eq,Show,Ord,Generic)
 
 instance NFData Address
-instance Serialize Address
 instance ToJSON Address where toJSON = lensyToJSON 2
 instance FromJSON Address where parseJSON = lensyParseJSON 2
 makeLenses ''Address
@@ -98,7 +96,6 @@ instance Default PrivateMeta where def = PrivateMeta def
 instance ToJSON PrivateMeta where toJSON = lensyToJSON 3
 instance FromJSON PrivateMeta where parseJSON = lensyParseJSON 3
 instance NFData PrivateMeta
-instance Serialize PrivateMeta
 
 -- | Allows user to specify execution parameters specific to public-chain
 -- execution, namely gas parameters, TTL, creation time, chain identifier.
@@ -140,7 +137,6 @@ instance FromJSON PublicMeta where
     <*> o .: "creationTime"
 
 instance NFData PublicMeta
-instance Serialize PublicMeta
 
 class HasPlafMeta a where
   getPrivateMeta :: a -> PrivateMeta

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -58,7 +58,6 @@ import Control.Lens hiding ((.=))
 import Control.DeepSeq
 
 import Data.ByteString (ByteString)
-import Data.Serialize as SZ
 import Data.Hashable (Hashable)
 import Data.Aeson as A
 import Data.Text (Text)
@@ -95,7 +94,6 @@ data Command a = Command
   , _cmdSigs :: ![UserSig]
   , _cmdHash :: !PactHash
   } deriving (Eq,Show,Ord,Generic,Functor,Foldable,Traversable)
-instance (Serialize a) => Serialize (Command a)
 instance (ToJSON a) => ToJSON (Command a) where
     toJSON (Command payload uSigs hsh) =
         object [ "cmd" .= payload
@@ -287,7 +285,6 @@ newtype UserSig = UserSig { _usSig :: Text }
   deriving (Eq, Ord, Show, Generic)
 
 instance NFData UserSig
-instance Serialize UserSig
 instance ToJSON UserSig where
   toJSON UserSig {..} = object [ "sig" .= _usSig ]
 instance FromJSON UserSig where
@@ -377,7 +374,7 @@ requestKeyToB16Text (RequestKey h) = hashToText h
 
 
 newtype RequestKey = RequestKey { unRequestKey :: Hash}
-  deriving (Eq, Ord, Generic, Serialize, Hashable, ParseText, FromJSON, ToJSON, ToJSONKey, NFData)
+  deriving (Eq, Ord, Generic, Hashable, ParseText, FromJSON, ToJSON, ToJSONKey, NFData)
 
 instance Show RequestKey where
   show (RequestKey rk) = show rk

--- a/src/Pact/Types/Exp.hs
+++ b/src/Pact/Types/Exp.hs
@@ -55,7 +55,6 @@ import Data.Maybe (fromMaybe)
 import GHC.Generics (Generic)
 import Data.Decimal
 import Control.DeepSeq
-import Data.Serialize (Serialize)
 import Data.String (IsString)
 import Test.QuickCheck
 
@@ -111,7 +110,6 @@ instance Arbitrary Literal where
     , genLiteralTime
     ]
 
-instance Serialize Literal
 instance NFData Literal
 
 instance SizeOf Literal where

--- a/src/Pact/Types/Gas.hs
+++ b/src/Pact/Types/Gas.hs
@@ -34,7 +34,6 @@ import Control.Lens (makeLenses,Wrapped)
 import Data.Aeson
 import Data.Text (Text, unpack)
 import Data.Aeson.Types (Parser)
-import Data.Serialize
 
 import GHC.Generics
 
@@ -57,7 +56,7 @@ parseGT0 v = parseJSON v >>= \a ->
 
 -- | API Price value, basically a newtype over `Decimal`
 newtype GasPrice = GasPrice ParsedDecimal
-  deriving (Eq,Ord,Num,Real,Fractional,RealFrac,NFData,Serialize,Generic,ToTerm,ToJSON,Pretty)
+  deriving (Eq,Ord,Num,Real,Fractional,RealFrac,NFData,Generic,ToTerm,ToJSON,Pretty)
 instance Show GasPrice where
   show (GasPrice (ParsedDecimal d)) = show d
 
@@ -170,7 +169,7 @@ instance Pretty GasArgs where
     GIntegerOpCost i j -> "GIntegerOpCost:" <> pretty i <> colon <> pretty j
 
 newtype GasLimit = GasLimit ParsedInteger
-  deriving (Eq,Ord,Num,Real,Integral,Enum,Serialize,NFData,Generic,ToTerm,ToJSON,Pretty)
+  deriving (Eq,Ord,Num,Real,Integral,Enum,NFData,Generic,ToTerm,ToJSON,Pretty)
 
 instance Show GasLimit where
   show (GasLimit (ParsedInteger i)) = show i

--- a/src/Pact/Types/Hash.hs
+++ b/src/Pact/Types/Hash.hs
@@ -28,7 +28,6 @@ module Pact.Types.Hash
 import Control.DeepSeq
 import Data.ByteString (ByteString)
 import Data.Hashable (Hashable(hashWithSalt))
-import Data.Serialize (Serialize(..))
 import Pact.Types.Pretty
 import Pact.Types.Util
 import Data.Aeson
@@ -58,7 +57,7 @@ import Crypto.Hash.Blake2Native
 -- Within Pact these are blake2b_256 but unvalidated as such,
 -- so other hash values are kosher (such as an ETH sha256, etc).
 newtype Hash = Hash { unHash :: ByteString }
-  deriving (Eq, Ord, Generic, Hashable, Serialize,SizeOf)
+  deriving (Eq, Ord, Generic, Hashable, SizeOf)
 
 instance Arbitrary Hash where
   -- TODO: add generators for other hash types
@@ -115,10 +114,6 @@ data TypedHash (h :: HashAlgo) where
 
 instance Hashable (TypedHash h) where
   hashWithSalt a h = hashWithSalt a (toUntypedHash h)
-
-instance Serialize (TypedHash h) where
-  put = put . toUntypedHash
-  get = fromUntypedHash <$> get
 
 instance Show (TypedHash h) where
   show (TypedHash h) = show $ encodeBase64UrlUnpadded h

--- a/src/Pact/Types/KeySet.hs
+++ b/src/Pact/Types/KeySet.hs
@@ -45,7 +45,6 @@ import Data.Char
 import Data.Default
 import Data.Foldable
 import Data.Maybe
-import Data.Serialize (Serialize)
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.String
@@ -69,7 +68,6 @@ newtype PublicKey = PublicKey { _pubKey :: ByteString }
 instance Arbitrary PublicKey where
   arbitrary = PublicKey <$> encodeUtf8 <$> T.pack <$> vectorOf 64 genValidPublicKeyChar
     where genValidPublicKeyChar = suchThat arbitraryASCIIChar isAlphaNum
-instance Serialize PublicKey
 instance NFData PublicKey
 instance FromJSON PublicKey where
   parseJSON = withText "PublicKey" (return . PublicKey . encodeUtf8)

--- a/src/Pact/Types/Orphans.hs
+++ b/src/Pact/Types/Orphans.hs
@@ -16,7 +16,6 @@
 --
 module Pact.Types.Orphans where
 
-import Data.Serialize
 import Data.Decimal
 import qualified Data.Aeson as A
 import Text.Trifecta.Combinators (DeltaParsing(..))
@@ -24,7 +23,6 @@ import Text.Trifecta.Delta
 import qualified Data.Attoparsec.Text as AP
 import qualified Data.Attoparsec.Internal.Types as APT
 import Data.Text (Text)
-import Data.Text.Encoding
 import Pact.Time.Internal (NominalDiffTime(..), UTCTime(..))
 import Data.Default
 import Data.Hashable
@@ -38,18 +36,6 @@ import Test.QuickCheck (Arbitrary(..))
 
 instance (Arbitrary i) => Arbitrary (DecimalRaw i) where
   arbitrary = Decimal <$> arbitrary <*> arbitrary
-
-instance (Serialize i) => Serialize (DecimalRaw i) where
-    put (Decimal p i) = put p >> put i
-    get = Decimal <$> get <*> get
-    {-# INLINE put #-}
-    {-# INLINE get #-}
-
-instance Serialize A.Value where
-    put v = put (A.encode v)
-    get = get >>= \g -> either fail return $ A.eitherDecode g
-    {-# INLINE put #-}
-    {-# INLINE get #-}
 
 instance NFData Delta
 
@@ -68,10 +54,6 @@ attoPos :: APT.Parser n APT.Pos
 attoPos = APT.Parser $ \t pos more _lose win -> win t pos more pos
 
 instance Default Text where def = ""
-instance Serialize Text where
-  put = put . encodeUtf8
-  get = decodeUtf8 <$> get
-
 ------ Bound/Scope/Var instances ------
 
 instance (A.ToJSON a, A.ToJSON b) =>

--- a/src/Pact/Types/Scheme.hs
+++ b/src/Pact/Types/Scheme.hs
@@ -15,7 +15,6 @@ module Pact.Types.Scheme
 import GHC.Generics
 import Control.DeepSeq
 import Data.Kind (Type)
-import Data.Serialize
 import Data.Aeson
 
 import Pact.Types.Util (ParseText(..))
@@ -28,7 +27,6 @@ data PPKScheme = ED25519 | ETH
 
 
 instance NFData PPKScheme
-instance Serialize PPKScheme
 instance ToJSON PPKScheme where
   toJSON ED25519 = "ED25519"
   toJSON ETH = "ETH"

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -119,7 +119,6 @@ import Data.Int (Int64)
 import Data.List
 import qualified Data.Map.Strict as M
 import Data.Maybe
-import Data.Serialize (Serialize)
 import Data.String
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -351,7 +350,7 @@ instance FromJSON g => FromJSON (Governance g) where
 -- | Newtype wrapper differentiating 'Hash'es from module hashes
 --
 newtype ModuleHash = ModuleHash { _mhHash :: Hash }
-  deriving (Eq, Ord, Show, Generic, Hashable, Serialize, AsString, Pretty, ToJSON, FromJSON, ParseText)
+  deriving (Eq, Ord, Show, Generic, Hashable, AsString, Pretty, ToJSON, FromJSON, ParseText)
   deriving newtype (NFData, SizeOf)
 
 instance Arbitrary ModuleHash where


### PR DESCRIPTION
We don't use it, and chainweb builds without it