### PR TITLE
Revert "fix docs layout for `install-capability` (#1157)"

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1575,7 +1575,7 @@ Execute GUARD, or defined keyset KEYSETNAME, to enforce desired predicate logic.
 *capability*&nbsp;` -> bool` *&rarr;*&nbsp;`string`
 
 
-Specifies, and provisions install of, a _managed_ CAPABILITY, defined in a 'defcap' in which a '@managed' tag designates a single parameter to be managed by a specified function. After install, CAPABILITY must still be brought into scope using 'with-capability', at which time the 'manager function' is invoked to validate the request. The manager function is of type 'managed:`p`requested:`p` -> `p`', where '`p`' indicates the type of the managed parameter, such that for '(defcap FOO (bar:string baz:integer) @managed baz FOO-mgr ...)', the manager function would be '(defun FOO-mgr:integer (managed:integer requested:integer) ...)'. Any capability matching the 'static' (non-managed) parameters will cause this function to be invoked with the current managed value and that of the requested capability. The function should perform whatever logic, presumably linear, to validate the request, and return the new managed value representing the 'balance' of the request. NOTE that signatures scoped to a managed capability cause the capability to be automatically provisioned for install similarly to one installed with this function.
+Specifies, and provisions install of, a _managed_ CAPABILITY, defined in a 'defcap' in which a '@managed' tag designates a single parameter to be managed by a specified function. After install, CAPABILITY must still be brought into scope using 'with-capability', at which time the 'manager function' is invoked to validate the request. The manager function is of type 'managed:<p> requested:<p> -> <p>', where '<p>' indicates the type of the managed parameter, such that for '(defcap FOO (bar:string baz:integer) @managed baz FOO-mgr ...)', the manager function would be '(defun FOO-mgr:integer (managed:integer requested:integer) ...)'. Any capability matching the 'static' (non-managed) parameters will cause this function to be invoked with the current managed value and that of the requested capability. The function should perform whatever logic, presumably linear, to validate the request, and return the new managed value representing the 'balance' of the request. NOTE that signatures scoped to a managed capability cause the capability to be automatically provisioned for install similarly to one installed with this function.
 ```lisp
 (install-capability (PAY "alice" "bob" 10.0))
 ```
@@ -1953,7 +1953,7 @@ Set environment gas limit to LIMIT.
 Enable and obtain gas logging. Bracket around the code whose gas logs you want to inspect.
 ```lisp
 pact> (env-gasmodel "table") (env-gaslimit 10) (env-gaslog) (map (+ 1) [1 2 3]) (env-gaslog)
-["TOTAL: 7" "map:GUnreduced:currTotalGas=4: 4" "+:GUnreduced:currTotalGas=5: 1" ":GIntegerOpCost:(1, ):(1, ):currTotalGas=5: 0" "+:GUnreduced:currTotalGas=6: 1" ":GIntegerOpCost:(1, ):(2, ):currTotalGas=6: 0" "+:GUnreduced:currTotalGas=7: 1" ":GIntegerOpCost:(1, ):(3, ):currTotalGas=7: 0"]
+["TOTAL: 7" "map:GUnreduced: 4" "+:GUnreduced: 1" "+:GUnreduced: 1" "+:GUnreduced: 1"]
 ```
 
 

--- a/docs/en/pact-functions.rst
+++ b/docs/en/pact-functions.rst
@@ -1764,18 +1764,41 @@ a ‘defcap’ in which a ‘@managed’ tag designates a single parameter to be
 managed by a specified function. After install, CAPABILITY must still be
 brought into scope using ‘with-capability’, at which time the ‘manager
 function’ is invoked to validate the request. The manager function is of
-type ‘managed:``p``\ requested:``p`` -> ``p``’, where ‘``p``’ indicates
-the type of the managed parameter, such that for ‘(defcap FOO
-(bar:string baz:integer) @managed baz FOO-mgr …)’, the manager function
-would be ‘(defun FOO-mgr:integer (managed:integer requested:integer)
-…)’. Any capability matching the ‘static’ (non-managed) parameters will
-cause this function to be invoked with the current managed value and
-that of the requested capability. The function should perform whatever
-logic, presumably linear, to validate the request, and return the new
-managed value representing the ‘balance’ of the request. NOTE that
-signatures scoped to a managed capability cause the capability to be
-automatically provisioned for install similarly to one installed with
-this function.
+type ’managed:
+
+.. raw:: html
+
+   <p>
+
+requested:
+
+.. raw:: html
+
+   <p>
+
+->
+
+.. raw:: html
+
+   <p>
+
+‘, where’
+
+.. raw:: html
+
+   <p>
+
+’ indicates the type of the managed parameter, such that for ‘(defcap
+FOO (bar:string baz:integer) @managed baz FOO-mgr …)’, the manager
+function would be ‘(defun FOO-mgr:integer (managed:integer
+requested:integer) …)’. Any capability matching the ‘static’
+(non-managed) parameters will cause this function to be invoked with the
+current managed value and that of the requested capability. The function
+should perform whatever logic, presumably linear, to validate the
+request, and return the new managed value representing the ‘balance’ of
+the request. NOTE that signatures scoped to a managed capability cause
+the capability to be automatically provisioned for install similarly to
+one installed with this function.
 
 .. code:: lisp
 
@@ -2228,7 +2251,7 @@ you want to inspect.
 .. code:: lisp
 
    pact> (env-gasmodel "table") (env-gaslimit 10) (env-gaslog) (map (+ 1) [1 2 3]) (env-gaslog)
-   ["TOTAL: 7" "map:GUnreduced:currTotalGas=4: 4" "+:GUnreduced:currTotalGas=5: 1" ":GIntegerOpCost:(1, ):(1, ):currTotalGas=5: 0" "+:GUnreduced:currTotalGas=6: 1" ":GIntegerOpCost:(1, ):(2, ):currTotalGas=6: 0" "+:GUnreduced:currTotalGas=7: 1" ":GIntegerOpCost:(1, ):(3, ):currTotalGas=7: 0"]
+   ["TOTAL: 7" "map:GUnreduced: 4" "+:GUnreduced: 1" "+:GUnreduced: 1" "+:GUnreduced: 1"]
 
 env-gasmodel
 ~~~~~~~~~~~~

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -94,8 +94,8 @@ installCapability =
   \After install, CAPABILITY must still be brought into scope using 'with-capability', at which time \
   \the 'manager function' is invoked to validate the request. \
   \The manager function is of type \
-  \'managed:`p`requested:`p` -> `p`', \
-  \where '`p`' indicates the type of the managed parameter, such that for \
+  \'managed:<p> requested:<p> -> <p>', \
+  \where '<p>' indicates the type of the managed parameter, such that for \
   \'(defcap FOO (bar:string baz:integer) @managed baz FOO-mgr ...)', \
   \the manager function would be '(defun FOO-mgr:integer (managed:integer requested:integer) ...)'. \
   \Any capability matching the 'static' (non-managed) parameters will cause this function to \


### PR DESCRIPTION
This reverts commit a7ef2705ca23fea57e00d3c3046384a26285a898.

The reason for reverting is that this causes a forking change in the Pact evaluator. Namely, after running this chainweb tool command:
```
cwtool tx-sim -d ~/.local/share/chainweb-node/mainnet01/0/sqlite -s 3527143 -i 0 -c 8 -g
```
you will note that the costs in the gas log now differ:
```
("Module Memory cost:GModuleMemory: 3681345:currTotalGas=83182",82089)
```
becomes:
```
("Module Memory cost:GModuleMemory: 3681331:currTotalGas=83181",82088)
```

As a result, the gas cost is too low, resulting in a hash discrepancy that prevents the block from being validated on mainnet.

We should revert until we understand why this is a forking change, and whether we indeed want it to be. If it's due to updating the function text -- as Stuart has suggested -- then I'd like to find a more general solution that makes it safe in future for us to update docstrings.