### PR TITLE
Update fold-db example to be syntactically correct

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -767,7 +767,7 @@ Select rows from TABLE using QRY as a predicate with both key and value, and the
 ```lisp
 (let* 
  ((qry (lambda (k obj) true)) ;; select all rows
-  (f (lambda (x) [(at 'firstName x), (at 'b x)]))
+  (f (lambda (k obj) [(at 'firstName obj), (at 'b obj)]))
  )
  (fold-db people (qry) (f))
 )


### PR DESCRIPTION
Turned 
`(f (lambda (x) [(at 'firstName x), (at 'b x)]))`
into
`(f (lambda (k obj) [(at 'firstName obj), (at 'b obj)]))`

Because the consumer must accept two arguments as described in the doc string, the key and the object (Row).