### PR TITLE
fix parsing failure message for PublicKeyText

### DIFF
--- a/src/Pact/Types/KeySet.hs
+++ b/src/Pact/Types/KeySet.hs
@@ -88,7 +88,7 @@ instance Arbitrary PublicKeyText where
 instance Serialize PublicKeyText
 instance NFData PublicKeyText
 instance FromJSON PublicKeyText where
-  parseJSON = withText "PublicKeyText" (return . PublicKeyText)
+  parseJSON = withText "PublicKey" (return . PublicKeyText)
 instance ToJSON PublicKeyText where
   toJSON = toJSON . _pubKey
 


### PR DESCRIPTION
This fix is needed in order to not break chainweb mainnet history replay