### PR TITLE
Ci/workflow trigger via open pr

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -3,6 +3,8 @@ name: Build and publish application binaries
 on:
   workflow_dispatch:
   push:
+  pull_request_target:
+    types: [ opened ]
 
 jobs:
   build:

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -136,7 +136,7 @@ initEvalEnv ls = do
   return $ EvalEnv
     { _eeRefStore = RefStore nativeDefs
     , _eeMsgSigs = mempty
-    , _eeMsgBody = Null
+    , _eeMsgBody = A.Object HM.empty 
     , _eeMode = Transactional
     , _eeEntity = Nothing
     , _eePactStep = Nothing


### PR DESCRIPTION
Currently, the build is triggered manually or with a push.  This does not allow external contributors to trigger the build.  With this change, their opening of a new PR should trigger the build (though new contributors will still require approval for security reasons, to prevent malicious build modifications that do annoying things).

The creation of this PR should itself be an example.

There is more complex logic we can use to determine when a build is triggered (ie pr to a specific branch, pr is in a waiting approval state, pr has been approved, etc) but for now this should cover the use case.

Also, this PR contains the approved change from PR #1188 just to have it build (this branch was forked from that PR).