### PR TITLE
Make Parsed._pLength strict

### DIFF
--- a/src/Pact/Parse.hs
+++ b/src/Pact/Parse.hs
@@ -64,7 +64,7 @@ expr = do
   let inf = do
         end <- position
         let len = bytes end - bytes delt
-        return $ Parsed delt (fromIntegral len)
+        return $! Parsed delt (fromIntegral len)
       separator t s = symbol t >> (ESeparator . SeparatorExp s <$> inf)
   msum
     [ TF.try (ELiteral <$> (LiteralExp <$> token number <*> inf)) <?> "number"

--- a/src/Pact/Types/Info.hs
+++ b/src/Pact/Types/Info.hs
@@ -56,7 +56,7 @@ import Pact.Types.Util
 -- | Code location, length from parsing.
 data Parsed = Parsed {
   _pDelta :: Delta,
-  _pLength :: Int
+  _pLength :: !Int
   } deriving (Eq,Show,Ord,Generic)
 
 instance Arbitrary Parsed where


### PR DESCRIPTION
`Parsed` showed up in some node profiling data and I noticed the `Int` is lazy. If we make it strict we can unbox it into `Parsed`, using a bit less memory, and as a bonus stop closing over so many `Trifecta.Delta`'s which the thunks hang onto.