### PR TITLE
docs: Fix invalid page link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Build Status](https://travis-ci.org/kadena-io/pact.svg?branch=master)](https://travis-ci.org/kadena-io/pact)
 
 
-[Pact](http://kadena.io/pact) is an open-source, Turing-**in**complete smart contract language that has been purpose-built with blockchains first in mind. Pact focuses on facilitating transactional logic with the optimal mix of functionality in authorization, data management, and workflow.
+[Pact](http://kadena.io/build) is an open-source, Turing-**in**complete smart contract language that has been purpose-built with blockchains first in mind. Pact focuses on facilitating transactional logic with the optimal mix of functionality in authorization, data management, and workflow.
 
 Read the whitepaper:
 


### PR DESCRIPTION
Related Issue
---

Invalid page link in README #1032

Changes
---

Invalid page link corrected to http://kadena.io/build.