### PR TITLE
remove describe-namespace shim

### DIFF
--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -621,6 +621,11 @@ spec = describe "analyze" $ do
           |]
     expectPass code $ Valid (Inj Success)
 
+  describe "describe-namespace" $ do
+    let code = [text|(defun test () (describe-namespace 'test))|]
+    expectVerificationFailure code
+                      
+
   --
   -- TODO: test use of read-keyset from property once possible
   --


### PR DESCRIPTION
From [docs](https://pact-language.readthedocs.io/en/stable/pact-functions.html?highlight=describe-namespace#describe-namespace), `describe-namespace` is TL only and will fail in module code.

We now fail while translation.