### PR TITLE
Updated expect-failure docs

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -2004,10 +2004,11 @@ pact> (expect "Sanity prevails." 4 (+ 2 2))
 
 
 Evaluate EXP and succeed only if it throws an error.
+When err is provided, it will succeed if err is contained within the thrown error.
 ```lisp
 pact> (expect-failure "Enforce fails on false" (enforce false "Expected error"))
 "Expect failure: success: Enforce fails on false"
-pact> (expect-failure "Enforce fails with message" "Expected error" (enforce false "Expected error"))
+pact> (expect-failure "Enforce fails with message" "Expected error" (enforce false "Behold, an Expected error!"))
 "Expect failure: success: Enforce fails with message"
 ```
 


### PR DESCRIPTION
`expect-failure` didn't fully describe how it worked: It checks if err is contained in the thrown error. So I added that. It's nice to have that info in there.