### PR TITLE
Allow use of unary operations without a binary form in properties

### DIFF
--- a/src-tool/Pact/Analyze/Parse/Prop.hs
+++ b/src-tool/Pact/Analyze/Parse/Prop.hs
@@ -564,6 +564,11 @@ inferPreProp preProp = case preProp of
     _   <- expectColumnType tn' cn' SGuard
     Some SBool . PropSpecific . RowEnforced tn' cn' <$> checkPreProp SStr rk
 
+  PreApp (toOp unaryArithOpP -> Just _) _ -> asum
+    [ Some SInteger <$> checkPreProp SInteger preProp
+    , Some SDecimal <$> checkPreProp SDecimal preProp
+    ]
+
   -- For unary / binary arithmetic operations, we switch polarity to checking.
   -- Same for string concatenation. For list concatenation, we infer both
   -- lists, then check that they have the same type. For object merges, we

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -2942,6 +2942,23 @@ spec = describe "analyze" $ do
         `shouldBe`
         Left "in (+ 0 1), unexpected argument types for (+): integer and integer"
 
+    it "checks abs" $ do
+      textToProp SInteger "(abs 10)"
+        `shouldBe`
+        Right (Inj (IntUnaryArithOp Abs 10 :: Numerical Prop 'TyInteger))
+
+      textToProp SDecimal "(abs 10.0)"
+        `shouldBe`
+        Right (Inj (DecUnaryArithOp Abs 10 :: Numerical Prop 'TyDecimal))
+
+      inferProp'' "(abs 10)"
+        `shouldBe`
+        Right (Some SInteger (Inj (IntUnaryArithOp Abs 10 :: Numerical Prop 'TyInteger)))
+
+      inferProp'' "(abs 10.0)"
+        `shouldBe`
+        Right (Some SDecimal (Inj (DecUnaryArithOp Abs 10 :: Numerical Prop 'TyDecimal)))
+
     it "check take/drop" $ do
       textToProp SStr "(take 2 \"asdf\")"
         `shouldBe`


### PR DESCRIPTION
Example code:
```lisp
(module mymodule G
  @model
  [(defproperty foo (> (abs 10.0) 0.0))]

  (defcap G ()
    1)

  (defun read-account:integer ()
    @model [(property foo)]
    10))
```