### PR TITLE
Add optional file path for `verify` to write SMTLib2 output

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -2147,13 +2147,13 @@ Typecheck MODULE, optionally enabling DEBUG output.
 
 *module*&nbsp;`string` *&rarr;*&nbsp;`string`
 
-*module*&nbsp;`string` *filepath*&nbsp;`string` *&rarr;*&nbsp;`string`
+*module*&nbsp;`string` *debug*&nbsp;`bool` *&rarr;*&nbsp;`string`
 
 
-Verify MODULE, checking that all properties hold, optionally enabling SMTLib2 file generation by supplying a FILEPATH
+Verify MODULE, checking that all properties hold. Optionally enabling SMTLib2 output to ".pact-verify-MODULE" file.
 ```lisp
 (verify "module")
-(verify "module" "/path/to/out.smt")
+(verify "module" true)
 ```
 
 

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -2147,8 +2147,14 @@ Typecheck MODULE, optionally enabling DEBUG output.
 
 *module*&nbsp;`string` *&rarr;*&nbsp;`string`
 
+*module*&nbsp;`string` *filepath*&nbsp;`string` *&rarr;*&nbsp;`string`
 
-Verify MODULE, checking that all properties hold.
+
+Verify MODULE, checking that all properties hold, optionally enabling SMTLib2 file generation by supplying a FILEPATH
+```lisp
+(verify "module")
+(verify "module" "/path/to/out.smt")
+```
 
 
 ### with-applied-env {#with-applied-env}

--- a/src-tool/Pact/Analyze/Remote/Server.hs
+++ b/src-tool/Pact/Analyze/Remote/Server.hs
@@ -165,4 +165,4 @@ loadModules mods0 = do
 
 runVerification :: ValidRequest -> IO Response
 runVerification (ValidRequest modsMap mod') =
-  Response . Check.renderVerifiedModule <$> Check.verifyModule mempty modsMap mod'
+  Response . Check.renderVerifiedModule <$> Check.verifyModule Nothing mempty modsMap mod'

--- a/src-tool/Pact/Analyze/Remote/Server.hs
+++ b/src-tool/Pact/Analyze/Remote/Server.hs
@@ -165,4 +165,4 @@ loadModules mods0 = do
 
 runVerification :: ValidRequest -> IO Response
 runVerification (ValidRequest modsMap mod') =
-  Response . Check.renderVerifiedModule <$> Check.verifyModule Nothing mempty modsMap mod'
+  Response . Check.renderVerifiedModule <$> Check.verifyModule False mempty modsMap mod'

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -145,7 +145,7 @@ runVerification code = do
   case eModuleData of
     Left tf -> pure $ Just tf
     Right moduleData -> do
-      results <- verifyModule mempty (HM.fromList [("test", moduleData)]) moduleData
+      results <- verifyModule Nothing mempty (HM.fromList [("test", moduleData)]) moduleData
       case results of
         Left failure -> pure $ Just $ VerificationFailure failure
         Right (ModuleChecks propResults stepResults invariantResults _) ->
@@ -171,7 +171,7 @@ runCheck' checkType code check = do
   case eModuleData of
     Left tf -> pure $ Left tf
     Right moduleData -> do
-      result <- runExceptT $ verifyCheck mempty moduleData "test" check checkType
+      result <- runExceptT $ verifyCheck Nothing mempty moduleData "test" check checkType
       pure $ case result of
         Left failure    -> Left $ VerificationFailure failure
         Right (Left cf:_) -> Left $ TestCheckFailure cf
@@ -183,7 +183,7 @@ checkInterface code = do
   case eModuleData of
     Left tf -> pure $ Just tf
     Right moduleData -> do
-      result <- verifyModule mempty HM.empty moduleData
+      result <- verifyModule Nothing mempty HM.empty moduleData
       pure $ case result of
         Left failure -> Just $ VerificationFailure failure
         Right _      -> Nothing
@@ -1966,7 +1966,7 @@ spec = describe "analyze" $ do
           case eModuleData of
             Left err -> error $ "failed to compile: " <> show err
             Right moduleData -> do
-              results <- verifyModule mempty (HM.fromList [("test", moduleData)]) moduleData
+              results <- verifyModule Nothing mempty (HM.fromList [("test", moduleData)]) moduleData
               case results of
                 Left failure -> error $ "unexpectedly failed verification: " <> show failure
                 Right x -> return x

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -145,7 +145,7 @@ runVerification code = do
   case eModuleData of
     Left tf -> pure $ Just tf
     Right moduleData -> do
-      results <- verifyModule Nothing mempty (HM.fromList [("test", moduleData)]) moduleData
+      results <- verifyModule False mempty (HM.fromList [("test", moduleData)]) moduleData
       case results of
         Left failure -> pure $ Just $ VerificationFailure failure
         Right (ModuleChecks propResults stepResults invariantResults _) ->
@@ -171,7 +171,7 @@ runCheck' checkType code check = do
   case eModuleData of
     Left tf -> pure $ Left tf
     Right moduleData -> do
-      result <- runExceptT $ verifyCheck Nothing mempty moduleData "test" check checkType
+      result <- runExceptT $ verifyCheck False mempty moduleData "test" check checkType
       pure $ case result of
         Left failure    -> Left $ VerificationFailure failure
         Right (Left cf:_) -> Left $ TestCheckFailure cf
@@ -183,7 +183,7 @@ checkInterface code = do
   case eModuleData of
     Left tf -> pure $ Just tf
     Right moduleData -> do
-      result <- verifyModule Nothing mempty HM.empty moduleData
+      result <- verifyModule False mempty HM.empty moduleData
       pure $ case result of
         Left failure -> Just $ VerificationFailure failure
         Right _      -> Nothing
@@ -1966,7 +1966,7 @@ spec = describe "analyze" $ do
           case eModuleData of
             Left err -> error $ "failed to compile: " <> show err
             Right moduleData -> do
-              results <- verifyModule Nothing mempty (HM.fromList [("test", moduleData)]) moduleData
+              results <- verifyModule False mempty (HM.fromList [("test", moduleData)]) moduleData
               case results of
                 Left failure -> error $ "unexpectedly failed verification: " <> show failure
                 Right x -> return x

--- a/tests/TypecheckSpec.hs
+++ b/tests/TypecheckSpec.hs
@@ -88,7 +88,7 @@ verifyModule fp mn = it (fp ++ ": " ++ moduleName mn ++ " verifies") $ do
   mModules <- replGetModules replState
   checkResult <- case mModules of
     Left err           -> die def (show err)
-    Right (modules, _) -> Check.verifyModule Nothing def (inlineModuleData <$> modules) (inlineModuleData modul)
+    Right (modules, _) -> Check.verifyModule False def (inlineModuleData <$> modules) (inlineModuleData modul)
   let ros = Check.renderVerifiedModule checkResult
   when (any ((== OutputFailure) . _roType) ros) $
     expectationFailure $ T.unpack $

--- a/tests/TypecheckSpec.hs
+++ b/tests/TypecheckSpec.hs
@@ -88,7 +88,7 @@ verifyModule fp mn = it (fp ++ ": " ++ moduleName mn ++ " verifies") $ do
   mModules <- replGetModules replState
   checkResult <- case mModules of
     Left err           -> die def (show err)
-    Right (modules, _) -> Check.verifyModule def (inlineModuleData <$> modules) (inlineModuleData modul)
+    Right (modules, _) -> Check.verifyModule Nothing def (inlineModuleData <$> modules) (inlineModuleData modul)
   let ros = Check.renderVerifiedModule checkResult
   when (any ((== OutputFailure) . _roType) ros) $
     expectationFailure $ T.unpack $


### PR DESCRIPTION
Add optional parameter to `verify` allowing to inspect generated SMTLib2 file (by SBV).