### PR TITLE
Fix `Print` native to use prettyprinter

### DIFF
--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -309,7 +309,7 @@ updateForOp i a = do
     Output es -> forM_ es (outStrLn HErr . renderPrettyString RColor) >> return (Right a)
     Print t -> do
       let rep = case t of TLitString s -> unpack s
-                          _ -> show t
+                          _ -> showPretty t
       outStrLn HOut rep
       return (Right a)
 


### PR DESCRIPTION
```
pact> (print 1)
""
1
pact> (print "hi Emily!")
""
hi Emily!


```

Fixes #1101 