### PR TITLE
Use Text in KeySet.PublicKey

### DIFF
--- a/src-ghc/Pact/ApiReq.hs
+++ b/src-ghc/Pact/ApiReq.hs
@@ -45,6 +45,7 @@ import Data.Aeson.Lens
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Short as SBS
 import Data.Default (def)
 import Data.List
 import Data.List.NonEmpty (NonEmpty(..))
@@ -358,7 +359,7 @@ signCmd keyFiles bs = do
     Right h -> do
       kps <- mapM importKeyFile keyFiles
       let signSingle kp = do
-            sig <- signHash (fromUntypedHash $ Hash h) kp
+            sig <- signHash (fromUntypedHash $ Hash $ SBS.toShort h) kp
             return $ toB16Text (getPublic kp) .= _usSig sig
       sigs <- mapM signSingle kps
       return $ Y.encode $ object sigs

--- a/src-ghc/Pact/ApiReq.hs
+++ b/src-ghc/Pact/ApiReq.hs
@@ -68,7 +68,7 @@ import Pact.Types.Capability
 import Pact.Types.Command
 import Pact.Types.Crypto
 import Pact.Types.RPC
-import Pact.Types.Runtime hiding (PublicKey)
+import Pact.Types.Runtime
 import Pact.Types.SigData
 import Pact.Types.SPV
 

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -19,7 +19,6 @@ import Criterion.Main hiding (env)
 import Data.Aeson
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Short as SBS
 import Data.ByteString.Lazy (toStrict)
 import Data.Default
 import qualified Data.HashMap.Strict as HM
@@ -210,12 +209,12 @@ benchPures pt dbEnv es = bgroup "pures" $ (`map` es) $
   \p -> benchNFIO (fst p) $ execPure pt dbEnv p
 
 benchKeySet :: KeySet
-benchKeySet = mkKeySet [PublicKey "benchadmin"] ">"
+benchKeySet = mkKeySet [PublicKeyText "benchadmin"] ">"
 
 acctRow :: RowData
 acctRow = RowData RDV1 $ fmap pactValueToRowData $ ObjectMap $ M.fromList
   [("balance",PLiteral (LDecimal 100.0))
-  ,("guard",PGuard $ GKeySet (mkKeySet [PublicKey $ SBS.toShort $ encodeUtf8 pk] "keys-all"))
+  ,("guard",PGuard $ GKeySet (mkKeySet [PublicKeyText pk] "keys-all"))
   ]
 
 benchRead :: PersistModuleData -> Domain k v -> k -> Method () (Maybe v)

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -19,6 +19,7 @@ import Criterion.Main hiding (env)
 import Data.Aeson
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as SBS
 import Data.ByteString.Lazy (toStrict)
 import Data.Default
 import qualified Data.HashMap.Strict as HM
@@ -214,7 +215,7 @@ benchKeySet = mkKeySet [PublicKey "benchadmin"] ">"
 acctRow :: RowData
 acctRow = RowData RDV1 $ fmap pactValueToRowData $ ObjectMap $ M.fromList
   [("balance",PLiteral (LDecimal 100.0))
-  ,("guard",PGuard $ GKeySet (mkKeySet [PublicKey $ encodeUtf8 pk] "keys-all"))
+  ,("guard",PGuard $ GKeySet (mkKeySet [PublicKey $ SBS.toShort $ encodeUtf8 pk] "keys-all"))
   ]
 
 benchRead :: PersistModuleData -> Domain k v -> k -> Method () (Maybe v)

--- a/src-ghc/Pact/GasModel/Utils.hs
+++ b/src-ghc/Pact/GasModel/Utils.hs
@@ -382,16 +382,16 @@ sampleLoadedKeysetName = "some-loaded-keyset"
 sampleLoadedMultisigKeysetName :: T.Text
 sampleLoadedMultisigKeysetName = "some-loaded-multisig-keyset"
 
-samplePubKeys :: [PublicKey]
-samplePubKeys = [PublicKey "something"]
+samplePubKeys :: [PublicKeyText]
+samplePubKeys = [PublicKeyText "something"]
 
-sampleMultiPubKeys :: [PublicKey]
+sampleMultiPubKeys :: [PublicKeyText]
 sampleMultiPubKeys =
-  [ PublicKey "key1"
-  , PublicKey "key2"
+  [ PublicKeyText "key1"
+  , PublicKeyText "key2"
   ]
 
-samplePubKeysWithCaps :: [(PublicKey, S.Set SigCapability)]
+samplePubKeysWithCaps :: [(PublicKeyText, S.Set SigCapability)]
 samplePubKeysWithCaps = map (\p -> (p,S.empty)) samplePubKeys
 
 sampleKeyset :: KeySet

--- a/src-ghc/Pact/Interpreter.hs
+++ b/src-ghc/Pact/Interpreter.hs
@@ -44,6 +44,7 @@ import Control.Monad.State (modify)
 import Control.Lens
 
 import Data.Aeson
+import qualified Data.ByteString.Short as SBS
 import Data.Default
 import Data.HashMap.Strict (HashMap)
 import qualified Data.Map.Strict as M
@@ -195,7 +196,7 @@ setupEvalEnv dbEnv ent mode msgData refStore gasEnv np spv pd ec = do
       where
         toPair Signer{..} = (pk,S.fromList _siCapList)
           where
-            pk = PublicKey $ encodeUtf8 $ fromMaybe _siPubKey _siAddress
+            pk = PublicKey $ SBS.toShort $ encodeUtf8 $ fromMaybe _siPubKey _siAddress
 
 
 initRefStore :: RefStore
@@ -240,7 +241,7 @@ evalTerms interp input = withRollback (start (interpreter interp runInput) >>= e
 
   where
 
-    withRollback act = 
+    withRollback act =
       act `onException` safeRollback
 
     safeRollback =

--- a/src-ghc/Pact/Interpreter.hs
+++ b/src-ghc/Pact/Interpreter.hs
@@ -44,7 +44,6 @@ import Control.Monad.State (modify)
 import Control.Lens
 
 import Data.Aeson
-import qualified Data.ByteString.Short as SBS
 import Data.Default
 import Data.HashMap.Strict (HashMap)
 import qualified Data.Map.Strict as M
@@ -52,7 +51,6 @@ import Data.IORef
 import Data.Maybe
 import qualified Data.Set as S
 import Data.Text (Text)
-import Data.Text.Encoding (encodeUtf8)
 import System.Directory
 
 import Pact.Compile
@@ -196,7 +194,7 @@ setupEvalEnv dbEnv ent mode msgData refStore gasEnv np spv pd ec = do
       where
         toPair Signer{..} = (pk,S.fromList _siCapList)
           where
-            pk = PublicKey $ SBS.toShort $ encodeUtf8 $ fromMaybe _siPubKey _siAddress
+            pk = PublicKeyText $ fromMaybe _siPubKey _siAddress
 
 
 initRefStore :: RefStore

--- a/src-ghc/Pact/Main.hs
+++ b/src-ghc/Pact/Main.hs
@@ -47,7 +47,7 @@ import Text.Trifecta as TF hiding (err)
 import Pact.Coverage
 import Pact.Repl
 import Pact.Parse
-import Pact.Types.Runtime hiding (PublicKey)
+import Pact.Types.Runtime
 import Pact.Server.Server
 import Pact.ReplTools
 import Pact.Repl.Types

--- a/src-ghc/Pact/PersistPactDb/Regression.hs
+++ b/src-ghc/Pact/PersistPactDb/Regression.hs
@@ -73,7 +73,7 @@ runRegression p = do
   let row' = RowData RDV1 $ ObjectMap $ fmap pactValueToRowData $ M.fromList [("gah",toPV False),("fh",toPV (1 :: Int))]
   _writeRow pactdb Update usert "key1" row' v
   assertEquals' "user update" (Just row') (_readRow pactdb usert "key1" v)
-  let ks = mkKeySet [PublicKey "skdjhfskj"] "predfun"
+  let ks = mkKeySet [PublicKeyText "skdjhfskj"] "predfun"
   _writeRow pactdb Write KeySets "ks1" ks v
   assertEquals' "keyset write" (Just ks) $ _readRow pactdb KeySets "ks1" v
   (modName,modRef,mod') <- loadModule

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -32,7 +32,7 @@ import Pact.Types.Gas
 import Pact.Types.Logger
 import Pact.Types.Persistence
 import Pact.Types.RPC
-import Pact.Types.Runtime hiding (PublicKey)
+import Pact.Types.Runtime
 import Pact.Types.Server
 import Pact.Types.Pretty (viaShow)
 import Pact.Types.PactValue (PactValue)
@@ -97,7 +97,7 @@ applyCmd _ _ _ _ _ _ _ _ _ _ cmd (ProcFail s) =
            (PactError TxFailure def def . viaShow $ s)
 applyCmd logger conf dbv gasModel bh _ pbh spv exConfig exMode _ (ProcSucc cmd) = do
   blocktime <-  (((*) 1000000) <$> systemSeconds <$> getSystemTime)
-  
+
   let payload = _cmdPayload cmd
       gasEnv = GasEnv (_pmGasLimit pubMeta) (_pmGasPrice pubMeta) gasModel
       pd = PublicData pubMeta bh blocktime pbh

--- a/src-ghc/Pact/Types/Crypto.hs
+++ b/src-ghc/Pact/Types/Crypto.hs
@@ -50,6 +50,7 @@ import Prelude
 import GHC.Generics
 
 import Data.ByteString    (ByteString)
+import Data.ByteString.Short (fromShort)
 import Data.String        (IsString(..))
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -163,8 +164,8 @@ instance Scheme (SPPKScheme 'ED25519) where
   type PrivateKey (SPPKScheme 'ED25519) = Ed25519.SecretKey
   type Signature (SPPKScheme 'ED25519) = Ed25519.Signature
 
-  _sign _ (Hash msg) pub priv = return $ Ed25519.sign priv pub msg
-  _valid _ (Hash msg) pub sig = Ed25519.verify pub msg sig
+  _sign _ (Hash msg) pub priv = return $ Ed25519.sign priv pub (fromShort msg)
+  _valid _ (Hash msg) pub sig = Ed25519.verify pub (fromShort msg) sig
   _genKeyPair _ = ed25519GenKeyPair
   _getPublic _ = Just . ed25519GetPublicKey
   _formatPublicKey _ p = toBS p
@@ -226,8 +227,8 @@ instance Scheme (SPPKScheme 'ETH) where
   type Signature (SPPKScheme 'ETH) = ECDSA.Signature
 
 
-  _sign _ (Hash msg) pub priv = ECDSA.signETH msg pub priv
-  _valid _ (Hash msg) pub sig = ECDSA.validETH msg pub sig
+  _sign _ (Hash msg) pub priv = ECDSA.signETH (fromShort msg) pub priv
+  _valid _ (Hash msg) pub sig = ECDSA.validETH (fromShort msg) pub sig
   _genKeyPair _ = ECDSA.genKeyPair
   _getPublic _ = Just . ECDSA.getPublicKey
   _formatPublicKey _ p = ECDSA.formatPublicKeyETH (toBS p)

--- a/src-ghc/Pact/Types/Server.hs
+++ b/src-ghc/Pact/Types/Server.hs
@@ -47,9 +47,7 @@ import Control.Monad.Reader
 import Control.Concurrent.Chan
 import Data.Maybe
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Short as SBS
 import qualified Data.Set as S
-import Data.Text.Encoding
 import Data.HashSet (HashSet)
 import Data.HashMap.Strict (HashMap)
 
@@ -64,13 +62,13 @@ import Pact.Types.SPV
 
 -- | Grab "runtime" public key from Signer, which is address
 -- if specified, otherwise pubkey
-userSigToPactPubKey :: Signer -> Pact.PublicKey
+userSigToPactPubKey :: Signer -> Pact.PublicKeyText
 userSigToPactPubKey Signer{..} =
-  Pact.PublicKey $ SBS.toShort $ encodeUtf8 $ fromMaybe _siPubKey _siAddress
+  Pact.PublicKeyText $ fromMaybe _siPubKey _siAddress
 
 
 -- | See 'userSigToPactPubKey'
-userSigsToPactKeySet :: [Signer] -> S.Set Pact.PublicKey
+userSigsToPactKeySet :: [Signer] -> S.Set Pact.PublicKeyText
 userSigsToPactKeySet = S.fromList . fmap userSigToPactPubKey
 
 

--- a/src-ghc/Pact/Types/Server.hs
+++ b/src-ghc/Pact/Types/Server.hs
@@ -47,6 +47,7 @@ import Control.Monad.Reader
 import Control.Concurrent.Chan
 import Data.Maybe
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Short as SBS
 import qualified Data.Set as S
 import Data.Text.Encoding
 import Data.HashSet (HashSet)
@@ -65,7 +66,7 @@ import Pact.Types.SPV
 -- if specified, otherwise pubkey
 userSigToPactPubKey :: Signer -> Pact.PublicKey
 userSigToPactPubKey Signer{..} =
-  Pact.PublicKey $ encodeUtf8 $ fromMaybe _siPubKey _siAddress
+  Pact.PublicKey $ SBS.toShort $ encodeUtf8 $ fromMaybe _siPubKey _siAddress
 
 
 -- | See 'userSigToPactPubKey'

--- a/src-tool/Pact/Analyze/Check.hs
+++ b/src-tool/Pact/Analyze/Check.hs
@@ -111,8 +111,9 @@ smtConfig = SBV.z3
 
 -- | Solver timeout in millis. Usually timeout is a bad sign
 -- but can always try larger values here.
+--
 timeout :: Integer
-timeout = 10000
+timeout = 20000
 
 newtype VerificationWarnings = VerificationWarnings [Text]
   deriving (Eq, Show)

--- a/src/Pact/Native/Decrypt.hs
+++ b/src/Pact/Native/Decrypt.hs
@@ -27,7 +27,7 @@ import Data.Text.Encoding
 
 import Pact.Native.Internal
 import Pact.Types.Pretty
-import Pact.Types.Runtime hiding (PublicKey)
+import Pact.Types.Runtime
 #if !defined(ghcjs_HOST_OS)
 import qualified Data.ByteArray as BA
 import Crypto.PubKey.Curve25519

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -65,7 +65,6 @@ import Control.Monad.State.Strict
 import Data.Aeson hiding ((.=),Object)
 import qualified Data.Aeson as A
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.UTF8 as BS
 import Data.Char
 import Data.Default
 import Data.List
@@ -193,7 +192,7 @@ getDelta :: Repl Delta
 getDelta = do
   m <- use rMode
   case m of
-    (Script _ file) -> return $ Directed (BS.fromString file) 0 0 0 0
+    (Script _ file) -> return $ Directed (encodeUtf8 $ pack file) 0 0 0 0
     _ -> return mempty
 
 handleParse :: TF.Result [Exp Parsed] -> ([Exp Parsed] -> Repl (Either String a)) -> Repl (Either String a)
@@ -286,7 +285,7 @@ renderErr a
   | peInfo a == def = do
       m <- use rMode
       let i = case m of
-                Script _ f -> Info (Just (mempty,Parsed (Directed (BS.fromString f) 0 0 0 0) 0))
+                Script _ f -> Info (Just (mempty,Parsed (Directed (encodeUtf8 $ pack f) 0 0 0 0) 0))
                 _ -> Info (Just (mempty,Parsed (Lines 0 0 0 0) 0))
       return $ renderInfo i ++ ": " ++ renderCompactString' (peDoc a)
   | otherwise = return $ renderInfo (peInfo a) ++ ": " ++ renderCompactString' (peDoc a)

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -30,7 +30,6 @@ import Control.Monad.State.Strict (get,put)
 
 import Data.Aeson (eitherDecode,toJSON)
 import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString.Short as SBS
 import Data.Default
 import Data.Foldable
 import Data.IORef
@@ -369,7 +368,7 @@ setsigs i [TList ts _ _] = do
   ks <- forM ts $ \t -> case t of
           (TLitString s) -> return s
           _ -> argsError i (V.toList ts)
-  setenv eeMsgSigs $ M.fromList ((,mempty) . PublicKey . SBS.toShort . encodeUtf8 <$> V.toList ks)
+  setenv eeMsgSigs $ M.fromList ((,mempty) . PublicKeyText <$> V.toList ks)
   return $ tStr "Setting transaction keys"
 setsigs i as = argsError i as
 
@@ -384,7 +383,7 @@ setsigs' _ [TList ts _ _] = do
               caps <- forM clist $ \cap -> case cap of
                 (TApp a _) -> view _1 <$> appToCap a
                 o -> evalError' o $ "Expected capability invocation"
-              return (PublicKey $ SBS.toShort $ encodeUtf8 k,S.fromList (V.toList caps))
+              return (PublicKeyText k,S.fromList (V.toList caps))
             _ -> evalError' k' "Expected string value"
         _ -> evalError' t "Expected object with 'key': string, 'caps': [capability]"
     _ -> evalError' t $ "Expected object"

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -30,6 +30,7 @@ import Control.Monad.State.Strict (get,put)
 
 import Data.Aeson (eitherDecode,toJSON)
 import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Short as SBS
 import Data.Default
 import Data.Foldable
 import Data.IORef
@@ -368,7 +369,7 @@ setsigs i [TList ts _ _] = do
   ks <- forM ts $ \t -> case t of
           (TLitString s) -> return s
           _ -> argsError i (V.toList ts)
-  setenv eeMsgSigs $ M.fromList ((,mempty) . PublicKey . encodeUtf8 <$> V.toList ks)
+  setenv eeMsgSigs $ M.fromList ((,mempty) . PublicKey . SBS.toShort . encodeUtf8 <$> V.toList ks)
   return $ tStr "Setting transaction keys"
 setsigs i as = argsError i as
 
@@ -383,7 +384,7 @@ setsigs' _ [TList ts _ _] = do
               caps <- forM clist $ \cap -> case cap of
                 (TApp a _) -> view _1 <$> appToCap a
                 o -> evalError' o $ "Expected capability invocation"
-              return (PublicKey $ encodeUtf8 k,S.fromList (V.toList caps))
+              return (PublicKey $ SBS.toShort $ encodeUtf8 k,S.fromList (V.toList caps))
             _ -> evalError' k' "Expected string value"
         _ -> evalError' t "Expected object with 'key': string, 'caps': [capability]"
     _ -> evalError' t $ "Expected object"

--- a/src/Pact/Runtime/Capabilities.hs
+++ b/src/Pact/Runtime/Capabilities.hs
@@ -264,8 +264,8 @@ revokeAllCapabilities = evalCapabilities .= def
 
 -- | Check signature caps against current granted set.
 checkSigCaps
-  :: M.Map PublicKey (S.Set UserCapability)
-     -> Eval e (M.Map PublicKey (S.Set UserCapability))
+  :: M.Map PublicKeyText (S.Set UserCapability)
+     -> Eval e (M.Map PublicKeyText (S.Set UserCapability))
 checkSigCaps sigs = go
   where
     go = do

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -73,7 +73,7 @@ import Pact.Types.ChainId
 import Pact.Types.Orphans ()
 import Pact.Types.PactValue (PactValue(..))
 import Pact.Types.RPC
-import Pact.Types.Runtime hiding (PublicKey)
+import Pact.Types.Runtime
 
 
 #if !defined(ghcjs_HOST_OS)

--- a/src/Pact/Types/Hash.hs
+++ b/src/Pact/Types/Hash.hs
@@ -27,6 +27,7 @@ module Pact.Types.Hash
 
 import Control.DeepSeq
 import Data.ByteString (ByteString)
+import Data.ByteString.Short (ShortByteString, fromShort, toShort)
 import Data.Hashable (Hashable(hashWithSalt))
 import Data.Serialize (Serialize(..))
 import Pact.Types.Pretty
@@ -57,7 +58,7 @@ import Crypto.Hash.Blake2Native
 -- | Untyped hash value, encoded with unpadded base64url.
 -- Within Pact these are blake2b_256 but unvalidated as such,
 -- so other hash values are kosher (such as an ETH sha256, etc).
-newtype Hash = Hash { unHash :: ByteString }
+newtype Hash = Hash { unHash :: ShortByteString }
   deriving (Eq, Ord, Generic, Hashable, Serialize,SizeOf)
 
 instance Arbitrary Hash where
@@ -65,13 +66,13 @@ instance Arbitrary Hash where
   arbitrary = pactHash <$> encodeUtf8 <$> resize 1000 arbitrary
 
 instance Show Hash where
-  show (Hash h) = show $ encodeBase64UrlUnpadded h
+  show (Hash h) = show $ encodeBase64UrlUnpadded $ fromShort h
 
 instance Pretty Hash where
   pretty = pretty . asString
 
 instance AsString Hash where
-  asString (Hash h) = decodeUtf8 (encodeBase64UrlUnpadded h)
+  asString (Hash h) = decodeUtf8 (encodeBase64UrlUnpadded $ fromShort h)
 
 instance NFData Hash
 
@@ -85,12 +86,12 @@ instance FromJSON Hash where
   {-# INLINE parseJSON #-}
 
 instance ParseText Hash where
-  parseText s = Hash <$> parseB64UrlUnpaddedText s
+  parseText s = Hash . toShort <$> parseB64UrlUnpaddedText s
   {-# INLINE parseText #-}
 
 
 hashToText :: Hash -> Text
-hashToText (Hash h) = toB64UrlUnpaddedText h
+hashToText (Hash h) = toB64UrlUnpaddedText $ fromShort h
 
 
 -- | All supported hashes in Pact (although not necessarily GHCJS pact).
@@ -110,7 +111,7 @@ hashLength SHA3_256 = 32
 
 -- | Typed hash, to indicate algorithm
 data TypedHash (h :: HashAlgo) where
-  TypedHash :: ByteString -> TypedHash h
+  TypedHash :: ShortByteString -> TypedHash h
   deriving (Eq, Ord, Generic)
 
 instance Hashable (TypedHash h) where
@@ -121,13 +122,13 @@ instance Serialize (TypedHash h) where
   get = fromUntypedHash <$> get
 
 instance Show (TypedHash h) where
-  show (TypedHash h) = show $ encodeBase64UrlUnpadded h
+  show (TypedHash h) = show $ encodeBase64UrlUnpadded $ fromShort h
 
 instance Pretty (TypedHash h) where
   pretty = pretty . asString
 
 instance AsString (TypedHash h) where
-  asString (TypedHash h) = decodeUtf8 (encodeBase64UrlUnpadded h)
+  asString (TypedHash h) = decodeUtf8 (encodeBase64UrlUnpadded $ fromShort h)
 
 instance NFData (TypedHash h)
 
@@ -139,11 +140,11 @@ instance FromJSON (TypedHash h) where
   {-# INLINE parseJSON #-}
 
 instance ParseText (TypedHash h) where
-  parseText s = TypedHash <$> parseB64UrlUnpaddedText s
+  parseText s = TypedHash . toShort <$> parseB64UrlUnpaddedText s
   {-# INLINE parseText #-}
 
 typedHashToText :: TypedHash h -> Text
-typedHashToText (TypedHash h) = toB64UrlUnpaddedText h
+typedHashToText (TypedHash h) = toB64UrlUnpaddedText $ fromShort h
 
 toUntypedHash :: TypedHash h -> Hash
 toUntypedHash (TypedHash h) = Hash h
@@ -166,7 +167,7 @@ pactHashLength = hashLength Blake2b_256
 #if !defined(ghcjs_HOST_OS)
 
 hash :: forall h . Reifies h HashAlgo => ByteString -> TypedHash h
-hash = TypedHash . go
+hash = TypedHash . toShort . go
   where
     algo = reflect (Proxy :: Proxy h)
     go = case algo of

--- a/src/Pact/Types/KeySet.hs
+++ b/src/Pact/Types/KeySet.hs
@@ -8,7 +8,7 @@
 -- License     :  BSD-style (see the file LICENSE)
 -- Maintainer  :  Stuart Popejoy <stuart@kadena.io>
 --
--- A Pact Keyset encapsulates the notion of a 'PublicKey'
+-- A Pact Keyset encapsulates the notion of a 'PublicKeyText'
 -- into a predicate that matches the image of the public key
 -- against some set in the environment representing public keys
 -- used to sign the currently operational transaction.
@@ -22,7 +22,7 @@
 --
 
 module Pact.Types.KeySet
-  ( PublicKey(..)
+  ( PublicKeyText(..)
   , KeySet(..)
   , KeySetName(..)
   , mkKeySet
@@ -46,8 +46,6 @@ import Control.Monad
 import Control.Lens hiding ((.=))
 import Data.Aeson
 import Data.Attoparsec.Text (parseOnly, takeText, Parser)
-import Data.ByteString.Short (ShortByteString, fromShort, toShort)
-import qualified Data.ByteString.Char8 as BSC
 import Data.Char
 import Data.Default
 import Data.Foldable
@@ -59,7 +57,6 @@ import Data.String
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import Data.Text.Encoding
 import GHC.Generics
 import Test.QuickCheck
 
@@ -79,28 +76,31 @@ import Text.Parser.Token
 --
 -- TODO: what exactly is the format?
 --
-newtype PublicKey = PublicKey { _pubKey :: ShortByteString }
-  deriving (Eq,Ord,Generic,IsString,AsString,Show,SizeOf)
+newtype PublicKeyText = PublicKeyText { _pubKey :: T.Text }
+  deriving (Eq,Ord,Generic,IsString,AsString,Show)
 
-instance Arbitrary PublicKey where
-  arbitrary = PublicKey . toShort . encodeUtf8 . T.pack <$> vectorOf 64 genValidPublicKeyChar
+instance SizeOf PublicKeyText where
+    sizeOf ver (PublicKeyText k) = sizeOf ver (T.encodeUtf8 k)
+
+instance Arbitrary PublicKeyText where
+  arbitrary = PublicKeyText . T.pack <$> vectorOf 64 genValidPublicKeyChar
     where genValidPublicKeyChar = suchThat arbitraryASCIIChar isAlphaNum
-instance Serialize PublicKey
-instance NFData PublicKey
-instance FromJSON PublicKey where
-  parseJSON = withText "PublicKey" (return . PublicKey . toShort . encodeUtf8)
-instance ToJSON PublicKey where
-  toJSON = toJSON . decodeUtf8 . fromShort . _pubKey
+instance Serialize PublicKeyText
+instance NFData PublicKeyText
+instance FromJSON PublicKeyText where
+  parseJSON = withText "PublicKeyText" (return . PublicKeyText)
+instance ToJSON PublicKeyText where
+  toJSON = toJSON . _pubKey
 
-instance Pretty PublicKey where
-  pretty (PublicKey s) = pretty (T.decodeUtf8 $ fromShort s)
+instance Pretty PublicKeyText where
+  pretty (PublicKeyText s) = pretty s
 
 -- -------------------------------------------------------------------------- --
 -- KeySet
 
 -- | KeySet pairs keys with a predicate function name.
 data KeySet = KeySet
-  { _ksKeys :: !(Set PublicKey)
+  { _ksKeys :: !(Set PublicKeyText)
   , _ksPredFun :: !Name
   } deriving (Eq,Generic,Show,Ord)
 makeLenses ''KeySet
@@ -226,19 +226,17 @@ parseQualifiedKeySetName
   = parseOnly qualifiedKeysetNameParser
 
 -- | Smart constructor for a simple list and barename predicate.
-mkKeySet :: [PublicKey] -> Text -> KeySet
+mkKeySet :: [PublicKeyText] -> Text -> KeySet
 mkKeySet pks p = KeySet
   (S.fromList pks)
   (Name $ BareName p def)
 
 -- | A predicate for public key format validation.
-type KeyFormat = PublicKey -> Bool
+type KeyFormat = PublicKeyText -> Bool
 
 -- | Current "Kadena" ED-25519 key format: 64-length hex.
 ed25519Hex :: KeyFormat
-ed25519Hex (PublicKey k) = BSC.length b == 64 && BSC.all isHexDigitLower b
-  where
-    b = fromShort k
+ed25519Hex (PublicKeyText k) = T.length k == 64 && T.all isHexDigitLower k
 
 -- | Lower-case hex numbers.
 isHexDigitLower :: Char -> Bool
@@ -250,12 +248,12 @@ isHexDigitLower c =
 keyFormats :: [KeyFormat]
 keyFormats = [ed25519Hex]
 
--- | Validate 'PublicKey' against 'keyFormats'.
-validateKeyFormat :: PublicKey -> Bool
+-- | Validate 'PublicKeyText' against 'keyFormats'.
+validateKeyFormat :: PublicKeyText -> Bool
 validateKeyFormat k = any ($ k) keyFormats
 
 -- | Enforce valid 'KeySet' keys, evaluating error action on failure.
-enforceKeyFormats :: Monad m => (PublicKey -> m ()) -> KeySet -> m ()
+enforceKeyFormats :: Monad m => (PublicKeyText -> m ()) -> KeySet -> m ()
 enforceKeyFormats err (KeySet ks _p) = traverse_ go ks
   where
     go k = unless (validateKeyFormat k) $ err k

--- a/src/Pact/Types/KeySet.hs
+++ b/src/Pact/Types/KeySet.hs
@@ -48,7 +48,6 @@ import Data.Aeson
 import Data.Attoparsec.Text (parseOnly, takeText, Parser)
 import Data.ByteString.Short (ShortByteString, fromShort, toShort)
 import qualified Data.ByteString.Char8 as BSC
-import qualified Data.ByteString.UTF8 as BSU
 import Data.Char
 import Data.Default
 import Data.Foldable
@@ -59,6 +58,7 @@ import qualified Data.Set as S
 import Data.String
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import Data.Text.Encoding
 import GHC.Generics
 import Test.QuickCheck
@@ -75,6 +75,10 @@ import Text.Parser.Token
 -- -------------------------------------------------------------------------- --
 -- PublicKey
 
+-- | Public key in UTF8 encoded textual format
+--
+-- TODO: what exactly is the format?
+--
 newtype PublicKey = PublicKey { _pubKey :: ShortByteString }
   deriving (Eq,Ord,Generic,IsString,AsString,Show,SizeOf)
 
@@ -89,7 +93,7 @@ instance ToJSON PublicKey where
   toJSON = toJSON . decodeUtf8 . fromShort . _pubKey
 
 instance Pretty PublicKey where
-  pretty (PublicKey s) = prettyString (BSU.toString $ fromShort s)
+  pretty (PublicKey s) = pretty (T.decodeUtf8 $ fromShort s)
 
 -- -------------------------------------------------------------------------- --
 -- KeySet

--- a/src/Pact/Types/Names.hs
+++ b/src/Pact/Types/Names.hs
@@ -39,6 +39,7 @@ import Control.DeepSeq
 import Control.Lens (makeLenses)
 import Data.Aeson (ToJSON(..), FromJSON(..), withText, FromJSONKey(..), ToJSONKey(..))
 import qualified Data.Attoparsec.Text as AP
+import qualified Data.ByteString.Short as SB
 import Data.Default
 import Data.Hashable
 import Data.Set (Set)
@@ -299,7 +300,7 @@ fullyQualNameParser = do
   oname <- optional (dot *> ident style)
   h <- dot *> (between (char '{') (char '}') $ some (alphaNum <|> char '-' <|> char '_'))
   hash' <- case parseB64UrlUnpaddedText' (T.pack h) of
-    Right hash' -> pure hash'
+    Right hash' -> pure $ SB.toShort hash'
     Left _ -> fail "invalid hash encoding"
   case oname of
     Just nn ->

--- a/src/Pact/Types/Pretty.hs
+++ b/src/Pact/Types/Pretty.hs
@@ -60,12 +60,12 @@ import           Control.DeepSeq      (NFData(..))
 import           GHC.Generics         (Generic(..))
 import           Bound.Var
 import           Data.Aeson           (Value(..))
-import qualified Data.ByteString.UTF8 as UTF8
 import           Data.Foldable        (toList)
 import qualified Data.HashMap.Strict  as HM
 import           Data.Int
 import           Data.Text            (Text, pack, unpack)
 import qualified Data.Text            as Text
+import qualified Data.Text.Encoding   as Text
 import           Data.Text.Prettyprint.Doc
   (SimpleDocStream, annotate, unAnnotate, layoutPretty,
   defaultLayoutOptions, vsep, hsep, (<+>), colon, angles, list, braces,
@@ -218,7 +218,7 @@ instance Pretty Delta where
         Columns c _         -> prettyDelta interactive 0 c
         Tab x y _           -> prettyDelta interactive 0 (nextTab x + y)
         Lines l c _ _       -> prettyDelta interactive l c
-        Directed fn l c _ _ -> prettyDelta (UTF8.toString fn) l c
+        Directed fn l c _ _ -> prettyDelta (unpack $ Text.decodeUtf8 fn) l c
       where
         prettyDelta
             :: String -- Source description

--- a/src/Pact/Types/Principal.hs
+++ b/src/Pact/Types/Principal.hs
@@ -18,6 +18,7 @@ import Control.Lens
 import Data.Aeson (encode)
 import Data.Attoparsec.Text
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as SBS
 import Data.ByteString.Lazy (toStrict)
 import Data.Foldable
 import Data.Functor (void)
@@ -108,7 +109,7 @@ principalParser (getInfo -> i) = kParser
       f c = c `elem` base64UrlUnpaddedAlphabet
 
     hexKeyFormat =
-      PublicKey . T.encodeUtf8 . T.pack <$> count 64 (satisfy isHexDigit)
+      PublicKey . SBS.toShort . T.encodeUtf8 . T.pack <$> count 64 (satisfy isHexDigit)
 
     char' = void . char
     eof' = void eof
@@ -186,7 +187,7 @@ guardToPrincipal chargeGas = \case
   GKeySet (KeySet ks pf) -> case (toList ks,asString pf) of
     ([k],"keys-all") -> chargeGas 1 >> pure (K k)
     (l,fun) -> do
-      h <- mkHash $ map _pubKey l
+      h <- mkHash $ map (SBS.fromShort . _pubKey) l
       pure $ W (asString h) fun
   GKeySetRef ksn -> chargeGas 1 >> pure (R ksn)
   GModule (ModuleGuard mn n) -> chargeGas 1 >> pure (M mn n)

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -193,7 +193,7 @@ data EvalEnv e = EvalEnv {
       -- | Environment references.
       _eeRefStore :: !RefStore
       -- | Verified keys from message.
-    , _eeMsgSigs :: !(M.Map PublicKey (S.Set UserCapability))
+    , _eeMsgSigs :: !(M.Map PublicKeyText (S.Set UserCapability))
       -- | JSON body accompanying message.
     , _eeMsgBody :: !Value
       -- | Execution mode

--- a/src/Pact/Types/SigData.hs
+++ b/src/Pact/Types/SigData.hs
@@ -31,7 +31,7 @@ import GHC.Generics
 
 import Pact.Parse
 import Pact.Types.Command
-import Pact.Types.Runtime hiding (PublicKey)
+import Pact.Types.Runtime
 
 newtype PublicKeyHex = PublicKeyHex { unPublicKeyHex :: Text }
   deriving (Eq,Ord,Show,Generic)

--- a/src/Pact/Types/SizeOf.hs
+++ b/src/Pact/Types/SizeOf.hs
@@ -29,6 +29,7 @@ module Pact.Types.SizeOf
 
 import Bound
 import qualified Data.ByteString.UTF8 as BS
+import qualified Data.ByteString.Short as SBS
 import Data.Decimal
 import Data.Int (Int64)
 import qualified Data.List as L
@@ -142,6 +143,12 @@ instance SizeOf BS.ByteString where
     where
       byteStringSize = (9 * wordSize) + byteStringLength
       byteStringLength = fromIntegral (BS.length bs)
+
+instance SizeOf SBS.ShortByteString where
+  sizeOf _ bs = byteStringSize
+    where
+      byteStringSize = (9 * wordSize) + byteStringLength
+      byteStringLength = fromIntegral (SBS.length bs)
 
 instance SizeOf Text where
   sizeOf _ t = (6 * wordSize) + (2 * (fromIntegral (T.length t)))

--- a/src/Pact/Types/SizeOf.hs
+++ b/src/Pact/Types/SizeOf.hs
@@ -148,7 +148,8 @@ instance SizeOf SBS.ShortByteString where
   sizeOf _ bs = byteStringSize
     where
       byteStringSize = (9 * wordSize) + byteStringLength
-      byteStringLength = fromIntegral (SBS.length bs)
+      -- byteStringLength = fromIntegral (SBS.length bs)
+      byteStringLength = fromIntegral (BS.length $ SBS.fromShort bs)
 
 instance SizeOf Text where
   sizeOf _ t = (6 * wordSize) + (2 * (fromIntegral (T.length t)))

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -35,7 +35,7 @@
 
 module Pact.Types.Term
  ( Meta(..),mDocs,mModel,
-   PublicKey(..),
+   PublicKeyText(..),
    KeySet(..), mkKeySet,
    KeySetName(..),
    PactGuard(..),

--- a/src/Pact/Types/Util.hs
+++ b/src/Pact/Types/Util.hs
@@ -53,6 +53,7 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Base64.URL as B64URL
 import qualified Data.ByteString.Lazy.Char8 as BSL8
+import qualified Data.ByteString.Short as SB
 import qualified Text.Trifecta as Trifecta
 import Data.Char
 import Data.Either (isRight)
@@ -180,6 +181,7 @@ class AsString a where asString :: a -> Text
 instance AsString String where asString = pack
 instance AsString Text where asString = id
 instance AsString B.ByteString where asString = asString . decodeUtf8
+instance AsString SB.ShortByteString where asString = asString . decodeUtf8 . SB.fromShort
 instance AsString BSL8.ByteString where asString = asString . BSL8.toStrict
 instance AsString Integer where asString = pack . show
 instance AsString a => AsString (Maybe a) where asString = maybe "" asString

--- a/tests/Analyze/Gen.hs
+++ b/tests/Analyze/Gen.hs
@@ -681,7 +681,7 @@ genParseTime = do
         StrLit timeStr
   pure (etm, emptyGenState)
 
-alice, bob :: Pact.PublicKey
+alice, bob :: Pact.PublicKeyText
 alice = "7d0c9ba189927df85c8c54f8b5c8acd76c1d27e923abbf25a957afdf25550804"
 bob   = "ac69d9856821f11b8e6ca5cdd84a98ec3086493fd6407e74ea9038407ec9eba9"
 

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -12,6 +12,7 @@ import Control.Lens hiding ((.=))
 import Control.Monad.Reader
 import Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL8
+import qualified Data.ByteString.Short as SBS
 import Data.Decimal
 import Data.Default (def)
 import qualified Data.HashMap.Strict as HM
@@ -102,7 +103,7 @@ testElideModRefEvents = do
 
 mkModuleHash :: Text -> IO ModuleHash
 mkModuleHash =
-  either (fail . show) (return . ModuleHash . Hash) . parseB64UrlUnpaddedText'
+  either (fail . show) (return . ModuleHash . Hash . SBS.toShort) . parseB64UrlUnpaddedText'
 
 testManagedCaps :: Spec
 testManagedCaps = do

--- a/tests/RoundTripSpec.hs
+++ b/tests/RoundTripSpec.hs
@@ -35,7 +35,7 @@ testJSONPersist = do
   rt "bool" (PLiteral (LBool False))
   rt "string" (PLiteral (LString "hello"))
   rt "time" (PLiteral (LTime (read "2016-09-17 22:47:31.904733 UTC")))
-  rt "keyset" (PGuard (GKeySet $ mkKeySet [PublicKey "askjh",PublicKey "dfgh"] "predfun"))
+  rt "keyset" (PGuard (GKeySet $ mkKeySet [PublicKeyText "askjh",PublicKeyText "dfgh"] "predfun"))
   rt "modref" (PModRef (ModRef "foo.bar" (Just ["baz", "bof.quux"]) def))
   rt "list" (PList (V.fromList [PLiteral (LInteger 123), PLiteral (LBool False), PLiteral (LTime (read "2016-09-17 22:47:31.904733 UTC"))]))
   rt "object" (PObject (ObjectMap (fromList [("A",PLiteral (LInteger 123)), ("B",PLiteral (LBool False))])))
@@ -48,7 +48,7 @@ testJSONColumns = do
   where
   uguard = GUser $ UserGuard (Name (BareName "a" def)) [PLiteral (LInteger 123)]
   pguard = GPact $ PactGuard (PactId "123") "456"
-  ksguard = GKeySet $ mkKeySet [PublicKey "askjh",PublicKey "dfgh"] "predfun"
+  ksguard = GKeySet $ mkKeySet [PublicKeyText "askjh",PublicKeyText "dfgh"] "predfun"
   ksrguard = GKeySetRef $ KeySetName "beepboop" Nothing
   mguard = GModule $ ModuleGuard (ModuleName "beep" Nothing) "boop"
   obj = ObjectMap $ fromList


### PR DESCRIPTION
* [x] Switch internal representation of `Pact.Types.KeysSet.PublicKey` from `ByteString` to `Text`. This type is actually expected to contain UTF8 encoded textual key material. Switching the representation makes this invariant explicit and also avoid numerous encoding/decoding cycles in the code. Additionally, `Text` is stored in pinned memory, which allows the storage of pact `Term`s in compact regions which, in some cases, is beneficial for GC performance.

* [x] Rename `PublicKey` into `PublicKeyText` in order to be more explicit about its meaning. It also reduces confusion from the overloading of the name `PublicKey` in the code base. Going forward this term is used for binary representations of the key material as it is used on cryptographic contexts.

* [x] Document the use of `length` from the `utf8-string` package in the `sizeOf` instance of `ByteString`.

* [x] remove use of `utf8-string` wherever it isn't required for legacy reasons.

* [x] bump z3 timeout from 10s to 20s to prevent occasional timeouts in CI

Some evidence for the effects on pact validation times on a mainnet node. The module cache was introduced around 2022-12-06T22:00:00, use compact region was first added around 2022-12-09T23:00:00, and optimized use of compact regions was deployed around 2022-12-10T23:00:00.  

<img width="880" alt="image" src="https://user-images.githubusercontent.com/1369810/206965745-20328086-23f0-45db-b615-9afe923ebbb7.png">

The effect of the use of compact regions in the module cache on some RTS metrics of a mainnet node:

<img width="1093" alt="image" src="https://user-images.githubusercontent.com/1369810/206967996-de958e91-a1de-4596-8d3e-193ec233a89d.png">

There also seems to be significant reduction in the rate of major GCs once the module cache reaches a certain fill level.