### PR TITLE
Fix Test Tree Creation

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1861,7 +1861,7 @@ Retreive any accumulated events and optionally clear event state. Object returne
  *&rarr;*&nbsp;`[string]`
 
 
-Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePactEvents","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
+Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisableNewTrans","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePactEvents","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
 ```lisp
 pact> (env-exec-config ['DisableHistoryInTransactionalMode]) (env-exec-config)
 ["DisableHistoryInTransactionalMode"]

--- a/pact.cabal
+++ b/pact.cabal
@@ -408,6 +408,7 @@ test-suite hspec
         TypecheckSpec
         SizeOfSpec
         PactCLISpec
+        Utils
 
       build-depends:
         , Decimal
@@ -421,7 +422,6 @@ test-suite hspec
         , intervals
         , mmorph
         , neat-interpolation
-        , prettyprinter
         , sbv
         , servant-client
         , yaml

--- a/pact.cabal
+++ b/pact.cabal
@@ -425,4 +425,5 @@ test-suite hspec
         , neat-interpolation
         , sbv
         , servant-client
+        , temporary >= 1.3
         , yaml

--- a/pact.cabal
+++ b/pact.cabal
@@ -361,6 +361,7 @@ test-suite hspec
     , containers
     , data-default
     , hspec
+    , hspec-core
     , pact
     , unordered-containers
 

--- a/src-ghc/Pact/GasModel/Types.hs
+++ b/src-ghc/Pact/GasModel/Types.hs
@@ -38,10 +38,13 @@ import NeatInterpolation (text)
 import System.Directory (removeFile)
 
 
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Base16 as B16
 import qualified Data.HashMap.Strict as HM
 import qualified Data.List.NonEmpty  as NEL
 import qualified Pact.Persist.SQLite as PSL
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 
 
 import Pact.Eval (eval)
@@ -153,7 +156,7 @@ createGasUnitTests sqliteUpdate mockUpdate pactExprs funName =
   where
     createTest expr =
       GasTest funName expr
-      (sqliteUpdate defSqliteGasSetup,
+      (sqliteUpdate (defSqliteGasSetup funName),
        mockUpdate defMockGasSetup)
 
 
@@ -163,15 +166,17 @@ defGasTest expr funName =
   GasTest
   funName
   expr
-  (defSqliteGasSetup, defMockGasSetup)
+  (defSqliteGasSetup funName, defMockGasSetup)
 
-defSqliteGasSetup :: GasSetup SQLiteDb
-defSqliteGasSetup =
+defSqliteGasSetup :: NativeDefName -> GasSetup SQLiteDb
+defSqliteGasSetup n =
   GasSetup
-  defSqliteBackend
+  (defSqliteBackend encName)
   defEvalState
   "SQLiteDb"
-  sqliteSetupCleanup
+  (sqliteSetupCleanup encName)
+ where
+  encName = B8.unpack $ B16.encode $ T.encodeUtf8 $ asString n
 
 defMockGasSetup :: GasSetup ()
 defMockGasSetup =
@@ -257,13 +262,13 @@ defMockDb = mockdb
 
 -- SQLite Db
 --
-sqliteFile :: String
-sqliteFile = "gasmodel.sqlite"
+sqliteFile :: Maybe String -> String
+sqliteFile s = "gasmodel" <> maybe "" ('.':) s <> ".sqlite"
 
-defSqliteBackend :: IO (EvalEnv SQLiteDb)
-defSqliteBackend = do
+defSqliteBackend :: String -> IO (EvalEnv SQLiteDb)
+defSqliteBackend name = do
   sqliteDb <- mkSQLiteEnv (newLogger neverLog "")
-              True (SQLiteConfig sqliteFile fastNoJournalPragmas) neverLog
+              True (SQLiteConfig dbFileName fastNoJournalPragmas) neverLog
   initSchema sqliteDb
   state <- defEvalState
   env <- defEvalEnv sqliteDb
@@ -279,16 +284,20 @@ defSqliteBackend = do
         |]
   setupTerms <- compileCode setupExprs
   (res,_) <- runEval' state env $ mapM eval setupTerms
-  _ <- onException (eitherDie "Sqlite setup expressions" res) (sqliteSetupCleanup (env,state))
+  _ <- onException (eitherDie "Sqlite setup expressions" res) (sqliteSetupCleanup name (env,state))
   return env
+ where
+  dbFileName = sqliteFile $ Just name
 
 
 -- | Default GasSetup cleanup
 mockSetupCleanup :: (EvalEnv (), EvalState) -> IO ()
 mockSetupCleanup (_, _) = return ()
 
-sqliteSetupCleanup :: (EvalEnv SQLiteDb, EvalState) -> IO ()
-sqliteSetupCleanup (env, _) = do
+sqliteSetupCleanup :: String -> (EvalEnv SQLiteDb, EvalState) -> IO ()
+sqliteSetupCleanup name (env, _) = do
   c <- readMVar $ _eePactDbVar env
   _ <- PSL.closeSQLite $ _db c
-  removeFile sqliteFile
+  removeFile dbFileName
+ where
+  dbFileName = sqliteFile $ Just name

--- a/src-ghc/Pact/Server/Test.hs
+++ b/src-ghc/Pact/Server/Test.hs
@@ -12,7 +12,7 @@ module Pact.Server.Test
   , testDir
   , serverBaseUrl
   ) where
-import Pact.Server.Server (serve)
+import Pact.Server.Server (serveLocal)
 import Pact.Server.API
 import Pact.Types.Crypto as Crypto
 
@@ -62,7 +62,7 @@ startServer configFile = startServer' configFile noSPVSupport
 
 startServer' :: FilePath -> SPVSupport -> IO (Async ())
 startServer' configFile spv = do
-  asyncServer <- async $ serve configFile spv
+  asyncServer <- async $ serveLocal configFile spv
   waitUntilStarted 0
   return asyncServer
 

--- a/src-tool/Pact/Analyze/Remote/Server.hs
+++ b/src-tool/Pact/Analyze/Remote/Server.hs
@@ -9,6 +9,7 @@
 module Pact.Analyze.Remote.Server
   ( verifyHandler
   , runServantServer
+  , runServantServerLocal
   ) where
 
 import           Control.Lens               ((^.), (.~), (&))
@@ -23,7 +24,7 @@ import qualified Data.HashMap.Strict        as HM
 import           Data.String                (IsString, fromString)
 import qualified Data.Text                  as T
 import           Data.Void                  (Void)
-import           Network.Wai.Handler.Warp   (run)
+import           Network.Wai.Handler.Warp   (runSettings, Settings, defaultSettings, setPort, setHost)
 import           Servant
 import qualified Text.Megaparsec            as MP
 import qualified Text.Megaparsec.Char       as MP
@@ -40,8 +41,16 @@ type VerifyAPI = "verify" :> ReqBody '[JSON] Request :> Post '[JSON] Response
 verifyAPI :: Proxy VerifyAPI
 verifyAPI = Proxy
 
+runServantServerLocal :: Int -> IO ()
+runServantServerLocal port = runServantServerSettings $ defaultSettings
+    & setPort port
+    & setHost "127.0.0.1"
+
 runServantServer :: Int -> IO ()
-runServantServer port = run port $ serve verifyAPI verifyHandler
+runServantServer port = runServantServerSettings $ setPort port defaultSettings
+
+runServantServerSettings :: Settings -> IO ()
+runServantServerSettings settings = runSettings settings $ serve verifyAPI verifyHandler
 
 verifyHandler :: Request -> Handler Response
 verifyHandler req = do

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -1261,21 +1261,20 @@ spec = describe "analyze" $ do
     expectCapGovPass code $ Satisfiable Abort'
 
   describe "property language can describe whether cap-based governance passes" $ do
-      res <- runIO $ runVerification $
-        [text|
-          (begin-tx)
-          (module test GOV
-              (defcap GOV ()
-                true)
+      it "passes in-code checks" $ do
+        res <- runVerification
+          [text|
+            (begin-tx)
+            (module test GOV
+                (defcap GOV ()
+                  true)
 
-              (defun test:bool ()
-                @model [(property governance-passes)]
-                (enforce-guard (create-module-guard "governance")))
-            )
-          (commit-tx)
-        |]
-
-      it "passes in-code checks" $
+                (defun test:bool ()
+                  @model [(property governance-passes)]
+                  (enforce-guard (create-module-guard "governance")))
+              )
+            (commit-tx)
+          |]
         handlePositiveTestResult res
 
   describe "property language can describe whether ks-based governance passes without mentioning the keyset" $ do
@@ -1906,48 +1905,49 @@ spec = describe "analyze" $ do
                 (update accounts to   { "balance": (+ to-bal amount) })))
           |]
 
-    eModuleData <- runIO $ compile $ wrapNoTable code
-    case eModuleData of
-      Left err -> it "failed to compile" $ expectationFailure (show err)
-      Right moduleData -> do
-        results <- runIO $
-          verifyModule mempty (HM.fromList [("test", moduleData)]) moduleData
-        case results of
-          Left failure -> it "unexpectedly failed verification" $
-            expectationFailure $ show failure
-          Right (ModuleChecks propResults _stepResults invariantResults _) -> do
-            it "should have no prop results" $
-              propResults `shouldBe` HM.singleton "test" []
+    let prep = do
+          eModuleData <- compile $ wrapNoTable code
+          case eModuleData of
+            Left err -> error $ "failed to compile: " <> show err
+            Right moduleData -> do
+              results <- verifyModule mempty (HM.fromList [("test", moduleData)]) moduleData
+              case results of
+                Left failure -> error $ "unexpectedly failed verification: " <> show failure
+                Right x -> return x
 
-            case invariantResults ^.. ix "test" . ix "accounts" . ix 0 . _Left of
-              -- see https://github.com/Z3Prover/z3/issues/1819
-              [CheckFailure _ (SmtFailure (SortMismatch msg))] ->
-                it "...nevermind..." $ pendingWith msg
-              [CheckFailure _ (SmtFailure (Invalid model))] -> do
-                let (Model args ModelTags{_mtWrites} ksProvs _) = model
+    beforeAll prep $ do
+      it "should have no prop results" $ \(ModuleChecks propResults _ _ _) ->
+        propResults `shouldBe` HM.singleton "test" []
 
-                it "should have a negative amount" $
-                  case find (\(Located _ (Unmunged nm, _)) -> nm == "amount") $ args ^.. traverse of
-                    Just (Located _ (_, (_, AVal _prov amount))) ->
-                      (SBV amount :: SBV Decimal) `shouldSatisfy` (`isConcretely` (< 0))
-                    _ -> fail "Failed pattern match"
+      it "has valid invariantResults" $ \(ModuleChecks _ _ invariantResults _) -> do
+        case invariantResults ^.. ix "test" . ix "accounts" . ix 0 . _Left of
+          -- see https://github.com/Z3Prover/z3/issues/1819
+          [CheckFailure _ (SmtFailure (SortMismatch msg))] ->
+            pendingWith $ "... nevermind:" <> msg
+          [CheckFailure _ (SmtFailure (Invalid model))] -> do
+            let (Model args ModelTags{_mtWrites} ksProvs _) = model
 
-                let negativeWrite (UObject m) = case m Map.! "balance" of
-                      (_bal, AVal _ sval) -> (SBV sval :: SBV Decimal) `isConcretely` (< 0)
-                      _                   -> False
+            -- it "should have a negative amount"
+            case find (\(Located _ (Unmunged nm, _)) -> nm == "amount") $ args ^.. traverse of
+             Just (Located _ (_, (_, AVal _prov amount))) ->
+               (SBV amount :: SBV Decimal) `shouldSatisfy` (`isConcretely` (< 0))
+             _ -> fail "Failed pattern match"
 
-                balanceWrite <- pure $ find negativeWrite
-                  $ _mtWrites ^.. traverse . located . accObject
+            let negativeWrite (UObject m) = case m Map.! "balance" of
+                  (_bal, AVal _ sval) -> (SBV sval :: SBV Decimal) `isConcretely` (< 0)
+                  _                   -> False
 
-                it "should have a negative write" $
-                  balanceWrite `shouldSatisfy` isJust
+                balanceWrite = find negativeWrite $ _mtWrites ^.. traverse . located . accObject
 
-                it "should have no keyset provenance" $ do
-                  ksProvs `shouldBe` Map.empty
+            -- it "should have a negative write"
+            balanceWrite `shouldSatisfy` isJust
 
-              [] -> runIO $ expectationFailure "expected a CheckFailure corresponding to a violation of the balance invariant due to updating with a negative amount"
+            -- it "should have no keyset provenance"
+            ksProvs `shouldBe` Map.empty
 
-              other -> runIO $ expectationFailure $ show other
+          [] -> expectationFailure "expected a CheckFailure corresponding to a violation of the balance invariant due to updating with a negative amount"
+
+          other -> expectationFailure $ show other
 
   describe "cell-delta.integer" $ do
     let code =
@@ -4201,27 +4201,29 @@ spec = describe "analyze" $ do
       "(defun test:bool (x:integer) (enforce (> x 0) \"\"))"
 
   describe "scope-checking interfaces" $ do
-    res <- runIO $ checkInterface [text|
-      (interface coin-sig
-        (defun transfer:string (sender:string receiver:string receiver-guard:guard amount:decimal)
-          @model [ (property (> amount 0.0))
-                   (property (not (= sender reciever)))
-                 ]
-          )
-      )
-      |]
-    it "flags reciever != receiver" $ isJust res
+    it "flags reciever != receiver" $ do
+      res <- checkInterface [text|
+        (interface coin-sig
+          (defun transfer:string (sender:string receiver:string receiver-guard:guard amount:decimal)
+            @model [ (property (> amount 0.0))
+                     (property (not (= sender reciever)))
+                   ]
+            )
+        )
+        |]
+      res `shouldSatisfy` isJust
 
-    res' <- runIO $ checkInterface [text|
-      (interface coin-sig
-        (defun transfer:string (sender:string receiver:string receiver-guard:guard amount:decimal)
-          @model [ (property (> amount 0.0))
-                   (property (not (= sender receiver)))
-                 ]
-          )
-      )
-      |]
-    it "checks when spelled correctly" $ isNothing res'
+    it "checks when spelled correctly" $ do
+      res' <- checkInterface [text|
+        (interface coin-sig
+          (defun transfer:string (sender:string receiver:string receiver-guard:guard amount:decimal)
+            @model [ (property (> amount 0.0))
+                     (property (not (= sender receiver)))
+                   ]
+            )
+        )
+        |]
+      res' `shouldSatisfy` isNothing
 
   describe "vacuous property produces error" $ do
     expectFalsifiedMessage [text|

--- a/tests/ClientSpec.hs
+++ b/tests/ClientSpec.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedLists   #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes       #-}
 
 module ClientSpec (spec) where
 
 import Data.Aeson
 import Data.Default (def)
 import Test.Hspec
-import qualified Network.HTTP.Client as HTTP
 import qualified Control.Exception as Exception
 
 import Pact.ApiReq
@@ -21,6 +19,8 @@ import Pact.Server.Test
 import Servant.Client
 import Pact.Types.Runtime
 import Pact.Types.PactValue
+
+import Utils
 
 #if ! MIN_VERSION_servant_client(0,16,0)
 type ClientError = ServantError
@@ -51,60 +51,56 @@ simpleServerCmdWithPactErr = do
   mkExec  "(+ 1 2 3)" Null def [(simpleKeys,[])] Nothing (Just "test1")
 
 spec :: Spec
-spec = describe "Servant API client tests" $ do
-  mgr <- runIO $ HTTP.newManager HTTP.defaultManagerSettings
-  url <- runIO $ parseBaseUrl _serverPath
-  let clientEnv = mkClientEnv mgr url
-  -- it "incorrectly runs a simple command privately" $ do
-  --   cmd <- simpleServerCmd
-  --   res <- runClientM (private (SubmitBatch [cmd])) clientEnv
-  --   let expt = Right (ApiFailure "Send private: payload must have address")
-  --   res `shouldBe` expt
-  it "correctly runs a simple command locally" $ do
-    cmd <- simpleServerCmd
-    res <- bracket $! do
-      r <- runClientM (localClient cmd) clientEnv
-      return r
-    let cmdPactResult = (PactResult . Right . PLiteral . LDecimal) 3
-    (_crResult <$> res) `shouldBe` (Right cmdPactResult)
+spec = describe "Servant API client tests" $
+  before mkClient $ do
+    -- it "incorrectly runs a simple command privately" $ do
+    --   cmd <- simpleServerCmd
+    --   res <- runClientM (private (SubmitBatch [cmd])) clientEnv
+    --   let expt = Right (ApiFailure "Send private: payload must have address")
+    --   res `shouldBe` expt
+    it "correctly runs a simple command locally" $ \clientEnv -> do
+      cmd <- simpleServerCmd
+      res <- bracket $! runClientM (localClient cmd) clientEnv
+      let cmdPactResult = (PactResult . Right . PLiteral . LDecimal) 3
+      (_crResult <$> res) `shouldBe` Right cmdPactResult
 
-  it "correctly runs a simple command with pact error locally" $ do
-    cmd <- simpleServerCmdWithPactErr
-    res <- bracket $! do
-      r <- runClientM (localClient cmd) clientEnv
-      return r
-    (_crResult <$> res) `shouldSatisfy` (failWith ArgsError)
+    it "correctly runs a simple command with pact error locally" $ \clientEnv -> do
+      cmd <- simpleServerCmdWithPactErr
+      res <- bracket $! runClientM (localClient cmd) clientEnv
+      (_crResult <$> res) `shouldSatisfy` failWith ArgsError
 
-  it "correctly runs a simple command publicly and listens to the result" $ do
-    cmd <- simpleServerCmd
-    let rk = cmdToRequestKey cmd
-    (res,res') <- bracket $! do
-      !res <- runClientM (sendClient (SubmitBatch [cmd])) clientEnv
-      !res' <- runClientM (listenClient (ListenerRequest rk)) clientEnv
-      -- print (res,res')
-      return (res,res')
-    res `shouldBe` (Right (RequestKeys [rk]))
-    let cmdData = (PactResult . Right . PLiteral . LDecimal) 3
-    case res' of
-      Left _ -> expectationFailure "client request failed"
-      Right r -> case r of
-        ListenTimeout _ -> expectationFailure "timeout"
-        ListenResponse lr -> _crResult lr `shouldBe` cmdData
+    it "correctly runs a simple command publicly and listens to the result" $ \clientEnv -> do
+      cmd <- simpleServerCmd
+      let rk = cmdToRequestKey cmd
+      (res,res') <- bracket $! do
+        !res <- runClientM (sendClient (SubmitBatch [cmd])) clientEnv
+        !res' <- runClientM (listenClient (ListenerRequest rk)) clientEnv
+        -- print (res,res')
+        return (res,res')
+      res `shouldBe` Right (RequestKeys [rk])
+      let cmdData = (PactResult . Right . PLiteral . LDecimal) 3
+      case res' of
+        Left _ -> expectationFailure "client request failed"
+        Right r -> case r of
+          ListenTimeout _ -> expectationFailure "timeout"
+          ListenResponse lr -> _crResult lr `shouldBe` cmdData
 
-  it "correctly runs a simple command with pact error publicly and listens to the result" $ do
-    cmd <- simpleServerCmdWithPactErr
-    let rk = cmdToRequestKey cmd
-    (res,res') <- bracket $! do
-      !res <- runClientM (sendClient (SubmitBatch [cmd])) clientEnv
-      !res' <- runClientM (listenClient (ListenerRequest rk)) clientEnv
-      -- print (res,res')
-      return (res,res')
-    res `shouldBe` (Right (RequestKeys [rk]))
-    case res' of
-      Left _ -> expectationFailure "client request failed"
-      Right r -> case r of
-        ListenTimeout _ -> expectationFailure "timeout"
-        ListenResponse lr -> (Right $ _crResult lr) `shouldSatisfy` (failWith ArgsError)
+    it "correctly runs a simple command with pact error publicly and listens to the result" $ \clientEnv -> do
+      cmd <- simpleServerCmdWithPactErr
+      let rk = cmdToRequestKey cmd
+      (res,res') <- bracket $! do
+        !res <- runClientM (sendClient (SubmitBatch [cmd])) clientEnv
+        !res' <- runClientM (listenClient (ListenerRequest rk)) clientEnv
+        -- print (res,res')
+        return (res,res')
+      res `shouldBe` Right (RequestKeys [rk])
+      case res' of
+        Left _ -> expectationFailure "client request failed"
+        Right r -> case r of
+          ListenTimeout _ -> expectationFailure "timeout"
+          ListenResponse lr -> Right (_crResult lr) `shouldSatisfy` failWith ArgsError
+ where
+  mkClient = mkClientEnv testMgr <$> parseBaseUrl _serverPath
 
 
 failWith :: PactErrorType -> Either ClientError PactResult -> Bool

--- a/tests/DocgenSpec.hs
+++ b/tests/DocgenSpec.hs
@@ -4,4 +4,4 @@ import qualified Pact.Docgen as Docgen
 import           Test.Hspec
 
 spec :: Spec
-spec = runIO Docgen.main
+spec = it "runs Docgen.main"  Docgen.main

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -20,8 +20,6 @@ import qualified Data.List.NonEmpty as NEL
 import Data.Text (Text, unpack)
 import qualified Data.Text as T
 import NeatInterpolation (text)
-import Network.HTTP.Client (Manager)
-import qualified Network.HTTP.Client as HTTP
 import Prelude hiding (concat)
 import Servant.Client
 import System.Environment (withArgs)
@@ -41,6 +39,8 @@ import Pact.Types.Pretty
 import Pact.Types.Runtime
 import Pact.Types.SPV
 
+import Utils
+
 #if ! MIN_VERSION_servant_client(0,16,0)
 type ClientError = ServantError
 #endif
@@ -49,27 +49,21 @@ type ClientError = ServantError
 
 spec :: Spec
 spec = describe "pacts in dev server" $ do
-  mgr <- runIO $ HTTP.newManager HTTP.defaultManagerSettings
-  describe "testPactContinuation" $ testPactContinuation mgr
-  describe "testPactRollback" $ testPactRollback mgr
-  describe "testPactYield" $ testPactYield mgr
-  describe "testTwoPartyEscrow" $ testTwoPartyEscrow mgr
-  describe "testOldNestedPacts" $ testOldNestedPacts mgr
-  describe "testManagedCaps" $ testManagedCaps mgr
-  describe "testElideModRefEvents" $ testElideModRefEvents mgr
-  describe "testNestedPactContinuation" $ testNestedPactContinuation mgr
-  describe "testNestedPactYield" $ testNestedPactYield mgr
+  describe "testPactContinuation" testPactContinuation
+  describe "testPactRollback" testPactRollback
+  describe "testPactYield" testPactYield
+  describe "testTwoPartyEscrow" testTwoPartyEscrow
+  describe "testOldNestedPacts" testOldNestedPacts
+  describe "testManagedCaps" testManagedCaps
+  describe "testElideModRefEvents" testElideModRefEvents
+  describe "testNestedPactContinuation" testNestedPactContinuation
+  describe "testNestedPactYield" testNestedPactYield
 
-_runOne :: (HTTP.Manager -> Spec) -> Spec
-_runOne test = do
-  mgr <- runIO $ HTTP.newManager HTTP.defaultManagerSettings
-  test mgr
-
-testElideModRefEvents :: HTTP.Manager -> Spec
-testElideModRefEvents mgr = before_ flushDb $ after_ flushDb $ do
+testElideModRefEvents :: Spec
+testElideModRefEvents = before_ flushDb $ after_ flushDb $ do
   it "elides modref infos" $ do
     cmd <- mkExec code Null def [] Nothing Nothing
-    results <- runAll' mgr [cmd] noSPVSupport testConfigFilePath
+    results <- runAll' [cmd] noSPVSupport testConfigFilePath
     runResults results $ do
       shouldMatch cmd $ ExpectResult $ \cr ->
         encode (_crEvents cr) `shouldSatisfy`
@@ -77,7 +71,7 @@ testElideModRefEvents mgr = before_ flushDb $ after_ flushDb $ do
 
   it "doesn't elide on backcompat" $ do
     cmd <- mkExec code Null def [] Nothing Nothing
-    results <- runAll' mgr [cmd] noSPVSupport backCompatConfig
+    results <- runAll' [cmd] noSPVSupport backCompatConfig
     runResults results $ do
       shouldMatch cmd $ ExpectResult $ \cr ->
         encode (_crEvents cr) `shouldSatisfy`
@@ -111,8 +105,8 @@ mkModuleHash :: Text -> IO ModuleHash
 mkModuleHash =
   either (fail . show) (return . ModuleHash . Hash) . parseB64UrlUnpaddedText'
 
-testManagedCaps :: HTTP.Manager -> Spec
-testManagedCaps mgr = before_ flushDb $ after_ flushDb $
+testManagedCaps :: Spec
+testManagedCaps = before_ flushDb $ after_ flushDb $
   it "exercises managed PAY cap" $ do
     let setupPath = testDir ++ "cont-scripts/setup-"
         testPath = testDir ++ "cont-scripts/managed-"
@@ -123,7 +117,7 @@ testManagedCaps mgr = before_ flushDb $ after_ flushDb $
     (_, managedPay) <- mkApiReq (testPath ++ "01-pay.yaml")
     (_, managedPayFails) <- mkApiReq (testPath ++ "02-pay-fails.yaml")
     let allCmds = [sysModuleCmd,acctModuleCmd,createAcctCmd,managedPay,managedPayFails]
-    allResults <- runAll mgr allCmds
+    allResults <- runAll allCmds
 
     mhash <- mkModuleHash "HniQBJ-NUJan20k4t6MiqpzhqkSsKmIzN5ef76pcLCU"
 
@@ -144,15 +138,15 @@ testManagedCaps mgr = before_ flushDb $ after_ flushDb $
 _runArgs :: String -> IO ()
 _runArgs args = withArgs (words args) $ hspec spec
 
-testOldNestedPacts :: HTTP.Manager -> Spec
-testOldNestedPacts mgr = before_ flushDb $ after_ flushDb $
+testOldNestedPacts :: Spec
+testOldNestedPacts = before_ flushDb $ after_ flushDb $
   it "throws error when multiple defpact executions occur in same transaction" $ do
     adminKeys <- genKeys
     let makeExecCmdWith = makeExecCmd adminKeys
 
     moduleCmd <- makeExecCmdWith (threeStepPactCode "nestedPact")
     nestedExecPactCmd <- makeExecCmdWith ("(nestedPact.tester)" <> " (nestedPact.tester)")
-    allResults <- runAll mgr [moduleCmd, nestedExecPactCmd]
+    allResults <- runAll [moduleCmd, nestedExecPactCmd]
 
     runResults allResults $ do
       moduleCmd `succeedsWith`  Nothing
@@ -161,70 +155,70 @@ testOldNestedPacts mgr = before_ flushDb $ after_ flushDb $
 
 -- CONTINUATIONS TESTS
 
-testPactContinuation :: HTTP.Manager -> Spec
-testPactContinuation mgr = before_ flushDb $ after_ flushDb $ do
+testPactContinuation :: Spec
+testPactContinuation = before_ flushDb $ after_ flushDb $ do
   it "sends (+ 1 2) command to locally running dev server" $ do
     let cmdData = (PactResult . Right . PLiteral . LDecimal) 3
         --expRes = Just $ CommandResult _ ((Just . TxId) 0) cmdData (Gas 0)
-    cr <- testSimpleServerCmd mgr
+    cr <- testSimpleServerCmd
     (_crResult <$> cr)`shouldBe` Just cmdData
 
   context "when provided with correct next step" $
     it "executes the next step and updates pact's state" $ do
       let mname1 = "testCorrectNextStep"
-      testCorrectNextStep mgr (threeStepPactCode mname1) ("(" <> mname1 <> ".tester)") testConfigFilePath
+      testCorrectNextStep (threeStepPactCode mname1) ("(" <> mname1 <> ".tester)") testConfigFilePath
 
   context "when provided with incorrect next step" $
     it "throws error and does not update pact's state" $ do
       let mname2 = "testIncorrectNextStep"
-      testIncorrectNextStep mgr (threeStepPactCode mname2) ("(" <> mname2 <> ".tester)") testConfigFilePath
+      testIncorrectNextStep (threeStepPactCode mname2) ("(" <> mname2 <> ".tester)") testConfigFilePath
 
   context "when last step of a pact executed" $
     it "deletes pact from the state" $ do
       let mname3 = "testLastStep"
-      testLastStep mgr (threeStepPactCode mname3) ("(" <> mname3 <> ".tester)") testConfigFilePath
+      testLastStep (threeStepPactCode mname3) ("(" <> mname3 <> ".tester)") testConfigFilePath
 
   context "when error occurs when executing pact step" $
     it "throws error and does not update pact's state" $ do
       let mname4 = "testErrStep"
-      testErrStep mgr (errorStepPactCode mname4) ("(" <> mname4 <> ".tester)") testConfigFilePath
+      testErrStep (errorStepPactCode mname4) ("(" <> mname4 <> ".tester)") testConfigFilePath
 
-testNestedPactContinuation :: HTTP.Manager -> Spec
-testNestedPactContinuation mgr = before_ flushDb $ after_ flushDb $ do
+testNestedPactContinuation :: Spec
+testNestedPactContinuation = before_ flushDb $ after_ flushDb $ do
   it "sends (+ 1 2) command to locally running dev server" $ do
     let cmdData = (PactResult . Right . PLiteral . LDecimal) 3
-    cr <- testSimpleServerCmd mgr
+    cr <- testSimpleServerCmd
     (_crResult <$> cr)`shouldBe` Just cmdData
 
   context "when provided with correct next step" $
     it "executes the next step and updates nested pact's state" $ do
     let mname1 = "testCorrectNextNestedStep"
-    testCorrectNextStep mgr (threeStepNestedPactCode mname1) ("(" <> mname1 <> "-nested.nestedTester " <> mname1 <> "-2)") testConfigNDPFilePath
+    testCorrectNextStep (threeStepNestedPactCode mname1) ("(" <> mname1 <> "-nested.nestedTester " <> mname1 <> "-2)") testConfigNDPFilePath
 
   context "when provided with incorrect next step" $
     it "throws error and does not update nested pact's state" $ do
       let mname2 = "testIncorrectNextNestedStep"
-      testIncorrectNextStep mgr (threeStepNestedPactCode mname2) ("(" <> mname2 <> "-nested.nestedTester " <> mname2 <> "-2)") testConfigNDPFilePath
+      testIncorrectNextStep (threeStepNestedPactCode mname2) ("(" <> mname2 <> "-nested.nestedTester " <> mname2 <> "-2)") testConfigNDPFilePath
   context "when last step of a pact executed" $
     it "deletes pact from the state" $ do
       let mname3 = "testNestedLastStep"
-      testLastStep mgr (threeStepNestedPactCode mname3) ("(" <> mname3 <> "-nested.nestedTester " <> mname3 <> "-2)") testConfigNDPFilePath
+      testLastStep (threeStepNestedPactCode mname3) ("(" <> mname3 <> "-nested.nestedTester " <> mname3 <> "-2)") testConfigNDPFilePath
 
   context "when error occurs when executing pact step" $
     it "throws error and does not update pact's state" $ do
       let mname4 = "testNestedErrStep"
-      testErrStep mgr (errorStepNestedPactCode mname4) ("(" <> mname4 <> "-nested.nestedTester)") testConfigNDPFilePath
+      testErrStep (errorStepNestedPactCode mname4) ("(" <> mname4 <> "-nested.nestedTester)") testConfigNDPFilePath
 
-testSimpleServerCmd :: HTTP.Manager -> IO (Maybe (CommandResult Hash))
-testSimpleServerCmd mgr = do
+testSimpleServerCmd :: IO (Maybe (CommandResult Hash))
+testSimpleServerCmd = do
   simpleKeys <- genKeys
   cmd <- mkExec  "(+ 1 2)" Null def [(simpleKeys,[])] Nothing (Just "test1")
-  allResults <- runAll mgr [cmd]
+  allResults <- runAll [cmd]
   return $ HM.lookup (cmdToRequestKey cmd) allResults
 
 
-testCorrectNextStep :: HTTP.Manager -> Text -> Text -> FilePath -> Expectation
-testCorrectNextStep mgr code command cfg = do
+testCorrectNextStep :: Text -> Text -> FilePath -> Expectation
+testCorrectNextStep code command cfg = do
   adminKeys <- genKeys
   let makeExecCmdWith = makeExecCmd adminKeys
   moduleCmd       <- makeExecCmdWith code
@@ -233,7 +227,7 @@ testCorrectNextStep mgr code command cfg = do
   let makeContCmdWith = makeContCmd adminKeys False Null executePactCmd
   contNextStepCmd <- makeContCmdWith 1 "test3"
   checkStateCmd   <- makeContCmdWith 1 "test4"
-  allResults      <- runAll' mgr [moduleCmd, executePactCmd, contNextStepCmd, checkStateCmd] noSPVSupport cfg
+  allResults      <- runAll' [moduleCmd, executePactCmd, contNextStepCmd, checkStateCmd] noSPVSupport cfg
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
@@ -312,8 +306,8 @@ threeStepNestedPactCode moduleName =
        |]
 
 
-testIncorrectNextStep :: HTTP.Manager -> Text -> Text -> FilePath -> Expectation
-testIncorrectNextStep mgr code command cfg = do
+testIncorrectNextStep :: Text -> Text -> FilePath -> Expectation
+testIncorrectNextStep code command cfg = do
   adminKeys <- genKeys
 
   let makeExecCmdWith = makeExecCmd adminKeys
@@ -323,7 +317,7 @@ testIncorrectNextStep mgr code command cfg = do
   let makeContCmdWith = makeContCmd adminKeys False Null executePactCmd
   incorrectStepCmd  <- makeContCmdWith 2 "test3"
   checkStateCmd     <- makeContCmdWith 1 "test4"
-  allResults        <- runAll' mgr [moduleCmd, executePactCmd, incorrectStepCmd, checkStateCmd] noSPVSupport cfg
+  allResults        <- runAll' [moduleCmd, executePactCmd, incorrectStepCmd, checkStateCmd] noSPVSupport cfg
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
@@ -332,8 +326,8 @@ testIncorrectNextStep mgr code command cfg = do
     checkStateCmd `succeedsWith` textVal "step 1"
 
 
-testLastStep :: HTTP.Manager -> Text -> Text -> FilePath -> Expectation
-testLastStep mgr code command cfg = do
+testLastStep :: Text -> Text -> FilePath -> Expectation
+testLastStep code command cfg = do
   adminKeys <- genKeys
 
   let makeExecCmdWith = makeExecCmd adminKeys
@@ -344,7 +338,7 @@ testLastStep mgr code command cfg = do
   contNextStep1Cmd <- makeContCmdWith 1 "test3"
   contNextStep2Cmd <- makeContCmdWith 2 "test4"
   checkStateCmd    <- makeContCmdWith 3 "test5"
-  allResults       <- runAll' mgr [moduleCmd, executePactCmd, contNextStep1Cmd,
+  allResults       <- runAll' [moduleCmd, executePactCmd, contNextStep1Cmd,
                               contNextStep2Cmd, checkStateCmd] noSPVSupport cfg
 
   runResults allResults $ do
@@ -357,8 +351,8 @@ testLastStep mgr code command cfg = do
 
 
 
-testErrStep :: HTTP.Manager -> Text -> Text -> FilePath -> Expectation
-testErrStep mgr code command cfg = do
+testErrStep :: Text -> Text -> FilePath -> Expectation
+testErrStep code command cfg = do
   adminKeys <- genKeys
 
   let makeExecCmdWith = makeExecCmd adminKeys
@@ -368,7 +362,7 @@ testErrStep mgr code command cfg = do
   let makeContCmdWith = makeContCmd adminKeys False Null executePactCmd
   contErrStepCmd   <- makeContCmdWith 1 "test3"
   checkStateCmd    <- makeContCmdWith 2 "test4"
-  allResults       <- runAll' mgr [moduleCmd, executePactCmd, contErrStepCmd, checkStateCmd] noSPVSupport cfg
+  allResults       <- runAll' [moduleCmd, executePactCmd, contErrStepCmd, checkStateCmd] noSPVSupport cfg
 
   runResults allResults $ do
     moduleCmd `succeedsWith`  Nothing
@@ -422,27 +416,27 @@ errorStepNestedPactCode moduleName =
 
 -- ROLLBACK TESTS
 
-testPactRollback :: HTTP.Manager -> Spec
-testPactRollback mgr = before_ flushDb $ after_ flushDb $ do
+testPactRollback :: Spec
+testPactRollback = before_ flushDb $ after_ flushDb $ do
   context "when provided with correct rollback step" $
-    it "executes the rollback function and deletes pact from state" $
-      testCorrectRollbackStep mgr
+    it "executes the rollback function and deletes pact from state"
+      testCorrectRollbackStep
 
   context "when provided with incorrect rollback step" $
-    it "throws error and does not delete pact from state" $
-      testIncorrectRollbackStep mgr
+    it "throws error and does not delete pact from state"
+      testIncorrectRollbackStep
 
   context "when error occurs when executing rollback function" $
-    it "throws error and does not delete pact from state" $
-      testRollbackErr mgr
+    it "throws error and does not delete pact from state"
+      testRollbackErr
 
   context "when trying to rollback a step without a rollback function" $
-    it "outputs a rollback failure and doesn't change the pact's state" $
-      testNoRollbackFunc mgr
+    it "outputs a rollback failure and doesn't change the pact's state"
+      testNoRollbackFunc
 
 
-testCorrectRollbackStep :: HTTP.Manager -> Expectation
-testCorrectRollbackStep mgr = do
+testCorrectRollbackStep :: Expectation
+testCorrectRollbackStep = do
   let moduleName = "testCorrectRollbackStep"
   adminKeys <- genKeys
 
@@ -455,7 +449,7 @@ testCorrectRollbackStep mgr = do
   contNextStepCmd <- makeContCmdWith 1 "test3"
   rollbackStepCmd <- makeContCmdWithRollback 1 "test4" -- rollback = True
   checkStateCmd   <- makeContCmdWith 2 "test5"
-  allResults      <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd,
+  allResults      <- runAll [moduleCmd, executePactCmd, contNextStepCmd,
                              rollbackStepCmd, checkStateCmd]
 
   runResults allResults $ do
@@ -480,8 +474,8 @@ pactWithRollbackCode moduleName =
         |]
 
 
-testIncorrectRollbackStep :: HTTP.Manager -> Expectation
-testIncorrectRollbackStep mgr = do
+testIncorrectRollbackStep :: Expectation
+testIncorrectRollbackStep = do
   let moduleName = "testIncorrectRollbackStep"
   adminKeys <- genKeys
 
@@ -494,7 +488,7 @@ testIncorrectRollbackStep mgr = do
   contNextStepCmd <- makeContCmdWith 1 "test3"
   incorrectRbCmd  <- makeContCmdWithRollback 2 "test4"
   checkStateCmd   <- makeContCmdWith 2 "test5"
-  allResults      <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd,
+  allResults      <- runAll [moduleCmd, executePactCmd, contNextStepCmd,
                              incorrectRbCmd, checkStateCmd]
 
   runResults allResults $ do
@@ -505,8 +499,8 @@ testIncorrectRollbackStep mgr = do
     checkStateCmd `succeedsWith` textVal "step 2"
 
 
-testRollbackErr :: HTTP.Manager -> Expectation
-testRollbackErr mgr = do
+testRollbackErr :: Expectation
+testRollbackErr = do
   let moduleName = "testRollbackErr"
   adminKeys <- genKeys
 
@@ -519,7 +513,7 @@ testRollbackErr mgr = do
   contNextStepCmd  <- makeContCmdWith 1 "test3"
   rollbackErrCmd   <- makeContCmdWithRollback 1 "test4"
   checkStateCmd    <- makeContCmdWith 2 "test5"
-  allResults       <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd,
+  allResults       <- runAll [moduleCmd, executePactCmd, contNextStepCmd,
                               rollbackErrCmd, checkStateCmd]
 
   runResults allResults $ do
@@ -542,8 +536,8 @@ pactWithRollbackErrCode moduleName =
         |]
 
 
-testNoRollbackFunc :: HTTP.Manager -> Expectation
-testNoRollbackFunc mgr = do
+testNoRollbackFunc :: Expectation
+testNoRollbackFunc = do
   let moduleName = "testNoRollbackFunc"
   adminKeys <- genKeys
 
@@ -556,7 +550,7 @@ testNoRollbackFunc mgr = do
   contNextStepCmd  <- makeContCmdWith 1 "test3"
   noRollbackCmd    <- makeContCmdWithRollback 1 "test4"
   checkStateCmd    <- makeContCmdWith 2 "test5"
-  allResults       <- runAll mgr [moduleCmd, executePactCmd, contNextStepCmd,
+  allResults       <- runAll [moduleCmd, executePactCmd, contNextStepCmd,
                               noRollbackCmd, checkStateCmd]
 
   runResults allResults $ do
@@ -570,52 +564,52 @@ testNoRollbackFunc mgr = do
 
 -- YIELD / RESUME TESTS
 
-testPactYield :: HTTP.Manager -> Spec
-testPactYield mgr = before_ flushDb $ after_ flushDb $ do
+testPactYield :: Spec
+testPactYield = before_ flushDb $ after_ flushDb $ do
   context "when previous step yields value" $
     it "resumes value" $ do
       let mname1 = "testValidYield"
-      testValidYield mname1 mgr pactWithYield testConfigFilePath
+      testValidYield mname1 pactWithYield testConfigFilePath
 
   context "when previous step does not yield value" $
     it "throws error when trying to resume, and does not delete pact from state" $ do
       let mname2 = "testNoYield"
-      testNoYield mname2 mgr pactWithYieldErr testConfigFilePath
+      testNoYield mname2 pactWithYieldErr testConfigFilePath
 
   it "resets yielded values after each step" $ do
     let mname3 = "testResetYield"
-    testResetYield mname3 mgr pactWithSameNameYield testConfigFilePath
+    testResetYield mname3 pactWithSameNameYield testConfigFilePath
 
   it "testCrossChainYield:succeeds with same module" $
-      testCrossChainYield mgr "" True False
+      testCrossChainYield "" True False
 
   it "testCrossChainYield:succeeds with back compat" $
-      testCrossChainYield mgr "" True True
+      testCrossChainYield "" True True
 
   it "testCrossChainYield:fails with different module" $
-      testCrossChainYield mgr ";;1" False False
+      testCrossChainYield ";;1" False False
 
   it "testCrossChainYield:succeeds with blessed module" $
-      testCrossChainYield mgr "(bless \"_9xPxvYomOU0iEqXpcrChvoA-E9qoaE1TqU460xN1xc\")" True False
+      testCrossChainYield "(bless \"_9xPxvYomOU0iEqXpcrChvoA-E9qoaE1TqU460xN1xc\")" True False
 
 
-testNestedPactYield :: HTTP.Manager -> Spec
-testNestedPactYield mgr = before_ flushDb $ after_ flushDb $ do
+testNestedPactYield :: Spec
+testNestedPactYield = before_ flushDb $ after_ flushDb $ do
   context "when previous step yields value" $
     it "resumes value" $ do
       let mname1 = "testNestedValidYield"
-      testValidYield mname1 mgr nestedPactWithYield testConfigNDPFilePath
+      testValidYield mname1 nestedPactWithYield testConfigNDPFilePath
 
   context "when previous step does not yield value" $
     it "throws error when trying to resume, and does not delete pact from state" $ do
       let mname2 = "testNestedNoYield"
-      testNoYield mname2 mgr nestedPactWithYieldErr testConfigNDPFilePath
+      testNoYield mname2 nestedPactWithYieldErr testConfigNDPFilePath
 
   it "resets yielded values after each step" $ do
     let mname3 = "testNestedResetYield"
-    testResetYield mname3 mgr nestedPactWithSameNameYield testConfigNDPFilePath
+    testResetYield mname3 nestedPactWithSameNameYield testConfigNDPFilePath
 
-  it "testCrossChainYield:succeeds with same module" $
+  it "testCrossChainYield:succeeds with same module"
       testNestedCrossChainYield
   where
   testNestedCrossChainYield = step0
@@ -632,7 +626,7 @@ testNestedPactYield mgr = before_ flushDb $ after_ flushDb $ do
       executePactCmd   <- makeExecCmdWith "(cross-chain-tester.cross-chain \"jose\")"
 
       chain0Results <-
-        runAll' mgr [moduleCmd,executePactCmd] noSPVSupport testConfigNDPFilePath
+        runAll' [moduleCmd,executePactCmd] noSPVSupport testConfigNDPFilePath
 
       mhash <- mkModuleHash "mGbCL-I0xXho_dxYfYAVmHfSfj3o43gbJ3ZgLHpaq14"
 
@@ -673,9 +667,9 @@ testNestedPactYield mgr = before_ flushDb $ after_ flushDb $ do
           spv = noSPVSupport {
             _spvVerifyContinuation = \cp ->
                 if cp == proof then
-                  return $ Right $ pe
+                  return $ Right pe
                 else
-                  return $ Left $ "Invalid proof"
+                  return $ Left "Invalid proof"
             }
 
       chain1Cont <- makeContCmdWith 1 "chain1Cont"
@@ -686,7 +680,7 @@ testNestedPactYield mgr = before_ flushDb $ after_ flushDb $ do
       flushDb
 
       chain1Results <-
-        runAll' mgr [moduleCmd, chain1Cont,chain1ContDupe] spv testConfigFilePath
+        runAll' [moduleCmd, chain1Cont,chain1ContDupe] spv testConfigFilePath
       let completedPactMsg =
             "resumePact: pact completed: " ++ showPretty (_cmdHash executePactCmd)
 
@@ -704,8 +698,8 @@ testNestedPactYield mgr = before_ flushDb $ after_ flushDb $ do
         chain1ContDupe `failsWith` Just completedPactMsg
 
 
-testValidYield :: Text -> HTTP.Manager -> (Text -> Text) -> FilePath -> Expectation
-testValidYield moduleName mgr mkCode cfg = do
+testValidYield :: Text -> (Text -> Text) -> FilePath -> Expectation
+testValidYield moduleName mkCode cfg = do
   adminKeys <- genKeys
 
   let makeExecCmdWith = makeExecCmd adminKeys
@@ -717,7 +711,7 @@ testValidYield moduleName mgr mkCode cfg = do
   resumeAndYieldCmd  <- makeContCmdWith 1 "test3"
   resumeOnlyCmd      <- makeContCmdWith 2 "test4"
   checkStateCmd      <- makeContCmdWith 3 "test5"
-  allResults         <- runAll' mgr [moduleCmd, executePactCmd, resumeAndYieldCmd,
+  allResults         <- runAll' [moduleCmd, executePactCmd, resumeAndYieldCmd,
                                 resumeOnlyCmd, checkStateCmd] noSPVSupport cfg
 
   runResults allResults $ do
@@ -787,8 +781,8 @@ nestedPactWithYield moduleName =
 
 
 
-testNoYield :: Text -> HTTP.Manager -> (Text -> Text) -> FilePath -> Expectation
-testNoYield moduleName mgr mkCode cfg = do
+testNoYield :: Text -> (Text -> Text) -> FilePath -> Expectation
+testNoYield moduleName mkCode cfg = do
   -- let moduleName = "testNoYield"
   adminKeys <- genKeys
 
@@ -800,7 +794,7 @@ testNoYield moduleName mgr mkCode cfg = do
   noYieldStepCmd <- makeContCmdWith 1 "test3"
   resumeErrCmd   <- makeContCmdWith 2 "test3"
   checkStateCmd  <- makeContCmdWith 1 "test5"
-  allResults     <- runAll' mgr [moduleCmd, executePactCmd, noYieldStepCmd,
+  allResults     <- runAll' [moduleCmd, executePactCmd, noYieldStepCmd,
                            resumeErrCmd, checkStateCmd] noSPVSupport cfg
 
   runResults allResults $ do
@@ -858,8 +852,8 @@ nestedPactWithYieldErr moduleName =
             |]
 
 
-testResetYield :: Text -> HTTP.Manager -> (Text -> Text) -> FilePath -> Expectation
-testResetYield moduleName mgr mkCode cfg = do
+testResetYield :: Text -> (Text -> Text) -> FilePath -> Expectation
+testResetYield moduleName mkCode cfg = do
   -- let moduleName = "testResetYield"
   adminKeys <- genKeys
 
@@ -871,7 +865,7 @@ testResetYield moduleName mgr mkCode cfg = do
   yieldSameKeyCmd  <- makeContCmdWith 1 "test3"
   resumeStepCmd    <- makeContCmdWith 2 "test4"
   checkStateCmd    <- makeContCmdWith 3 "test5"
-  allResults       <- runAll' mgr [moduleCmd, executePactCmd, yieldSameKeyCmd,
+  allResults       <- runAll' [moduleCmd, executePactCmd, yieldSameKeyCmd,
                               resumeStepCmd, checkStateCmd] noSPVSupport cfg
 
   runResults allResults $ do
@@ -939,8 +933,8 @@ nestedPactWithSameNameYield moduleName =
             |]
 
 
-testCrossChainYield :: HTTP.Manager -> T.Text -> Bool -> Bool -> Expectation
-testCrossChainYield mgr blessCode succeeds backCompat = step0
+testCrossChainYield :: T.Text -> Bool -> Bool -> Expectation
+testCrossChainYield blessCode succeeds backCompat = step0
   where
 
     -- STEP 0: runs on server for "chain0results"
@@ -956,7 +950,7 @@ testCrossChainYield mgr blessCode succeeds backCompat = step0
       executePactCmd   <- makeExecCmdWith "(cross-chain-tester.cross-chain \"emily\")"
 
       chain0Results <-
-        runAll' mgr [moduleCmd,executePactCmd] noSPVSupport $
+        runAll' [moduleCmd,executePactCmd] noSPVSupport $
         if backCompat then backCompatConfig else testConfigFilePath
 
       mhash <- mkModuleHash "_9xPxvYomOU0iEqXpcrChvoA-E9qoaE1TqU460xN1xc"
@@ -1000,9 +994,9 @@ testCrossChainYield mgr blessCode succeeds backCompat = step0
           spv = noSPVSupport {
             _spvVerifyContinuation = \cp ->
                 if cp == proof then
-                  return $ Right $ pe
+                  return $ Right pe
                 else
-                  return $ Left $ "Invalid proof"
+                  return $ Left "Invalid proof"
             }
 
       chain1Cont <- makeContCmdWith 1 "chain1Cont"
@@ -1013,7 +1007,7 @@ testCrossChainYield mgr blessCode succeeds backCompat = step0
       flushDb
 
       chain1Results <-
-        runAll' mgr [moduleCmd,chain1Cont,chain1ContDupe] spv testConfigFilePath
+        runAll' [moduleCmd,chain1Cont,chain1ContDupe] spv testConfigFilePath
       let completedPactMsg =
             "resumePact: pact completed: " ++ showPretty (_cmdHash executePactCmd)
           provenanceFailedMsg = "enforceYield: yield provenance"
@@ -1101,38 +1095,37 @@ nestedPactCrossChainYield =
 
 -- TWO PARTY ESCROW TESTS
 
-testTwoPartyEscrow :: HTTP.Manager -> Spec
-testTwoPartyEscrow mgr = before_ flushDb $ after_ flushDb $ do
+testTwoPartyEscrow :: Spec
+testTwoPartyEscrow = before_ flushDb $ after_ flushDb $ do
   context "when debtor tries to cancel pre-timeout" $
-    it "throws error and money still escrowed" $
-      testDebtorPreTimeoutCancel mgr
+    it "throws error and money still escrowed"
+      testDebtorPreTimeoutCancel
 
   context "when debtor tries to cancel after timeout" $
-    it "cancels escrow and deposits escrowed amount back to debtor" $
-      testDebtorPostTimeoutCancel mgr
+    it "cancels escrow and deposits escrowed amount back to debtor"
+      testDebtorPostTimeoutCancel
 
-  it "cancels escrow immediately if creditor cancels" $
-    testCreditorCancel mgr
+  it "cancels escrow immediately if creditor cancels"
+    testCreditorCancel
 
-  it "throws error when creditor or debtor try to finish alone" $
-    testFinishAlone mgr
+  it "throws error when creditor or debtor try to finish alone"
+    testFinishAlone
 
-  it "throws error when final price negotiated up" $
-    testPriceNegUp mgr
+  it "throws error when final price negotiated up"
+    testPriceNegUp
 
   context "when both debtor and creditor finish together" $ do
-    it "finishes escrow if final price stays the same or negotiated down" $
-      testValidEscrowFinish mgr
-    it "with valid price, still fails if bad cap is on a signature" $
-      testPriceNegDownBadCaps mgr
+    it "finishes escrow if final price stays the same or negotiated down"
+      testValidEscrowFinish
+    it "with valid price, still fails if bad cap is on a signature"
+      testPriceNegDownBadCaps
 
 
 twoPartyEscrow
   :: [Command Text]
-  -> HTTP.Manager
   -> (PactHash -> ReaderT (HM.HashMap RequestKey (CommandResult Hash)) IO ())
   -> Expectation
-twoPartyEscrow testCmds mgr act = do
+twoPartyEscrow testCmds act = do
   let setupPath = testDir ++ "cont-scripts/setup-"
 
   (_, sysModuleCmd)  <- mkApiReq (setupPath ++ "01-system.yaml")
@@ -1144,7 +1137,7 @@ twoPartyEscrow testCmds mgr act = do
   (_, balanceCmd)    <- mkApiReq (setupPath ++ "07-balance.yaml")
   let allCmds = sysModuleCmd : acctModuleCmd : testModuleCmd : createAcctCmd
                 : resetTimeCmd : runEscrowCmd : balanceCmd : testCmds
-  allResults <- runAll mgr allCmds
+  allResults <- runAll allCmds
 
   runResults allResults $ do
     sysModuleCmd `succeedsWith` textVal "system module loaded"
@@ -1176,8 +1169,8 @@ checkContHash reqs act hsh = forM_ reqs $ \req ->
             | otherwise -> liftIO $ toExpectationFailure' ("checkContHash for req " ++ desc ++ ": ") ph hsh
 
 
-testDebtorPreTimeoutCancel :: HTTP.Manager -> Expectation
-testDebtorPreTimeoutCancel mgr = do
+testDebtorPreTimeoutCancel :: Expectation
+testDebtorPreTimeoutCancel = do
   let testPath = testDir ++ "cont-scripts/fail-deb-cancel-"
 
   (req, tryCancelCmd)        <- mkApiReq (testPath ++ "01-rollback.yaml")
@@ -1188,13 +1181,13 @@ testDebtorPreTimeoutCancel mgr = do
   let cancelMsg = "Cancel can only be effected by" <>
                   " creditor, or debitor after timeout"
 
-  twoPartyEscrow allCmds mgr $ checkContHash [req] $ do
+  twoPartyEscrow allCmds $ checkContHash [req] $ do
     tryCancelCmd `failsWith` Just cancelMsg
     checkStillEscrowCmd `succeedsWith` decValue 98.00
 
 
-testDebtorPostTimeoutCancel :: HTTP.Manager -> Expectation
-testDebtorPostTimeoutCancel mgr = do
+testDebtorPostTimeoutCancel :: Expectation
+testDebtorPostTimeoutCancel = do
   let testPath = testDir ++ "cont-scripts/pass-deb-cancel-"
 
   (_, setTimeCmd)          <- mkApiReq (testPath ++ "01-set-time.yaml")
@@ -1202,14 +1195,14 @@ testDebtorPostTimeoutCancel mgr = do
   (_, checkStillEscrowCmd) <- mkApiReq (testPath ++ "03-balance.yaml")
   let allCmds = [setTimeCmd, tryCancelCmd, checkStillEscrowCmd]
 
-  twoPartyEscrow allCmds mgr $ checkContHash [req] $ do
+  twoPartyEscrow allCmds $ checkContHash [req] $ do
     setTimeCmd `succeedsWith`  Nothing
     tryCancelCmd `succeedsWith`  Nothing
     checkStillEscrowCmd `succeedsWith` decValue 100.00
 
 
-testCreditorCancel :: HTTP.Manager -> Expectation
-testCreditorCancel mgr = do
+testCreditorCancel :: Expectation
+testCreditorCancel = do
   let testPath = testDir ++ "cont-scripts/pass-cred-cancel-"
 
   (_, resetTimeCmd)        <- mkApiReq (testPath ++ "01-reset.yaml")
@@ -1217,14 +1210,14 @@ testCreditorCancel mgr = do
   (_, checkStillEscrowCmd) <- mkApiReq (testPath ++ "03-balance.yaml")
   let allCmds = [resetTimeCmd, credCancelCmd, checkStillEscrowCmd]
 
-  twoPartyEscrow allCmds mgr $ checkContHash [req] $ do
+  twoPartyEscrow allCmds $ checkContHash [req] $ do
     resetTimeCmd `succeedsWith`  Nothing
     credCancelCmd `succeedsWith`  Nothing
     checkStillEscrowCmd `succeedsWith` decValue 100.00
 
 
-testFinishAlone :: HTTP.Manager -> Expectation
-testFinishAlone mgr = do
+testFinishAlone :: Expectation
+testFinishAlone = do
   let testPathCred  = testDir ++ "cont-scripts/fail-cred-finish-"
       testPathDeb   = testDir ++ "cont-scripts/fail-deb-finish-"
 
@@ -1232,24 +1225,24 @@ testFinishAlone mgr = do
   (r2, tryDebAloneCmd)  <- mkApiReq (testPathDeb ++ "01-cont.yaml")
   let allCmds = [tryCredAloneCmd, tryDebAloneCmd]
 
-  twoPartyEscrow allCmds mgr $ checkContHash [r1, r2] $ do
+  twoPartyEscrow allCmds $ checkContHash [r1, r2] $ do
     tryCredAloneCmd `failsWith`
       (Just "Keyset failure (keys-all): [7d0c9ba1...]")
     tryDebAloneCmd `failsWith`
       (Just "Keyset failure (keys-all): [ac69d985...]")
 
 
-testPriceNegUp :: HTTP.Manager -> Expectation
-testPriceNegUp mgr = do
+testPriceNegUp :: Expectation
+testPriceNegUp = do
   let testPath = testDir ++ "cont-scripts/fail-both-price-up-"
 
   (req, tryNegUpCmd) <- mkApiReq (testPath ++ "01-cont.yaml")
-  twoPartyEscrow [tryNegUpCmd] mgr $ checkContHash [req] $ do
+  twoPartyEscrow [tryNegUpCmd] $ checkContHash [req] $ do
     tryNegUpCmd `failsWith` (Just "Price cannot negotiate up")
 
 
-testValidEscrowFinish :: HTTP.Manager -> Expectation
-testValidEscrowFinish mgr = do
+testValidEscrowFinish :: Expectation
+testValidEscrowFinish = do
   let testPath = testDir ++ "cont-scripts/pass-both-price-down-"
 
   (req, tryNegDownCmd)  <- mkApiReq (testPath ++ "01-cont.yaml")
@@ -1257,18 +1250,18 @@ testValidEscrowFinish mgr = do
   (_, debBalanceCmd)  <- mkApiReq (testPath ++ "03-deb-balance.yaml")
   let allCmds = [tryNegDownCmd, credBalanceCmd, debBalanceCmd]
 
-  twoPartyEscrow allCmds mgr $ checkContHash [req] $ do
+  twoPartyEscrow allCmds $ checkContHash [req] $ do
     tryNegDownCmd `succeedsWith`
                          (textVal "Escrow completed with 1.75 paid and 0.25 refunded")
     credBalanceCmd `succeedsWith` decValue 1.75
     debBalanceCmd `succeedsWith` decValue 98.25
 
-testPriceNegDownBadCaps :: HTTP.Manager -> Expectation
-testPriceNegDownBadCaps mgr = do
+testPriceNegDownBadCaps :: Expectation
+testPriceNegDownBadCaps = do
   let testPath = testDir ++ "cont-scripts/fail-both-price-down-"
 
   (req, tryNegUpCmd) <- mkApiReq (testPath ++ "01-cont-badcaps.yaml")
-  twoPartyEscrow [tryNegUpCmd] mgr $ checkContHash [req] $ do
+  twoPartyEscrow [tryNegUpCmd] $ checkContHash [req] $ do
     tryNegUpCmd `failsWith` (Just "Keyset failure (keys-all): [7d0c9ba1...]")
 
 
@@ -1310,11 +1303,11 @@ succeedsWith cmd r = succeedsWith' cmd ((,[]) <$> r)
 
 succeedsWith' :: HasCallStack => Command Text -> Maybe (PactValue,[PactEvent]) ->
                 ReaderT (HM.HashMap RequestKey (CommandResult Hash)) IO ()
-succeedsWith' cmd r = shouldMatch cmd (resultShouldBe $ Right $ r)
+succeedsWith' cmd r = shouldMatch cmd (resultShouldBe $ Right r)
 
 failsWith :: HasCallStack => Command Text -> Maybe String ->
              ReaderT (HM.HashMap RequestKey (CommandResult Hash)) IO ()
-failsWith cmd r = shouldMatch cmd (resultShouldBe $ Left $ r)
+failsWith cmd r = shouldMatch cmd (resultShouldBe $ Left r)
 
 runResults :: r -> ReaderT r m a -> m a
 runResults rs act = runReaderT act rs
@@ -1389,25 +1382,24 @@ data CommandResultCheck = CommandResultCheck
 makeCheck :: Command T.Text -> ExpectResult -> CommandResultCheck
 makeCheck c@Command{} expect = CommandResultCheck (cmdToRequestKey c) expect
 
-runAll :: Manager -> [Command T.Text] -> IO (HM.HashMap RequestKey (CommandResult Hash))
-runAll mgr cmds = runAll' mgr cmds noSPVSupport testConfigFilePath
+runAll :: [Command T.Text] -> IO (HM.HashMap RequestKey (CommandResult Hash))
+runAll cmds = runAll' cmds noSPVSupport testConfigFilePath
 
 runAll'
-  :: Manager
-  -> [Command T.Text]
+  :: [Command T.Text]
   -> SPVSupport
   -> FilePath
   -> IO (HM.HashMap RequestKey (CommandResult Hash))
-runAll' mgr cmds spv config = Exception.bracket
+runAll' cmds spv config = Exception.bracket
               (startServer' config spv)
                stopServer
-              (const (run mgr cmds))
+              (const (run cmds))
 
 
 
-run :: Manager -> [Command T.Text] -> IO (HM.HashMap RequestKey (CommandResult Hash))
-run mgr cmds = do
-  sendResp <- doSend mgr . SubmitBatch $ NEL.fromList cmds
+run :: [Command T.Text] -> IO (HM.HashMap RequestKey (CommandResult Hash))
+run cmds = do
+  sendResp <- doSend . SubmitBatch $ NEL.fromList cmds
   case sendResp of
     Left servantErr -> Exception.evaluate (error $ show servantErr)
     Right RequestKeys{..} -> do
@@ -1417,7 +1409,7 @@ run mgr cmds = do
         Just res -> return res
 
   where helper reqKeys = do
-          pollResp <- doPoll mgr $ Poll reqKeys
+          pollResp <- doPoll $ Poll reqKeys
           case pollResp of
             Left servantErr -> Exception.evaluate (error $ show servantErr)
             Right (PollResponses apiResults) ->
@@ -1426,15 +1418,15 @@ run mgr cmds = do
 
 
 
-doSend :: Manager -> SubmitBatch -> IO (Either ClientError RequestKeys)
-doSend mgr req = do
+doSend :: SubmitBatch -> IO (Either ClientError RequestKeys)
+doSend req = do
   baseUrl <- serverBaseUrl
-  runClientM (sendClient req) (mkClientEnv mgr baseUrl)
+  runClientM (sendClient req) (mkClientEnv testMgr baseUrl)
 
-doPoll :: Manager -> Poll -> IO (Either ClientError PollResponses)
-doPoll mgr req = do
+doPoll :: Poll -> IO (Either ClientError PollResponses)
+doPoll req = do
   baseUrl <- serverBaseUrl
-  runClientM (pollClient req) (mkClientEnv mgr baseUrl)
+  runClientM (pollClient req) (mkClientEnv testMgr baseUrl)
 
 
 resultShouldBe

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -27,6 +27,7 @@ import System.Timeout
 import qualified Data.Vector as V
 
 import Test.Hspec
+import Test.Hspec.Core.Spec
 
 import Pact.ApiReq
 import Pact.Server.API
@@ -49,15 +50,15 @@ type ClientError = ServantError
 
 spec :: Spec
 spec = describe "pacts in dev server" $ do
-  describe "testPactContinuation" testPactContinuation
-  describe "testPactRollback" testPactRollback
-  describe "testPactYield" testPactYield
-  describe "testTwoPartyEscrow" testTwoPartyEscrow
-  describe "testOldNestedPacts" testOldNestedPacts
-  describe "testManagedCaps" testManagedCaps
-  describe "testElideModRefEvents" testElideModRefEvents
-  describe "testNestedPactContinuation" testNestedPactContinuation
-  describe "testNestedPactYield" testNestedPactYield
+  describe "testPactContinuation" $ sequential testPactContinuation
+  describe "testPactRollback" $ sequential testPactRollback
+  describe "testPactYield" $ sequential testPactYield
+  describe "testTwoPartyEscrow" $ sequential testTwoPartyEscrow
+  describe "testOldNestedPacts" $ sequential testOldNestedPacts
+  describe "testManagedCaps" $ sequential testManagedCaps
+  describe "testElideModRefEvents" $ sequential testElideModRefEvents
+  describe "testNestedPactContinuation" $ sequential testNestedPactContinuation
+  describe "testNestedPactYield" $sequential testNestedPactYield
 
 testElideModRefEvents :: Spec
 testElideModRefEvents = before_ flushDb $ after_ flushDb $ do

--- a/tests/PactTests.hs
+++ b/tests/PactTests.hs
@@ -31,7 +31,7 @@ import qualified PactCLISpec
 #endif
 
 main :: IO ()
-main = hspec $ do
+main = hspec $ parallel $ do
 
   describe "Blake2Spec" Blake2Spec.spec
   describe "KeysetSpec" KeysetSpec.spec

--- a/tests/PactTestsSpec.hs
+++ b/tests/PactTestsSpec.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE RecordWildCards #-}
 module PactTestsSpec (spec) where
 
-
 import Test.Hspec
 
 import Control.Concurrent
@@ -25,26 +24,23 @@ import Pact.Persist.SQLite as SQLite
 import Pact.Interpreter
 import Pact.Parse (parsePact, legacyParsePact)
 
-
 import System.Directory
 import System.FilePath
 
 spec :: Spec
 spec = do
-  pactTests
+  tests <- runIO findTests
+  pactTests tests
   badTests
   accountsTest
   cpTest
   verifiedAccountsTest
-  prodParserTests
-  legacyProdParserTests
+  prodParserTests tests
+  legacyProdParserTests tests
 
 
-pactTests :: Spec
-pactTests = do
-  describe "pact tests" $ do
-    fs <- runIO findTests
-    forM_ fs runScript
+pactTests :: [FilePath] -> Spec
+pactTests tests = describe "pact tests" $ mapM_ runScript tests
 
 badTests :: Spec
 badTests = do
@@ -69,29 +65,31 @@ findTests = findTests' $ "tests" </> "pact"
 findTests' :: FilePath -> IO [FilePath]
 findTests' tdir = (map (tdir </>) . filter ((== ".repl") . reverse . take 5 . reverse)) <$> getDirectoryContents tdir
 
-
 runScript :: String -> SpecWith ()
-runScript fp = describe fp $ do
-  (r,ReplState{..}) <- runIO $ do
-    (PactDbEnv _ pdb) <- mkSQLiteEnv (newLogger neverLog "") False (SQLiteConfig "" []) neverLog
-    ls <- initLibState' (LibDb pdb) Nothing
-    rs <- initReplState' ls Quiet
-    execScriptState' fp rs id
+runScript fp = it fp $ do
+  (PactDbEnv _ pdb) <- mkSQLiteEnv (newLogger neverLog "") False (SQLiteConfig "" []) neverLog
+  ls <- initLibState' (LibDb pdb) Nothing
+  rs <- initReplState' ls Quiet
+  (r, ReplState{..}) <- execScriptState' fp rs id
   case r of
-    Left e -> it ("failed to load " ++ fp) $ expectationFailure e
+    Left e -> expectationFailure e
     Right _ -> do
-      LibState{..} <- runIO $ readMVar $ _eePactDbVar _rEnv
-      forM_ _rlsTests $ \TestResult {..} -> it (unpack trName) $ case trFailure of
+      LibState{..} <- readMVar $ _eePactDbVar _rEnv
+      forM_ _rlsTests $ \TestResult {..} -> case trFailure of
         Nothing -> return ()
         Just (i,e) -> expectationFailure $ renderInfo (_faInfo i) ++ ": " ++ unpack e
 
 runBadScript :: String -> SpecWith ()
 runBadScript fp = describe ("bad-" ++ fp) $ do
-  (r,ReplState{}) <- runIO $ execScript' Quiet fp
-  let expectedError = M.lookup fp badErrors
-  it "has error in badErrors" $ expectedError `shouldSatisfy` isJust
-  it ("failed as expected: " ++ show expectedError) $
-    r `shouldSatisfy` isCorrectError expectedError
+  beforeAll prep $ do
+    it "has error in badErrors" $ \(_, expectedError) ->
+        expectedError `shouldSatisfy` isJust
+    it "failed as expected" $ \(r, expectedError) ->
+      r `shouldSatisfy` isCorrectError expectedError
+ where
+  prep = do
+   (r,ReplState{}) <- execScript' Quiet fp
+   return (r, M.lookup fp badErrors)
 
 isCorrectError :: Maybe String -> Either String (Term Name) -> Bool
 isCorrectError Nothing _ = False
@@ -155,35 +153,40 @@ _evalRefMap cmd = fmap (_rsLoadedModules . _evalRefs . _rEvalState . snd)
 -- -------------------------------------------------------------------------- --
 -- Production Parser Tests
 
-prodParserTests :: Spec
-prodParserTests =
-  describe "test production parser" $ do
-    fs <- runIO findTests
-    forM_ fs $ \fp ->
+prodParserTests :: [FilePath] -> Spec
+prodParserTests tests =
+  describe "test production parser" $
+    forM_ tests $ \fp ->
         checkProdParser (notElem fp badParserTests) fp
  where
   badParserTests =
    [ "tests/pact/bad/bad-parens.repl"
    ]
 
-legacyProdParserTests :: Spec
+legacyProdParserTests :: [FilePath] -> Spec
 legacyProdParserTests =
-  describe "test legacy production parser" $ do
-    fs <- runIO findTests
-    forM_ fs (checkLegacyProdParser True)
+  describe "test legacy production parser" . mapM_ (checkLegacyProdParser True)
 
 checkProdParser :: Bool -> String -> SpecWith ()
 checkProdParser expectSuccess fp = describe fp $ do
-  source <- runIO $ T.readFile fp
-  let pc = parsePact source
   if expectSuccess
-    then it "parsing succeeds" $ pc `shouldSatisfy` isRight
-    else it "parsing fails as expected" $ pc `shouldSatisfy` isLeft
+    then it "parsing succeeds" $ do
+      pc <- parse
+      pc `shouldSatisfy` isRight
+    else it "parsing fails as expected" $ do
+      pc <- parse
+      pc `shouldSatisfy` isLeft
+ where
+  parse = parsePact <$> T.readFile fp
 
 checkLegacyProdParser :: Bool -> String -> SpecWith ()
 checkLegacyProdParser expectSuccess fp = describe fp $ do
-  source <- runIO $ T.readFile fp
-  let pc = legacyParsePact source
   if expectSuccess
-    then it "parsing succeeds" $ pc `shouldSatisfy` isRight
-    else it "parsing fails as expected" $ pc `shouldSatisfy` isLeft
+    then it "parsing succeeds" $ do
+      pc <- parse
+      pc `shouldSatisfy` isRight
+    else it "parsing fails as expected" $ do
+      pc <- parse
+      pc `shouldSatisfy` isLeft
+ where
+  parse = legacyParsePact <$> T.readFile fp

--- a/tests/ParserSpec.hs
+++ b/tests/ParserSpec.hs
@@ -20,10 +20,10 @@ import Pact.Types.Term
 
 spec :: Spec
 spec = do
-  describe "loadBadParens" $ loadBadParens
-  describe "runBadTests" $ runBadTests
-  describe "prettyLit" $ prettyLit
-  describe "narrowTryBackCompat" $ narrowTryBackCompat
+  describe "loadBadParens" loadBadParens
+  describe "runBadTests" runBadTests
+  describe "prettyLit" prettyLit
+  describe "narrowTryBackCompat" narrowTryBackCompat
   parseNames
 
 evalString' :: String -> IO (Either String (Term Name), ReplState)
@@ -31,22 +31,27 @@ evalString' cmd = initReplState StringEval Nothing >>= runStateT (evalRepl' cmd)
 
 loadBadParens :: Spec
 loadBadParens = do
-  (r,_s) <- runIO $ execScript' Quiet "tests/pact/bad/bad-parens.repl"
-  it "should fail due to extra close-parens" $ r `shouldSatisfy` isLeft
+  it "should fail due to extra close-parens" $ do
+    (r,_s) <- execScript' Quiet "tests/pact/bad/bad-parens.repl"
+    r `shouldSatisfy` isLeft
 
-  (r',_s) <- runIO $ execScript' Quiet "tests/pact/parsing.repl"
-  it "should parse correctly" $ r' `shouldSatisfy` isRight
+  it "should parse correctly" $ do
+    (r',_s) <- execScript' Quiet "tests/pact/parsing.repl"
+    r' `shouldSatisfy` isRight
 
-  (r'',_s) <- runIO $ execScript' Quiet "tests/pact/bad/bad-pact.repl"
-  it "should fail due to a rollback on the last step" $ r'' `shouldSatisfy` isLeft
+  it "should fail due to a rollback on the last step" $ do
+    (r'',_s) <- execScript' Quiet "tests/pact/bad/bad-pact.repl"
+    r'' `shouldSatisfy` isLeft
 
 runBadTests :: Spec
 runBadTests = do
-  (r,_s) <- runIO $ evalString' "{ 'a: 1 'b: 2}"
-  it "should not parse bad object" $ r `shouldSatisfy` isLeft
+  it "should not parse bad object" $ do
+    (r,_s) <- evalString' "{ 'a: 1 'b: 2}"
+    r `shouldSatisfy` isLeft
 
-  (r',_s) <- runIO $ evalString' "2.5000000000000082438366423843257667709673523588188657691908576057841129660246632518344756443840469044035563870195392340918714818321610099200359876739795884554030084775850222523998548261336376757270608452858970446458373412193311600907493698300484416227447910"
-  it "should not parse overly-long decimal literals" $ r' `shouldSatisfy` isLeft
+  it "should not parse overly-long decimal literals" $ do
+    (r',_s) <- evalString' "2.5000000000000082438366423843257667709673523588188657691908576057841129660246632518344756443840469044035563870195392340918714818321610099200359876739795884554030084775850222523998548261336376757270608452858970446458373412193311600907493698300484416227447910"
+    r' `shouldSatisfy` isLeft
 
 prettyLit :: Spec
 prettyLit = do

--- a/tests/PersistSpec.hs
+++ b/tests/PersistSpec.hs
@@ -17,12 +17,12 @@ spec = do
 
 
 regressSQLite :: Spec
-regressSQLite = do
+regressSQLite = it "SQLite successfully closes" $ do
   let f = "deleteme.sqllite"
-  db <- runIO $ do
+  db <- do
     doesFileExist f >>= \b -> when b (removeFile f)
     sl <- SQLite.initSQLite (SQLite.SQLiteConfig "deleteme.sqllite" []) neverLog
     mv <- runRegression (initDbEnv neverLog SQLite.persister sl)
     _db <$> readMVar mv
-  it "SQLite successfully closes" $ SQLite.closeSQLite db `shouldReturn` (Right ())
-  runIO $ removeFile f
+  SQLite.closeSQLite db `shouldReturn` Right ()
+  removeFile f

--- a/tests/RemoteVerifySpec.hs
+++ b/tests/RemoteVerifySpec.hs
@@ -25,7 +25,7 @@ import qualified Network.HTTP.Client as HTTP
 
 import Servant.Client
 
-import Pact.Analyze.Remote.Server (runServantServer)
+import Pact.Analyze.Remote.Server (runServantServerLocal)
 import qualified Pact.Analyze.Remote.Types as Remote
 import Pact.Repl
 import Pact.Repl.Types
@@ -57,7 +57,7 @@ stateModuleData :: ModuleName -> ReplState -> IO (Either String (ModuleData Ref)
 stateModuleData nm replState = replLookupModule replState nm
 
 serve :: Int -> IO ThreadId
-serve port = forkIO $ runServantServer port
+serve port = forkIO $ runServantServerLocal port
 
 serveAndRequest :: Int -> Remote.Request -> IO (Either ClientError Remote.Response)
 serveAndRequest port body = do

--- a/tests/RemoteVerifySpec.hs
+++ b/tests/RemoteVerifySpec.hs
@@ -21,8 +21,6 @@ import Data.Text (Text, unpack)
 
 import NeatInterpolation (text)
 
-import qualified Network.HTTP.Client as HTTP
-
 import Servant.Client
 
 import Pact.Analyze.Remote.Server (runServantServerLocal)
@@ -31,6 +29,8 @@ import Pact.Repl
 import Pact.Repl.Types
 import Pact.Server.API
 import Pact.Types.Runtime
+
+import Utils
 
 #if ! MIN_VERSION_servant_client(0,16,0)
 type ClientError = ServantError
@@ -63,16 +63,23 @@ serveAndRequest :: Int -> Remote.Request -> IO (Either ClientError Remote.Respon
 serveAndRequest port body = do
   let url = "http://localhost:" ++ show port
   verifyBaseUrl <- parseBaseUrl url
-  mgr <- HTTP.newManager HTTP.defaultManagerSettings
-  let clientEnv = mkClientEnv mgr verifyBaseUrl
+  let clientEnv = mkClientEnv testMgr verifyBaseUrl
   tid <- serve port
   finally
     (runClientM (verifyClient body) clientEnv)
     (killThread tid)
 
 testSingleModule :: Spec
-testSingleModule = do
-  replState0 <- runIO $ either (error.show) id <$> loadCode
+testSingleModule = beforeAll load $ do
+  it "loads locally" $
+    stateModuleData "mod1" >=> (`shouldSatisfy` isRight)
+
+  it "verifies over the network" $ \replState0 -> do
+    (ModuleData mod1 _refs _) <- either error id <$> stateModuleData "mod1" replState0
+    resp <- serveAndRequest 3000 $ Remote.Request [derefDef <$> mod1] "mod1"
+    fmap (view Remote.responseLines) resp `shouldBe` Right []
+ where
+   load = either (error.show) id <$> loadCode
     [text|
       (env-exec-config ["DisablePact44"])
       (env-keys ["admin"])
@@ -89,35 +96,22 @@ testSingleModule = do
       (commit-tx)
     |]
 
-  it "loads locally" $ do
-    stateModuleData "mod1" replState0 >>= (`shouldSatisfy` isRight)
-
-  (ModuleData mod1 _refs _) <- runIO $ either error id <$> stateModuleData "mod1" replState0
-
-  resp <- runIO $ serveAndRequest 3000 $ Remote.Request [derefDef <$> mod1] "mod1"
-
-  it "verifies over the network" $
-    fmap (view Remote.responseLines) resp `shouldBe`
-    (Right [])
-
 testUnsortedModules :: Spec
-testUnsortedModules = do
-  replState0 <- runIO $ either (error . show) id <$> loadCode code
+testUnsortedModules = beforeAll load $ do
 
-  it "loads when topologically sorted locally" $ do
-    stateModuleData "mod2" replState0 >>= (`shouldSatisfy` isRight)
+  it "loads when topologically sorted locally" $
+    stateModuleData "mod2" >=> (`shouldSatisfy` isRight)
 
-  resp <- runIO . runExceptT $ do
-    ModuleData mod1 _refs _ <- ExceptT $ stateModuleData "mod1" replState0
-    ModuleData mod2 _refs _ <- ExceptT $ stateModuleData "mod2" replState0
-    ExceptT . fmap (first show) . serveAndRequest 3001 $
-      Remote.Request [derefDef <$> mod2, derefDef <$> mod1] "mod2"
-
-  it "verifies over the network" $
-    fmap (view Remote.responseLines) resp `shouldBe`
-    (Right [])
-  where
-    code = [text|
+  it "verifies over the network" $ \replState0  -> do
+    resp <- runExceptT $ do
+      ModuleData mod1 _refs _ <- ExceptT $ stateModuleData "mod1" replState0
+      ModuleData mod2 _refs _ <- ExceptT $ stateModuleData "mod2" replState0
+      ExceptT . fmap (first show) . serveAndRequest 3001 $
+        Remote.Request [derefDef <$> mod2, derefDef <$> mod1] "mod2"
+    fmap (view Remote.responseLines) resp `shouldBe` Right []
+ where
+  load = either (error . show) id <$> loadCode
+    [text|
       (env-exec-config ["DisablePact44"])
       (env-keys ["admin"])
       (env-data { "keyset": { "keys": ["admin"], "pred": "=" } })

--- a/tests/SchemeSpec.hs
+++ b/tests/SchemeSpec.hs
@@ -230,7 +230,7 @@ testSigNonMalleability = do
     shouldBeProcFail (verifyCommand cmdWithWrongNumSig)
 
 testSigsRoundtrip :: Spec
-testSigsRoundtrip = runIO $ do
+testSigsRoundtrip = it "SigsRoundtrip succeeds" $ do
   uapiReq "tests/sign-scripts/unsigned-exec.yaml"
   uapiReq "tests/sign-scripts/unsigned-cont.yaml"
 

--- a/tests/SignatureSpec.hs
+++ b/tests/SignatureSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -17,42 +18,34 @@ import Pact.Repl.Types
 import Pact.Types.Exp
 import Pact.Types.Runtime
 
-
 spec :: Spec
 spec = compareModelSpec
 
 compareModelSpec :: Spec
 compareModelSpec = describe "Module models" $ do
-  (r,s) <- runIO $ execScript' Quiet "tests/pact/signatures.repl"
-
-  eres <- runIO . runExceptT $ do
-    void $ hoistEither r
-    (rs,_) <- ExceptT . fmap (first show) $ replGetModules s
-    md <- failWith "Map lookup failed" $ HM.lookup (ModuleName "model-test1-impl" Nothing) rs
-    ifd <- failWith "Map lookup failed" $ HM.lookup (ModuleName "model-test1" Nothing) rs
-    pure (md, ifd)
-
-  case eres of
-    Left e -> it "script loading + lookups" $ expectationFailure e
-    Right (md, ifd) -> do
-      let mModels = case _mdModule md of
-            MDModule m -> _mModel $ _mMeta m
-            _ -> def
-          iModels = case _mdModule ifd of
-            MDInterface i -> _mModel $ _interfaceMeta i
-            _ -> def
-          mfunModels = aggregateFunctionModels md
-          ifunModels = aggregateFunctionModels ifd
-
-      -- test toplevel models
-      hasAllExps mModels iModels
-      -- test function modules
-      hasAllExps mfunModels ifunModels
-
-hasAllExps :: [Exp Info] -> [Exp Info] -> Spec
-hasAllExps mexps iexps = forM_ iexps $ \e ->
-  it "should find all exps defined in interface in corresponding module" $
-    (e,mexps) `shouldSatisfy` (\_ -> any (expEquality e) mexps)
+  it "should find all exps defined in interface in corresponding module" $ do
+    (r,s) <- execScript' Quiet "tests/pact/signatures.repl"
+    eres <- runExceptT $ do
+      void $ hoistEither r
+      (rs,_) <- ExceptT . fmap (first show) $ replGetModules s
+      md <- failWith "Map lookup failed" $ HM.lookup (ModuleName "model-test1-impl" Nothing) rs
+      ifd <- failWith "Map lookup failed" $ HM.lookup (ModuleName "model-test1" Nothing) rs
+      pure (md, ifd)
+    case eres of
+      Left e -> expectationFailure $ "script loading + lookups: " <> e
+      Right (md, ifd) -> do
+        let mModels = case _mdModule md of
+              MDModule m -> _mModel $ _mMeta m
+              _ -> def
+            iModels = case _mdModule ifd of
+              MDInterface i -> _mModel $ _interfaceMeta i
+              _ -> def
+            mfunModels = aggregateFunctionModels md
+            ifunModels = aggregateFunctionModels ifd
+        forM_ iModels $ \e ->
+          (e,mModels) `shouldSatisfy` (\_ -> any (expEquality e) mModels)
+        forM_ ifunModels $ \e ->
+          (e,mfunModels) `shouldSatisfy` (\_ -> any (expEquality e) mfunModels)
 
 aggregateFunctionModels :: ModuleData Ref -> [Exp Info]
 aggregateFunctionModels ModuleData{..} =

--- a/tests/TypecheckSpec.hs
+++ b/tests/TypecheckSpec.hs
@@ -50,85 +50,85 @@ getUnresolvedTys tl = filter isUnresolvedTy (map _aTy (toList tl))
 checkFailures :: TCResultCheck Failure
 checkFailures (_,s) test = toList (_tcFailures s) `test` []
 
-topLevelTypechecks :: Text -> TCResult -> Spec
-topLevelTypechecks n r = it (unpack n ++ " typechecks") $ checkUnresolvedTys r shouldBe
+topLevelTypechecks :: Text -> SpecWith TCResult
+topLevelTypechecks n = it (unpack n ++ " typechecks") $ \r ->
+  checkUnresolvedTys r shouldBe
 
-topLevelNoFailures :: Text -> TCResult -> Spec
-topLevelNoFailures n r =
-  it (unpack n ++ " has no failures") $ checkFailures r shouldBe
+topLevelNoFailures :: Text -> SpecWith TCResult
+topLevelNoFailures n = it (unpack n ++ " has no failures") $ \r ->
+  checkFailures r shouldBe
 
-topLevelFails :: Text -> TCResult -> Spec
-topLevelFails n r =
-  it (unpack n ++ " should fail") $ checkFailures r shouldNotBe
+topLevelFails :: Text -> SpecWith TCResult
+topLevelFails n = it (unpack n ++ " should fail") $ \r ->
+  r `checkFailures` shouldNotBe
 
-topLevelChecks :: Text -> TCResult -> Spec
-topLevelChecks n r = topLevelTypechecks n r >> topLevelNoFailures n r
+topLevelChecks :: Text -> SpecWith TCResult
+topLevelChecks n = topLevelTypechecks n  >> topLevelNoFailures n
 
 checkModule :: FilePath -> ModuleName -> Spec
 checkModule fp mn = describe (fp ++ ": " ++ moduleName mn ++ " typechecks") $ do
-  (tls,fs) <- runIO $ inferModule False fp mn
-  it (moduleName mn ++ ": module has no failures") $ map prettyFail fs `shouldBe` []
-  it (moduleName mn ++ ": all toplevels typecheck") $ concatMap getUnresolvedTys tls `shouldBe` []
+  beforeAll (inferModule False fp mn) $ do
+    it (moduleName mn ++ ": module has no failures") $ \(_, fs) ->
+      map prettyFail fs `shouldBe` []
+    it (moduleName mn ++ ": all toplevels typecheck") $ \(tls, _) ->
+      concatMap getUnresolvedTys tls `shouldBe` []
 
 moduleName :: ModuleName -> String
 moduleName = unpack . asString
 
 -- | Check that this module has no verification failures
 verifyModule :: FilePath -> ModuleName -> Spec
-verifyModule fp mn = describe (fp ++ ": " ++ moduleName mn ++ " verifies") $ do
-  success <- runIO $ do
-    (resultTm, replState) <- execScript' Quiet fp
-    either (die def) (const (pure ())) resultTm
-    eModule <- replLookupModule replState mn
-    modul <- case eModule of
-      Left e      -> die def $ "Module not found: " ++ show (fp,mn,e)
-      Right modul -> pure modul
-    mModules <- replGetModules replState
-    checkResult <- case mModules of
-      Left err           -> die def (show err)
-      Right (modules, _) -> Check.verifyModule def (inlineModuleData <$> modules) (inlineModuleData modul)
-    let ros = Check.renderVerifiedModule checkResult
-    pure $ if any ((== OutputFailure) . _roType) ros
-       then expectationFailure $ T.unpack $
-            "Verification errors found: " <> T.intercalate "\n" (map renderCompactText ros)
-       else pure ()
-  it (moduleName mn ++ ": module verifies") success
+verifyModule fp mn = it (fp ++ ": " ++ moduleName mn ++ " verifies") $ do
+  (resultTm, replState) <- execScript' Quiet fp
+  either (die def) (const (pure ())) resultTm
+  eModule <- replLookupModule replState mn
+  modul <- case eModule of
+    Left e      -> die def $ "Module not found: " ++ show (fp,mn,e)
+    Right modul -> pure modul
+  mModules <- replGetModules replState
+  checkResult <- case mModules of
+    Left err           -> die def (show err)
+    Right (modules, _) -> Check.verifyModule def (inlineModuleData <$> modules) (inlineModuleData modul)
+  let ros = Check.renderVerifiedModule checkResult
+  when (any ((== OutputFailure) . _roType) ros) $
+    expectationFailure $ T.unpack $
+      "Verification errors found: " <> T.intercalate "\n" (map renderCompactText ros)
 
 prettyFail :: Failure -> String
 prettyFail (Failure TcId{..} msg) = renderInfo _tiInfo ++ ": " ++ msg
 
 
 checkFun :: FilePath -> ModuleName -> Text -> Spec
-checkFun fp mn fn = do
-  r <- runIO $ inferFun False fp mn fn
-  topLevelChecks (asString mn <> "." <> fn) r
+checkFun fp mn fn =
+  beforeAll (inferFun False fp mn fn) $
+    topLevelChecks (asString mn <> "." <> fn)
 
 
 checkFuns :: Spec
 checkFuns = describe "pact typecheck" $ do
   let mn = "tests/pact/tc.repl"
-  (ModuleData _ m _) <- runIO $ fmap inlineModuleData $ loadModule mn "tctest"
+  -- runIO is needed here to construct the test tree
+  (ModuleData _ m _) <- runIO $ inlineModuleData <$> loadModule mn "tctest"
   forM_ (HM.toList m) $ \(fn,ref) -> do
-    let doTc = runIO $ runTC 0 False (typecheckTopLevel ref)
+    let doTc = beforeAll (runTC 0 False (typecheckTopLevel ref))
         n = asString mn <> "." <> fn
     when (take 3 fn == "tc-") $
-      doTc >>= \r -> do
-      topLevelChecks n r
-      customFunChecks n r
+      doTc $ do
+        topLevelChecks n
+        customFunChecks n
     when (take 6 fn == "fails-") $
-      doTc >>= \r -> do
-        topLevelTypechecks n r
-        topLevelFails n r
+      doTc $ do
+        topLevelTypechecks n
+        topLevelFails n
 
-
-customFunChecks :: Text -> TCResult -> Spec
-customFunChecks name (tl,_) = case name of
+customFunChecks :: Text -> SpecWith TCResult
+customFunChecks name = case name of
   "tests/pact/tc.repl.tc-update-partial" -> do
     -- TODO top levels don't get inferred return type, so we have to dig in here
-    it (show name ++ ":specializes partial type") $
-      preview (tlFun . fBody . _head . aNode . aTy . tySchemaPartial) tl
-        `shouldBe`
-      (Just $ PartialSchema $ Set.singleton "name")
+    it (show name ++ ":specializes partial type") $ \(tl, _) -> do
+      shouldBe
+        (preview (tlFun . fBody . _head . aNode . aTy . tySchemaPartial) tl)
+        (Just $ PartialSchema $ Set.singleton "name")
   _ -> return ()
 
 loadModule :: FilePath -> ModuleName -> IO (ModuleData Ref)

--- a/tests/Utils.hs
+++ b/tests/Utils.hs
@@ -1,0 +1,14 @@
+module Utils
+( testMgr
+) where
+
+import qualified Network.HTTP.Client as HTTP
+
+import System.IO.Unsafe
+
+-- | Use a single global Manager throughout all tests
+--
+testMgr :: HTTP.Manager
+testMgr = unsafePerformIO $ HTTP.newManager HTTP.defaultManagerSettings
+{-# NOINLINE testMgr #-}
+


### PR DESCRIPTION
This PR 

* [x] fixes and speeds up the creation of the test tree for the unit tests.
* [x] makes the tests suite safe to run with with more than a single core using `-j` or `+RTS -N`.
* [x] prevents tests server from being exposed on public networks
* [x] suppresses the firewall popup on macOS when running test suite.

### Regarding Test Tree Creation

With this PR `$(cabal list-bin spec) --help` will return almost instantly and use of `--match` will use only the time that is required to run the matching tests.

Most uses of `runIO` are replaced by `beforeAll` or [other appropriate hspec  test hooks](https://hackage.haskell.org/package/hspec-core-2.10.6/docs/Test-Hspec-Core-Hooks.html).

The function `runIO` is intended to be used only for creation of the test tree. However, it was miss-used throughout the code base to execute test logic.

> runIO :: [IO](https://hackage.haskell.org/package/base-4.16.3.0/docs/System-IO.html#t:IO) r -> [SpecM](https://hackage.haskell.org/package/hspec-core-2.10.6/docs/Test-Hspec-Core-Spec.html#t:SpecM) a r     [#](https://hackage.haskell.org/package/hspec-2.10.6/docs/Test-Hspec.html#v:runIO)
>
> Run an IO action while constructing the spec tree.
>
> [SpecM](https://hackage.haskell.org/package/hspec-core-2.10.6/docs/Test-Hspec-Core-Spec.html#t:SpecM) is a monad to construct a spec tree, without executing any spec items. runIO allows you to run IO actions during this construction phase. The IO action is always run when the spec tree is constructed (e.g. even when --dry-run is specified). If you do not need the result of the IO action to construct the spec tree, [beforeAll](https://hackage.haskell.org/package/hspec-core-2.10.6/docs/Test-Hspec-Core-Hooks.html#v:beforeAll) may be more suitable for your use case.

There were a few places in the code where the test tree would depend on the outcome of execution of previous tests. As a result a large part of the test code was executed during test tree creation. This also cause allocation of a lot of data on the heap during initial test-tree creation. This data was released only after all preceding tests were executed. The PR makes the shape of the test tree independent of the outcome of test logic, while trying to retain the current shape as much as possible.