### PR TITLE
Pact 4.4.1 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+4.4.1
+---
+* Export `ApiReq` constituent data structures (#1055)
+* Fix test tree creation to allow tests to run faster, safer to run on a single core,
+  and prevents test servers from being exposed to public environs (#1060, #1062)
+* Added capability guards (#1057)
+* Lazily evaluate `enforce` to reduce gas usage on evaluation (#1069)
+* Gas adjustment for various natives (#1071)
+* Fix FV regression that disallowed the verification of unary operators like `abs` (#1079)
+
 4.4
 ---
 * Document VSCode support - thanks JeremeyJS! (#965)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Lazily evaluate `enforce` to reduce gas usage on evaluation (#1069)
 * Gas adjustment for various natives (#1071)
 * Fix FV regression that disallowed the verification of unary operators like `abs` (#1079)
+* Documentation link fixes (thanks @przemeklach! #1075)
 
 4.4
 ---

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -461,7 +461,7 @@ Return ID if called during current pact execution, failing if not.
 Obtain current pact build version.
 ```lisp
 pact> (pact-version)
-"4.4"
+"4.4.1"
 ```
 
 Top level only: this function will fail if used in module code.

--- a/pact.cabal
+++ b/pact.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                pact
-version:             4.4
+version:             4.4.1
 -- ^ 4 digit is prerelease, 3- or 2-digit for prod release
 synopsis:            Smart contract language library and REPL
 description:


### PR DESCRIPTION
Bumps the `.cabal` file, updates the changelog, and ran the tests locally to produce any missed docs. 