### PR TITLE
Update direct-sqlite dependency to 2.3.27

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -197,7 +197,7 @@ library
     build-depends:
       , criterion >= 1.1.4 && < 1.6
       , cryptonite
-      , direct-sqlite == 2.3.26
+      , direct-sqlite == 2.3.27
       , http-client
       , memory
       , safe-exceptions >= 0.1.5.0 && < 0.2

--- a/project.nix
+++ b/project.nix
@@ -12,8 +12,8 @@ in {
       overrides = self: super: {
         direct-sqlite = dontCheck (self.callHackageDirect {
           pkg = "direct-sqlite";
-          ver = "2.3.26";
-          sha256 = "1kdkisj534nv5r0m3gmxy2iqgsn6y1dd881x77a87ynkx1glxfva";
+          ver = "2.3.27";
+          sha256 = "0w8wj3210h08qlws40qhidkscgsil3635zk83kdlj929rbd8khip";
         } {});
 
         # The z3 dependency needs to be conditional so pact can be a


### PR DESCRIPTION
This bump is needed for the new `chainweb-node` version. I'm unsure of how to provide it to our `pact-linux` build environment on GitLab, however.