### PR TITLE
fix docs

### DIFF
--- a/docs/en/pact-properties-api.md
+++ b/docs/en/pact-properties-api.md
@@ -635,6 +635,21 @@ List / string / object contains
 
 Supported in either invariants or properties.
 
+### enumerate {#FEnumerate}
+
+```lisp
+(enumerate from to step)
+```
+
+* takes `from`: `integer`
+* takes `to`: `integer`
+* takes `step`: `integer`
+* produces [`integer`]
+
+Returns a sequence of numbers as a list
+
+Supported in either invariants or properties.
+
 ### reverse {#FReverse}
 
 ```lisp

--- a/src-tool/Pact/Analyze/Feature.hs
+++ b/src-tool/Pact/Analyze/Feature.hs
@@ -959,7 +959,7 @@ doc FEnumerate = Doc
   InvAndProp
   "Returns a sequence of numbers as a list"
   [ Usage
-      "(drop n xs)"
+      "(enumerate from to step)"
       Map.empty
       $ Fun
         Nothing


### PR DESCRIPTION
This PR fixes the incorrect documentation of `enumerate` introduced in https://github.com/kadena-io/pact/pull/1155