### PR TITLE
Repl doc support for `with-capability`

### DIFF
--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -197,7 +197,7 @@ parsedCompileEval src r = do
 
 
 handleCompile :: String -> Exp Parsed -> (Term Name -> Repl (Either String a)) -> Repl (Either String a)
-handleCompile src exp a = do
+handleCompile src exp a =
     case compile (mkStringInfo src) exp of
       Right t -> a t
       -- special case for `with-capability` bareword due to


### PR DESCRIPTION
Janky, but it gets us what we want: 

```
pact> with-capability    
native `with-capability`
  
  Specifies and requests grant of _acquired_ CAPABILITY which is an application
  of a 'defcap' production. Given the unique token specified by this
  application, ensure that the token is granted in the environment during
  execution of BODY. 'with-capability' can only be called in the same module
  that declares the corresponding 'defcap', otherwise module-admin rights are
  required. If token is not present, the CAPABILITY is evaluated, with
  successful completion resulting in the installation/granting of the token,
  which will then be revoked upon completion of BODY. Nested 'with-capability'
  calls for the same token will detect the presence of the token, and will not
  re-apply CAPABILITY, but simply execute BODY. 'with-capability' cannot be
  called from within an evaluating defcap. Acquire of a managed capability
  results in emission of the equivalent event.
  
  Type:
  capability: -> bool body:[*] -> <a>
  
  Examples:
  (with-capability (UPDATE-USERS id) (update users id { salary: new-salary }))
pact> 

```