### PR TITLE
added passage of time in the local pact server

### DIFF
--- a/pact.cabal
+++ b/pact.cabal
@@ -195,6 +195,7 @@ library
     , vector >= 0.11.0.0 && < 0.13
     , vector-algorithms >= 0.7
     , vector-space >= 0.10.4 && < 0.17
+    , time
 
   -- GHCJS
   if impl(ghcjs)

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -37,6 +37,7 @@ import Pact.Types.Server
 import Pact.Types.Pretty (viaShow)
 import Pact.Types.PactValue (PactValue)
 import Pact.Types.SPV
+import Data.Time.Clock.System
 
 
 initPactService
@@ -94,13 +95,14 @@ applyCmd _ _ _ _ _ _ _ _ _ _ cmd (ProcFail s) =
            Nothing
            (cmdToRequestKey cmd)
            (PactError TxFailure def def . viaShow $ s)
-applyCmd logger conf dbv gasModel bh bt pbh spv exConfig exMode _ (ProcSucc cmd) = do
+applyCmd logger conf dbv gasModel bh _ pbh spv exConfig exMode _ (ProcSucc cmd) = do
+  blocktime <-  (((*) 1000000) <$> systemSeconds <$> getSystemTime)
+  
   let payload = _cmdPayload cmd
       gasEnv = GasEnv (_pmGasLimit pubMeta) (_pmGasPrice pubMeta) gasModel
-      pd = PublicData pubMeta bh bt pbh
+      pd = PublicData pubMeta bh blocktime pbh
       pubMeta = _pMeta payload
       nid = _pNetworkId payload
-
 
   res <- catchesPactError $ runCommand
                             (CommandEnv conf exMode dbv logger gasEnv pd spv nid exConfig)


### PR DESCRIPTION
The current `pact -s` local server does not proceed block-time as well as block-height and prev-block-hash, but I didn't change the last two as I am not sure when a block mine is supposed to happen. This sets the block-time at the current UTC time which makes the (chain-data) a little bit more interesting than being stuck on 0 of epoch.