### PR TITLE
fix repl output

### DIFF
--- a/src-ghc/Pact/ReplTools.hs
+++ b/src-ghc/Pact/ReplTools.hs
@@ -123,8 +123,8 @@ handleMultilineInput input prevLines lastResult =
            -- If so, continue accepting input
            -> haskelineLoop multilineInput lastResult
 
-       Failure e -> do
-         liftIO $ print e
+       Failure (ErrInfo e _) -> do
+         liftIO (print e)
          haskelineLoop [] Nothing
 
        parsed -> do


### PR DESCRIPTION
```
pact> (module m g (defcap g () true) (defcap OFFERED (pid:string) true) (defpact sale () (step (= (create-capability-guard (OFFERED (pact-id))) (create-capability-guard (OFFERED pact-id))))))))\
(interactive):1:186: error: expected: ",", ":", ":=", (list), [list], atom,
    bool, dyn-atom, end of input, number, string, symbol, {list}
1 | <d (OFFERED (pact-id))) (create-capability-guard (OFFERED pact-id))))))))\ 
  |                                                                        ^   

```