### PR TITLE
Revert "Pluggable user table name munger (#1074)"

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -317,11 +317,8 @@ library
         , hedgehog >= 1.0.1 && < 1.2
         , hspec
         , hspec-golden >= 0.1.0.2
-        , http-client
         , hw-hspec-hedgehog == 0.1.*
         , intervals
-        , temporary >= 1.3
-
 
 executable pact
   if impl(ghcjs) || !flag(build-tool)
@@ -431,7 +428,6 @@ test-suite hspec
         , QuickCheck
         , deepseq
         , directory
-        , direct-sqlite
         , exceptions
         , hedgehog >= 1.0.1 && < 1.2
         , hspec-golden >= 0.1.0.2

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -158,7 +158,7 @@ loadBenchModule db = do
            [Signer Nothing pk Nothing []]
   let ec = ExecutionConfig $ S.fromList [FlagDisablePact44]
   e <- setupEvalEnv db entity Transactional md initRefStore
-          freeGasEnv permissiveNamespacePolicy noSPVSupport def ec simpleTableMunger
+          freeGasEnv permissiveNamespacePolicy noSPVSupport def ec
   (r :: Either SomeException EvalResult) <- try $ evalExec  defaultInterpreter e pc
   void $ eitherDie "loadBenchModule (load)" $ fmapL show r
   (benchMod,_) <- runEval def e $ getModule (def :: Info) (ModuleName "bench" Nothing)
@@ -186,7 +186,7 @@ runPactExec pt msg ss cdata benchMod dbEnv pc = do
   let md = MsgData cdata Nothing pactInitialHash ss
       ec = ExecutionConfig $ S.fromList [FlagDisablePact44]
   e <- fmap (set eeAdvice pt) $ setupEvalEnv dbEnv entity Transactional md
-          initRefStore prodGasEnv permissiveNamespacePolicy noSPVSupport def ec simpleTableMunger
+          initRefStore prodGasEnv permissiveNamespacePolicy noSPVSupport def ec
   let s = perfInterpreter pt $ defaultInterpreterState $
           maybe id (const . initStateModules . HM.singleton (ModuleName "bench" Nothing)) benchMod
   (r :: Either SomeException EvalResult) <- try $! evalExec s e pc
@@ -198,7 +198,7 @@ execPure pt dbEnv (n,ts) = do
   let md = MsgData Null Nothing pactInitialHash []
       ec = ExecutionConfig $ S.fromList [FlagDisablePact44]
   env <- fmap (set eeAdvice pt) $ setupEvalEnv dbEnv entity Local md
-            initRefStore prodGasEnv permissiveNamespacePolicy noSPVSupport def ec simpleTableMunger
+            initRefStore prodGasEnv permissiveNamespacePolicy noSPVSupport def ec
   o <- try $ runEval def env $ mapM eval ts
   case o of
     Left (e :: SomeException) -> die "execPure" (n ++ ": " ++ show e)

--- a/src-ghc/Pact/GasModel/Types.hs
+++ b/src-ghc/Pact/GasModel/Types.hs
@@ -239,7 +239,6 @@ defEvalEnv :: PactDbEnv e -> IO (EvalEnv e)
 defEvalEnv db = do
   setupEvalEnv db entity Transactional (initMsgData pactInitialHash)
     initRefStore prodGasModel permissiveNamespacePolicy noSPVSupport def noPact44EC
-    simpleTableMunger
   where entity = Just $ EntityName "entity"
         prodGasModel = GasEnv 10000000 0.01 $ tableGasModel defaultGasConfig
         noPact44EC = mkExecutionConfig [FlagDisablePact44]

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -152,7 +152,6 @@ applyExec rk hsh signers (ExecMsg parsedCode edata) = do
         (MsgData edata Nothing (toUntypedHash hsh) signers)
         initRefStore _ceGasEnv permissiveNamespacePolicy
         _ceSPVSupport _cePublicData _ceExecutionConfig
-        ucaseEncodeTableMunger
   EvalResult{..} <- liftIO $ evalExec defaultInterpreter evalEnv parsedCode
   mapM_ (\p -> liftIO $ logLog _ceLogger "DEBUG" $ "applyExec: new pact added: " ++ show p) _erExec
   return $ resultSuccess _erTxId rk _erGas (last _erOutput) _erExec _erLogs _erEvents
@@ -165,6 +164,5 @@ applyContinuation rk hsh signers cm = do
   evalEnv <- liftIO $ setupEvalEnv _ceDbEnv _ceEntity _ceMode
                 (MsgData (_cmData cm) Nothing (toUntypedHash hsh) signers) initRefStore
                 _ceGasEnv permissiveNamespacePolicy _ceSPVSupport _cePublicData _ceExecutionConfig
-                ucaseEncodeTableMunger
   EvalResult{..} <- liftIO $ evalContinuation defaultInterpreter evalEnv cm
   return $ resultSuccess _erTxId rk _erGas (last _erOutput) _erExec _erLogs _erEvents

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -216,22 +216,15 @@ descModule i [TLitString t] = do
     Nothing -> evalError' i $ "Module not found: " <> pretty t
 descModule i as = argsError i as
 
--- | Create domain from table
-userTable :: Term n -> Eval e (Domain RowKey RowData)
-userTable t = UserTables <$> userTable' t
+-- | unsafe function to create domain from TTable.
+userTable :: Show n => Term n -> Domain RowKey RowData
+userTable = UserTables . userTable'
 
--- | Munge table name per environment.
-userTable' :: Term n -> Eval e TableName
-userTable' TTable {..} = view eeTableMunger >>= \f -> pure $ f _tModuleName _tTableName
-userTable' t = evalError' t "userTable invariant error"
+-- | unsafe function to create TableName from TTable.
+userTable' :: Show n => Term n -> TableName
+userTable' TTable {..} = TableName $ asString _tModuleName <> "_" <> asString _tTableName
+userTable' t = error $ "creating user table from non-TTable: " ++ show t
 
--- | 'readRow' from TTable term
-readRow_ :: Info -> Term n -> RowKey -> Eval e (Maybe RowData)
-readRow_ i t k = userTable t >>= \t' -> readRow i t' k
-
--- | 'keys' from TTable term
-keys_ :: Info -> Term n -> Eval e [RowKey]
-keys_ i t = userTable t >>= keys i
 
 read' :: GasRNativeFun e
 read' g0 i as@(table@TTable {}:TLitString key:rest) = do
@@ -240,7 +233,7 @@ read' g0 i as@(table@TTable {}:TLitString key:rest) = do
     [l] -> colsToList (argsError i as) l
     _ -> argsError i as
   guardTable i table GtRead
-  mrow <- readRow_ (_faInfo i) table (RowKey key)
+  mrow <- readRow (_faInfo i) (userTable table) (RowKey key)
   case mrow of
     Nothing -> failTx (_faInfo i) $ "read: row not found: " <> pretty key
     Just cs -> do
@@ -267,9 +260,9 @@ foldDB' i [tbl, tLamToApp -> TApp qry _, tLamToApp -> TApp consumer _] = do
   asBool t = evalError' i $ "Unexpected return value from fold-db query condition " <> pretty t
   getKeys table = do
     guardTable i table GtKeys
-    keys_ (_faInfo i) table
+    keys (_faInfo i) (userTable table)
   fdb table (!g0, acc) key = do
-    mrow <- readRow_ (_faInfo i) table key
+    mrow <- readRow (_faInfo i) (userTable table) key
     case mrow of
       Just row -> do
         g1 <- gasPostRead i g0 row
@@ -325,11 +318,11 @@ select' i _ cols' app@TApp{} tbl@TTable{} = do
     guardTable i tbl GtSelect
     let fi = _faInfo i
         tblTy = _tTableType tbl
-    ks <- keys_ fi tbl
+    ks <- keys fi (userTable tbl)
     fmap (second (\b -> TList (V.fromList (reverse b)) tblTy def)) $
       (\f -> foldM f (g0 + g1, []) ks) $ \(gPrev,rs) k -> do
 
-      mrow <- readRow_ fi tbl k
+      mrow <- readRow fi (userTable tbl) k
       case mrow of
         Nothing -> evalError fi $ "select: unexpected error, key not found in select: "
                    <> pretty k <> ", table: " <> pretty tbl
@@ -355,7 +348,7 @@ withDefaultRead fi as@[table',key',defaultRow',b@(TBinding ps bd (BindSchema _) 
   case tkd of
     [table@TTable {}, TLitString key, TObject (Object defaultRow _ _ _) _] -> do
       guardTable fi table GtWithDefaultRead
-      mrow <- readRow_ (_faInfo fi) table (RowKey key)
+      mrow <- readRow (_faInfo fi) (userTable table) (RowKey key)
       case mrow of
         Nothing -> (g0,) <$> (bindToRow ps bd b =<< enforcePactValue' defaultRow)
         (Just row) -> gasPostRead' fi g0 row $ bindToRow ps bd b (rowDataToPactValue <$> _rdData row)
@@ -369,7 +362,7 @@ withRead fi as@[table',key',b@(TBinding ps bd (BindSchema _) _)] = do
   case tk of
     [table@TTable {},TLitString key] -> do
       guardTable fi table GtWithRead
-      mrow <- readRow_ (_faInfo fi) table (RowKey key)
+      mrow <- readRow (_faInfo fi) (userTable table) (RowKey key)
       case mrow of
         Nothing -> failTx (_faInfo fi) $ "with-read: row not found: " <> pretty key
         (Just row) -> gasPostRead' fi g0 row $ bindToRow ps bd b (rowDataToPactValue <$> _rdData row)
@@ -386,7 +379,7 @@ keys' g i [table@TTable {}] = do
   gasPostReads i g
     ((\b -> TList (V.fromList b) tTyString def) . map toTerm) $ do
       guardTable i table GtKeys
-      keys_ (_faInfo i) table
+      keys (_faInfo i) (userTable table)
 keys' _ i as = argsError i as
 
 
@@ -396,7 +389,7 @@ txids' g i [table@TTable {},TLitInteger key] = do
   gasPostReads i g
     ((\b -> TList (V.fromList b) tTyInteger def) . map toTerm) $ do
       guardTable i table GtTxIds
-      userTable' table >>= \t -> txids (_faInfo i) t (fromIntegral key)
+      txids (_faInfo i) (userTable' table) (fromIntegral key)
 txids' _ i as = argsError i as
 
 txlog :: GasRNativeFun e
@@ -404,7 +397,7 @@ txlog g i [table@TTable {},TLitInteger tid] = do
   checkNonLocalAllowed i
   gasPostReads i g (toTList TyAny def . map txlogToObj) $ do
       guardTable i table GtTxLog
-      userTable table >>= \t -> getTxLog (_faInfo i) t (fromIntegral tid)
+      getTxLog (_faInfo i) (userTable table) (fromIntegral tid)
 txlog _ i as = argsError i as
 
 txlogToObj :: TxLog RowData -> Term Name
@@ -430,9 +423,8 @@ keylog g i [table@TTable {..},TLitString key,TLitInteger utid] = do
                 toTObject TyAny def [("txid", toTerm t),("value",columnsToObject _tTableType (_txValue r))]
   gasPostReads i g postProc $ do
     guardTable i table GtKeyLog
-    table' <- userTable' table
-    tids <- txids (_faInfo i) table' (fromIntegral utid)
-    logs <- fmap concat $ forM tids $ \tid -> map (tid,) <$> getTxLog (_faInfo i) (UserTables table') tid
+    tids <- txids (_faInfo i) (userTable' table) (fromIntegral utid)
+    logs <- fmap concat $ forM tids $ \tid -> map (tid,) <$> getTxLog (_faInfo i) (userTable table) tid
     return $ filter (\(_,TxLog {..}) -> _txKey == key) logs
 
 keylog _ i as = argsError i as
@@ -452,8 +444,7 @@ write wt partial i as = do
         TyVar {} -> return ()
         tty -> void $ checkUserType partial (_faInfo i) ps tty
       rdv <- ifExecutionFlagSet' FlagDisablePact420 RDV0 RDV1
-      t <- userTable table
-      r <- success "Write succeeded" $ writeRow (_faInfo i) wt t (RowKey key) $
+      r <- success "Write succeeded" $ writeRow (_faInfo i) wt (userTable table) (RowKey key) $
           RowData rdv (pactValueToRowData <$> ps')
       return (cost0 + cost1, r)
     _ -> argsError i ts
@@ -462,7 +453,7 @@ write wt partial i as = do
 createTable' :: GasRNativeFun e
 createTable' g i [t@TTable {..}] = do
   guardTable i t GtCreateTable
-  tn <- userTable' t
+  let (UserTables tn) = userTable t
   szVer <- getSizeOfVersion
   computeGas' g i (GPreWrite (WriteTable (asString tn)) szVer) $
     success "TableCreated" $ createUserTable (_faInfo i) tn _tModuleName

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -33,11 +33,9 @@ module Pact.Repl
   , evalString
   , handleCompile
   , handleParse
-  , initEvalEnv
   , initPureEvalEnv
   , initReplState
   , initReplState'
-  , initReplStateDb
   , isPactFile
   , loadFile
   , parsedCompileEval
@@ -87,7 +85,6 @@ import Pact.Eval
 import Pact.Types.Pretty hiding (line)
 import Pact.Types.Runtime
 import Pact.Native
-import Pact.PersistPactDb (DbEnv(..))
 import Pact.Repl.Lib
 import Pact.Types.Logger
 import Pact.Types.SPV
@@ -127,11 +124,6 @@ initReplState' :: MonadIO m => LibState -> ReplMode -> m ReplState
 initReplState' ls m =
   liftIO (initEvalEnv ls) >>= \e -> return (ReplState e def m def def def)
 
-initReplStateDb :: MonadIO m => MVar (DbEnv e) -> ReplMode -> Maybe String -> m ReplState
-initReplStateDb pdb m verifyUri = do
-  ls <- liftIO $ initLibState' (LibDb pdb) verifyUri
-  initReplState' ls m
-
 initPureEvalEnv :: Maybe String -> IO (EvalEnv LibState)
 initPureEvalEnv verifyUri = do
   initLibState neverLog verifyUri >>= initEvalEnv
@@ -159,7 +151,6 @@ initEvalEnv ls = do
     , _eeExecutionConfig = def
     , _eeAdvice = def
     , _eeInRepl = True
-    , _eeTableMunger = simpleTableMunger
     }
   where
     spvs mv = set spvSupport (spv mv) noSPVSupport

--- a/src/Pact/Types/Purity.hs
+++ b/src/Pact/Types/Purity.hs
@@ -100,7 +100,6 @@ mkPureEnv holder purity readRowImpl env@EvalEnv{..} = do
     _eeExecutionConfig
     _eeAdvice
     _eeInRepl
-    _eeTableMunger
 
 -- | Operationally creates the sysread-only environment.
 -- Phantom type and typeclass assigned in "runXXX" functions.

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -28,7 +28,7 @@ module Pact.Types.Runtime
    RefStore(..),rsNatives,
    EvalEnv(..),eeRefStore,eeMsgSigs,eeMsgBody,eeMode,eeEntity,eePactStep,eePactDbVar,eeInRepl,
    eePactDb,eePurity,eeHash,eeGas, eeGasEnv,eeNamespacePolicy,eeSPVSupport,eePublicData,eeExecutionConfig,
-   eeAdvice,eeTableMunger,
+   eeAdvice,
    toPactId,
    Purity(..),
    RefState(..),rsLoaded,rsLoadedModules,rsNamespace,rsQualifiedDeps,
@@ -226,8 +226,6 @@ data EvalEnv e = EvalEnv {
     , _eeAdvice :: !Advice
       -- | Are we in the repl? If so, ignore info
     , _eeInRepl :: Bool
-      -- | Table name munging strategy
-    , _eeTableMunger :: TableMunger
     }
 makeLenses ''EvalEnv
 

--- a/tests/PactTestsSpec.hs
+++ b/tests/PactTestsSpec.hs
@@ -16,9 +16,11 @@ import Data.Text (unpack)
 import qualified Data.Text.IO as T
 
 import Pact.Repl
+import Pact.Repl.Lib
 import Pact.Repl.Types
 import Pact.Types.Logger
 import Pact.Types.Runtime
+import Pact.Persist.SQLite as SQLite
 import Pact.Interpreter
 import Pact.Parse (parsePact, legacyParsePact)
 
@@ -65,8 +67,9 @@ findTests' tdir = (map (tdir </>) . filter ((== ".repl") . reverse . take 5 . re
 
 runScript :: String -> SpecWith ()
 runScript fp = it fp $ do
-  (PactDbEnv _ pdb) <- mkInMemSQLiteEnv neverLog
-  rs <- initReplStateDb pdb Quiet Nothing
+  (PactDbEnv _ pdb) <- mkSQLiteEnv (newLogger neverLog "") False (SQLiteConfig "" []) neverLog
+  ls <- initLibState' (LibDb pdb) Nothing
+  rs <- initReplState' ls Quiet
   (r, ReplState{..}) <- execScriptState' fp rs id
   case r of
     Left e -> expectationFailure e

--- a/tests/PersistSpec.hs
+++ b/tests/PersistSpec.hs
@@ -2,30 +2,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 module PersistSpec (spec) where
 
-import Control.Concurrent
-import Control.Lens
-import Control.Monad
-import Data.Either
-import qualified Data.Map.Strict as M
-import Database.SQLite3.Direct
-import System.Directory
 import Test.Hspec
-
-import Pact.Interpreter
-import qualified Pact.Persist.SQLite as SQLite
-import qualified Pact.PersistPactDb as Pdb
 import Pact.PersistPactDb.Regression
-import Pact.Repl
-import Pact.Repl.Types
+import qualified Pact.Persist.SQLite as SQLite
+import System.Directory
+import Control.Monad
 import Pact.Types.Logger
-import Pact.Types.Runtime
+import Control.Concurrent
 
 spec :: Spec
 spec = do
   it "regress Pure" (void $ regressPure neverLog)
   describe "regress SQLite" regressSQLite
-  describe "simpleTableMungerTest" simpleTableMungerTest
-  describe "ucaseMungerTest" ucaseMungerTest
 
 
 regressSQLite :: Spec
@@ -38,35 +26,3 @@ regressSQLite = it "SQLite successfully closes" $ do
     _db <$> readMVar mv
   SQLite.closeSQLite db `shouldReturn` Right ()
   removeFile f
-
-dbScript :: FilePath
-dbScript = "tests/pact/db.repl"
-
-simpleTableMungerTest :: Spec
-simpleTableMungerTest = runMungerTest simpleTableMunger
-      [ "[USER_mungeModule_mungeTable_DATA]"
-      , "[USER_mungeNamespace.mungeModule_mungeTable_DATA]"
-      ]
-
-
-ucaseMungerTest :: Spec
-ucaseMungerTest = runMungerTest ucaseEncodeTableMunger
-      [ "[USER_munge:module.munge:table_DATA]"
-      , "[USER_munge:namespace.munge:module.munge:table_DATA]"
-      ]
-
--- | Munger test fixture.
--- munged names are further modified by backend, we're really
--- just ensuring that db functions work on sqlite with all
--- munge types, and verifying the mungers run.
-runMungerTest :: TableMunger -> [Utf8] -> Spec
-runMungerTest munger names = do
-  (PactDbEnv _ pdb) <- runIO $ mkInMemSQLiteEnv neverLog
-  rs <- set (rEnv . eeTableMunger) munger <$> runIO (initReplStateDb pdb Quiet Nothing)
-  (r,_) <- runIO $ execScriptState' dbScript rs id
-  -- statements are indexed by table name so grab them to test
-  -- easier than running `.tables` on the connection directly
-  ks <- M.keys . SQLite.tableStmts . Pdb._db <$> runIO (readMVar pdb)
-  it "db repl succeeds" $ r `shouldSatisfy` isRight
-  forM_ names $ \t ->
-    it ("found table " ++ show t) $ ks `shouldSatisfy` (t `elem`)

--- a/tests/Utils.hs
+++ b/tests/Utils.hs
@@ -114,3 +114,4 @@ withTestPactServerWithSpv label flags spv action =
     withTestPactServerWithSpv_ spv fp $ \port -> do
       clientEnv <- mkClientEnv testMgr <$> parseBaseUrl (serverRoot port)
       action clientEnv
+

--- a/tests/pact/db.repl
+++ b/tests/pact/db.repl
@@ -269,26 +269,3 @@
   [["a" 1] ["b" 2]]
   (fold-db fdb-tbl (lambda (k o)  (< k "c")) (lambda (k o) [k (at 'a o)]))
   )
-
-
-;; tables specifically for testing munging, see PersistSpec
-(begin-tx)
-
-;; root version
-(module mungeModule G
-  (defcap G () (enforce false "non-upgradeable"))
-  (defschema s i:integer)
-  (deftable mungeTable:{s}))
-(create-table mungeTable)
-
-;; namespace version
-(define-namespace "mungeNamespace" (sig-keyset) (sig-keyset))
-(namespace 'mungeNamespace)
-
-(module mungeModule G
-  (defcap G () 1)
-  (defschema s i:integer)
-  (deftable mungeTable:{s}))
-(create-table mungeTable)
-
-(commit-tx)


### PR DESCRIPTION
This reverts commit 1afa7d24de6c42af55a7395ba853c84048e29141.

There are issues involved with how a change in munging changes the interpretation of table names after the upcoming fork, so this fix is not correct and needs further deliberation.