### PR TITLE
Add `describe-namespace` native

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -175,6 +175,8 @@ Describe the namespace NS, returning a row object containing the user and admin 
 (describe-namespace 'my-namespace)
 ```
 
+Top level only: this function will fail if used in module code.
+
 
 ### distinct {#distinct}
 

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -165,6 +165,17 @@ Create a namespace called NAMESPACE where ownership and use of the namespace is 
 Top level only: this function will fail if used in module code.
 
 
+### describe-namespace {#describe-namespace}
+
+*ns*&nbsp;`string` *&rarr;*&nbsp;`object:{described-namespace}`
+
+
+Describe the namespace NS, returning a row object containing the user and admin guards of the namespace, as well as its name.
+```lisp
+(describe-namespace 'my-namespace)
+```
+
+
 ### distinct {#distinct}
 
 *values*&nbsp;`[<a>]` *&rarr;*&nbsp;`[<a>]`
@@ -448,7 +459,7 @@ Return ID if called during current pact execution, failing if not.
 Obtain current pact build version.
 ```lisp
 pact> (pact-version)
-"4.3"
+"4.3.1"
 ```
 
 Top level only: this function will fail if used in module code.
@@ -1848,7 +1859,7 @@ Retreive any accumulated events and optionally clear event state. Object returne
  *&rarr;*&nbsp;`[string]`
 
 
-Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePactEvents","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
+Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePactEvents","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNamespaceUpgrade","PreserveNsModuleInstallBug","PreserveShowDefs"]
 ```lisp
 pact> (env-exec-config ['DisableHistoryInTransactionalMode]) (env-exec-config)
 ["DisableHistoryInTransactionalMode"]

--- a/golden/gas-model/golden
+++ b/golden/gas-model/golden
@@ -486,6 +486,8 @@
   - 201
 - - (+ smallOjectMap smallOjectMap)
   - 21
+- - (describe-namespace "my-namespace")
+  - 101
 - - (define-namespace 'some-other-namespace some-loaded-keyset some-loaded-keyset)
   - 89
 - - '(define-namespace ''my-namespace some-loaded-keyset some-loaded-keyset): Defining

--- a/pact.cabal
+++ b/pact.cabal
@@ -344,6 +344,7 @@ test-suite hspec
     Blake2Spec
     KeysetSpec
     RoundTripSpec
+    PrincipalSpec
 
   if !impl(ghcjs)
     other-modules:

--- a/src-ghc/Pact/GasModel/GasTests.hs
+++ b/src-ghc/Pact/GasModel/GasTests.hs
@@ -178,22 +178,23 @@ unitTestFromDef nativeName = tests
       "read-keyset"    -> Just $ readKeysetTests nativeName
 
       -- Database native functions
-      "create-table"      -> Just $ createTableTests nativeName
-      "describe-keyset"   -> Just $ describeKeysetTests nativeName
-      "describe-module"   -> Just $ describeModuleTests nativeName
-      "describe-table"    -> Just $ describeTableTests nativeName
-      "insert"            -> Just $ insertTests nativeName
-      "keylog"            -> Just $ keylogTests nativeName
-      "keys"              -> Just $ keysTests nativeName
-      "read"              -> Just $ readTests nativeName
-      "select"            -> Just $ selectTests nativeName
-      "txids"             -> Just $ txidsTests nativeName
-      "txlog"             -> Just $ txlogTests nativeName
-      "update"            -> Just $ updateTests nativeName
-      "with-default-read" -> Just $ withDefaultReadTests nativeName
-      "with-read"         -> Just $ withReadTests nativeName
-      "write"             -> Just $ writeTests nativeName
-      "fold-db"           -> Just $ foldDBTests nativeName
+      "create-table"       -> Just $ createTableTests nativeName
+      "describe-keyset"    -> Just $ describeKeysetTests nativeName
+      "describe-module"    -> Just $ describeModuleTests nativeName
+      "describe-table"     -> Just $ describeTableTests nativeName
+      "describe-namespace" -> Just $ describeNamespaceTests nativeName
+      "insert"             -> Just $ insertTests nativeName
+      "keylog"             -> Just $ keylogTests nativeName
+      "keys"               -> Just $ keysTests nativeName
+      "read"               -> Just $ readTests nativeName
+      "select"             -> Just $ selectTests nativeName
+      "txids"              -> Just $ txidsTests nativeName
+      "txlog"              -> Just $ txlogTests nativeName
+      "update"             -> Just $ updateTests nativeName
+      "with-default-read"  -> Just $ withDefaultReadTests nativeName
+      "with-read"          -> Just $ withReadTests nativeName
+      "write"              -> Just $ writeTests nativeName
+      "fold-db"            -> Just $ foldDBTests nativeName
 
       -- Capabilities native functions
       "compose-capability"  -> Just $ composeCapabilityTests nativeName
@@ -544,6 +545,11 @@ describeKeysetTests = defGasUnitTests allExprs
       defPactExpression [text| (describe-keyset "$sampleLoadedKeysetName") |]
     allExprs = describeKeysetExpr :| []
 
+describeNamespaceTests :: NativeDefName -> GasUnitTests
+describeNamespaceTests = defGasUnitTests $ pure descNsTestExpr
+  where
+    descNsTestExpr = defPactExpression
+      [text| (describe-namespace "$sampleNamespaceName") |]
 
 createTableTests :: NativeDefName -> GasUnitTests
 createTableTests = defGasUnitTests allExprs

--- a/src-tool/Pact/Analyze/Translate.hs
+++ b/src-tool/Pact/Analyze/Translate.hs
@@ -1716,6 +1716,11 @@ translateNode astNode = withAstContext astNode $ case astNode of
     Some SStr _ -> shimNative' node fn [] "principal" a'
     _ -> unexpectedNode astNode
 
+  AST_NFun node fn@"describe-namespace" [a] -> translateNode a >>= \case
+    -- assuming we have a namespace name as input, yield an empty object
+    Some SStr _ -> shimNative astNode node fn []
+    _ -> unexpectedNode astNode
+
   AST_NFun node fn as -> shimNative astNode node fn as
 
   _ -> unexpectedNode astNode

--- a/src/Pact/Gas/Table.hs
+++ b/src/Pact/Gas/Table.hs
@@ -202,6 +202,7 @@ defaultGasTable =
   ,("describe-module", 100)
   ,("describe-table", 100)
   ,("list-modules", 100)
+  ,("describe-namespace",100)
 
   -- History, massive tx penalty
   ,("keylog", 100000)

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -51,6 +51,8 @@ module Pact.Native
     , atDef
     , chainDataSchema
     , cdChainId, cdBlockHeight, cdBlockTime, cdSender, cdGasLimit, cdGasPrice
+    , describeNamespaceSchema
+    , dnUserGuard, dnAdminGuard, dnNamespaceName
     , cdPrevBlockHash
     ) where
 
@@ -384,6 +386,56 @@ toNamespacePactValue info (Namespace name userg adming) = do
 fromNamespacePactValue :: Namespace PactValue -> Namespace (Term Name)
 fromNamespacePactValue (Namespace n userg adming) =
   Namespace n (fromGuardPactValue userg) (fromGuardPactValue adming)
+
+dnUserGuard :: FieldKey
+dnUserGuard = "user-guard"
+
+dnAdminGuard :: FieldKey
+dnAdminGuard = "admin-guard"
+
+dnNamespaceName :: FieldKey
+dnNamespaceName = "namespace-name"
+
+describeNamespaceSchema :: NativeDef
+describeNamespaceSchema = defSchema "described-namespace"
+  "Schema type for data returned from 'describe-namespace'."
+  [ (dnUserGuard, tTyGuard Nothing)
+  , (dnAdminGuard, tTyGuard Nothing)
+  , (dnNamespaceName, tTyString)
+  ]
+
+describeNamespaceDef :: NativeDef
+describeNamespaceDef = defGasRNative "describe-namespace" describeNamespace
+  (funType (tTyObject dnTy) [("ns", tTyString)])
+  [LitExample "(describe-namespace 'my-namespace)"]
+  "Describe the namespace NS, returning a row object containing \
+  \the user and admin guards of the namespace, as well as its name."
+  where
+    dnTy = TyUser (snd describeNamespaceSchema)
+
+    describeNamespace :: GasRNativeFun e
+    describeNamespace g0 i as = case as of
+      [TLitString nsn] -> go g0 i nsn
+      _ -> argsError i as
+
+    go g0 fi n = do
+      let i = getInfo fi
+
+      mNs <- readRow i Namespaces $ NamespaceName n
+
+      case mNs of
+        Just ns@(Namespace nsn user admin) -> do
+          let guardTermOf g = TGuard (fromPactValue <$> g) def
+
+          computeGas' g0 fi (GPostRead (ReadNamespace ns)) $
+            pure $ toTObject TyAny def
+              [ (dnUserGuard, guardTermOf user)
+              , (dnAdminGuard, guardTermOf admin)
+              , (dnNamespaceName, toTerm $ renderCompactText nsn)
+              ]
+
+        Nothing -> evalError i $ "Namespace not defined: " <> pretty n
+
 
 
 defineNamespaceDef :: NativeDef
@@ -777,6 +829,7 @@ langDefs =
     ,intToStrDef
     ,hashDef
     ,defineNamespaceDef
+    ,describeNamespaceDef
     ,namespaceDef
     ,chainDataDef
     ,chainDataSchema

--- a/tests/pact/namespaces.repl
+++ b/tests/pact/namespaces.repl
@@ -16,6 +16,22 @@
 (define-namespace 'alice (read-keyset 'alice-keys) (read-keyset 'alice-keys))
 (define-namespace 'bob (read-keyset 'bob-keys) (read-keyset 'bob-keys))
 
+(expect
+  "describe-namespace describes namespaces correctly - alice"
+  { "admin-guard": (read-keyset 'alice-keys)
+  , "namespace-name": "alice"
+  , "user-guard": (read-keyset 'alice-keys)
+  }
+  (describe-namespace 'alice))
+
+(expect
+  "describe-namespace describes namespaces correctly - bob"
+  { "admin-guard": (read-keyset 'bob-keys)
+  , "namespace-name": "bob"
+  , "user-guard": (read-keyset 'bob-keys)
+  }
+  (describe-namespace 'bob))
+
 ; Set tx namespace to 'alice'
 (namespace 'alice)
 


### PR DESCRIPTION
see: #1009 

Adds the `describe-namespace` native, along with tests, analysis shims, and gas regressions.
