### PR TITLE
add warning if fv finds an invalidating model and decimals use 255

### DIFF
--- a/src-tool/Pact/Analyze/Model/Text.hs
+++ b/src-tool/Pact/Analyze/Model/Text.hs
@@ -239,7 +239,7 @@ showEvent ksProvs tags event = do
                   vals :: Map VarId Unmunged
                   vals = Map.mapMaybe (\case Located _ (n, (EType SDecimal, AVal p sval)) ->
                                                case unliteralS $ mkS p sval of
-                                                 Just v | Pact.decimalPlaces (toPact decimalIso v) == 255 -> Just n
+                                                 Just v | Pact.decimalPlaces (toPact decimalIso v) == maxBound -> Just n
                                                  _ -> Nothing
                                              _ -> Nothing) $  tags ^. mtVars
                   warnLines = case Map.size vals of

--- a/src-tool/Pact/Analyze/Model/Text.hs
+++ b/src-tool/Pact/Analyze/Model/Text.hs
@@ -24,7 +24,7 @@ import qualified Data.SBV.Internals         as SBVI
 import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import           GHC.Natural                (Natural)
-import qualified Data.Decimal as Pact
+import qualified Data.Decimal               as Pact
 
 import qualified Pact.Types.Info            as Pact
 import qualified Pact.Types.Lang            as Pact


### PR DESCRIPTION
Addresses #1107 by adding a warning in case, an invalidating model is found which uses 255 decimal places. This indicates a precision underflow.

The following program
```
(module test GOVERNANCE
  (defcap GOVERNANCE() true)
  
  (defun get-refund:decimal (balance:decimal stakers:integer)
    @model [ (property  (> result 0.0))  ]
    
    (enforce (> balance 0.0) "balance must be non-negative")
    (enforce (> stakers 0) "stakers must be non-negative")

    (/ balance stakers)) )

(verify 'test)
```

will result in this output:
![image](https://user-images.githubusercontent.com/26225067/211000093-5befab69-16bf-462e-8c9d-786666e8c588.png)

The warning is placed in the corresponding FV trace.
