### PR TITLE
Repl Tests

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -169,6 +169,7 @@ jobs:
       shell: bash
       run: cabal build
     - name: Install
+      if: "!contains(matrix.flags, '-build-tool')"
       run: cabal install --overwrite-policy=always
     - name: Test
       shell: bash

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -168,6 +168,8 @@ jobs:
     - name: Build
       shell: bash
       run: cabal build
+    - name: Install
+      run: cabal install --overwrite-policy=always
     - name: Test
       shell: bash
       run: cabal test +RTS -N

--- a/pact.cabal
+++ b/pact.cabal
@@ -429,6 +429,7 @@ test-suite hspec
         TypecheckSpec
         PactCLISpec
         ZkSpec
+        ReplSpec
         PairingSpec
         Utils
 
@@ -454,3 +455,4 @@ test-suite hspec
         , servant-client
         , temporary >= 1.3
         , yaml
+        , process

--- a/pact.cabal
+++ b/pact.cabal
@@ -456,3 +456,4 @@ test-suite hspec
         , temporary >= 1.3
         , yaml
         , process
+        , posix-pty

--- a/tests/PactTests.hs
+++ b/tests/PactTests.hs
@@ -28,6 +28,7 @@ import qualified RemoteVerifySpec
 import qualified TypecheckSpec
 import qualified PactCLISpec
 import qualified ZkSpec
+import qualified ReplSpec
 # endif
 #endif
 
@@ -62,6 +63,7 @@ main = hspec $ parallel $ do
   describe "TypecheckSpec" TypecheckSpec.spec
   describe "PactCLISpec" PactCLISpec.spec
   describe "ZkSpec" ZkSpec.spec
+  describe "ReplSpec" ReplSpec.spec
 
 
 # endif

--- a/tests/ReplSpec.hs
+++ b/tests/ReplSpec.hs
@@ -1,0 +1,65 @@
+-- |
+{-# LANGUAGE OverloadedStrings #-}
+
+module ReplSpec where
+
+import Test.Hspec
+
+import Data.ByteString (ByteString)
+import Control.Monad.IO.Class
+import System.Process
+import qualified Data.ByteString as BS
+import Control.Concurrent (threadDelay)
+import GHC.IO.Handle (hClose)
+
+spec :: Spec
+spec = describe "ReplSpec" $ do
+  it "should not print literal via `Show` (regression #1101)" $ do
+    let src = "(print 1)"
+    out <- liftIO (runInteractive src)
+    out `shouldSatisfy` outputSatisfy containsNoTermInfo
+
+  it "should not print `ErrInfo` via `Show` (regression #1164)" $ do
+    let src = "(module m g (defcap g () true) (defcap OFFERED (pid:string) true) \
+              \ (defpact sale () (step (= (create-capability-guard (OFFERED (pact-id)))\
+              \ (create-capability-guard (OFFERED pact-id)))))))"
+    out <- liftIO (runInteractive src)
+    out `shouldSatisfy` outputSatisfy containsNoErrInfo
+
+
+runInteractive :: ByteString -> IO (ByteString, ByteString)
+runInteractive src = do
+  let cp = (shell "pact")
+        { std_in  = CreatePipe
+        , std_out = CreatePipe
+        , std_err = CreatePipe
+        }
+  (Just inH, Just outH, Just errH, ph) <- createProcess cp
+  BS.hPut inH src
+  hClose inH
+  threadDelay 20000
+  (out, err) <- readTillPrompt outH errH mempty mempty
+
+  terminateProcess ph
+
+  pure (out, err)
+  where
+    readTillPrompt outH errH o e = do
+      out <- BS.hGetNonBlocking outH 4046
+      err <- BS.hGetNonBlocking errH 4096
+
+      pure (o <> out, e <> err)
+
+      -- if not ("pact>" `BS.isInfixOf` err)
+      --   then threadDelay 20000 >>  readTillPrompt outH errH o e
+      --   else pure (o <> out, e <> err)
+
+
+outputSatisfy :: (ByteString -> Bool) -> (ByteString, ByteString) ->Bool
+outputSatisfy f (o, e) = f o && f e
+
+containsNoErrInfo :: ByteString -> Bool
+containsNoErrInfo s = not ("_errDeltas" `BS.isInfixOf` s)
+
+containsNoTermInfo :: ByteString -> Bool
+containsNoTermInfo s = not ("_tLiteral" `BS.isInfixOf` s)

--- a/tests/ReplSpec.hs
+++ b/tests/ReplSpec.hs
@@ -7,56 +7,40 @@ import Test.Hspec
 
 import Data.ByteString (ByteString)
 import Control.Monad.IO.Class
-import System.Process
 import qualified Data.ByteString as BS
 import Control.Concurrent (threadDelay)
-import GHC.IO.Handle (hClose)
+import System.Posix.Pty
+import Control.Monad (void)
 
 spec :: Spec
 spec = describe "ReplSpec" $ do
   it "should not print literal via `Show` (regression #1101)" $ do
     let src = "(print 1)"
     out <- liftIO (runInteractive src)
-    out `shouldSatisfy` outputSatisfy containsNoTermInfo
+    out `shouldSatisfy` containsNoTermInfo
 
   it "should not print `ErrInfo` via `Show` (regression #1164)" $ do
     let src = "(module m g (defcap g () true) (defcap OFFERED (pid:string) true) \
               \ (defpact sale () (step (= (create-capability-guard (OFFERED (pact-id)))\
               \ (create-capability-guard (OFFERED pact-id)))))))"
     out <- liftIO (runInteractive src)
-    out `shouldSatisfy` outputSatisfy containsNoErrInfo
+    out `shouldSatisfy`containsNoErrInfo
 
 
-runInteractive :: ByteString -> IO (ByteString, ByteString)
+runInteractive :: ByteString -> IO ByteString
 runInteractive src = do
-  let cp = (shell "pact")
-        { std_in  = CreatePipe
-        , std_out = CreatePipe
-        , std_err = CreatePipe
-        }
-  (Just inH, Just outH, Just errH, ph) <- createProcess cp
-  BS.hPut inH src
-  hClose inH
-  threadDelay 20000
-  (out, err) <- readTillPrompt outH errH mempty mempty
-
-  terminateProcess ph
-
-  pure (out, err)
+  (pty, _) <- spawnWithPty Nothing True "pact" [] (100,100)
+  threadDelay 2000
+  writePty pty (src <> "\n")
+  threadDelay 2000
+  void $ go pty mempty -- the first pact prompt
+  go pty mempty
   where
-    readTillPrompt outH errH o e = do
-      out <- BS.hGetNonBlocking outH 4046
-      err <- BS.hGetNonBlocking errH 4096
-
-      pure (o <> out, e <> err)
-
-      -- if not ("pact>" `BS.isInfixOf` err)
-      --   then threadDelay 20000 >>  readTillPrompt outH errH o e
-      --   else pure (o <> out, e <> err)
-
-
-outputSatisfy :: (ByteString -> Bool) -> (ByteString, ByteString) ->Bool
-outputSatisfy f (o, e) = f o && f e
+    go pty o = do
+      content <- readPty pty
+      if "pact>" `BS.isInfixOf` content
+      then pure o
+      else go pty (o <> content)
 
 containsNoErrInfo :: ByteString -> Bool
 containsNoErrInfo s = not ("_errDeltas" `BS.isInfixOf` s)


### PR DESCRIPTION
This PR aims to provide repl-output based testing. It turns out that `haskeline` behaves different if executed within a terminal[1](https://hackage.haskell.org/package/haskeline-0.8.2.1/docs/System-Console-Haskeline.html):

```
It uses terminal-style interaction if stdin is connected to a terminal and has echoing enabled. Otherwise (e.g., if stdin is a pipe), it uses file-style interaction.
```

As a consequence, we are not able to test for #1164 as the output is not provided via `stdout` or `stderr` (same for the pact prompt `pact>`). 

A potential solution might be_ to run a pseudo-terminal using the `unix` package [2](https://hackage.haskell.org/package/unix-2.8.1.1/docs/System-Posix-Terminal.html#v:openPseudoTerminal).