### PR TITLE
Conditionally import modules needed by hspec < 2.10.10

### DIFF
--- a/tests/GasModelSpec.hs
+++ b/tests/GasModelSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -41,6 +42,9 @@ import Pact.GasModel.Utils
 import Pact.GasModel.GasTests
 import Pact.Gas.Table
 import Pact.Native
+#if !MIN_VERSION_hspec(2,10,10)
+import Test.Hspec.Core.Spec
+#endif
 
 spec :: Spec
 spec = describe "gas model tests" $ do

--- a/tests/HistoryServiceSpec.hs
+++ b/tests/HistoryServiceSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module HistoryServiceSpec (spec) where
@@ -10,6 +11,9 @@ import Data.ByteString (ByteString)
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.HashSet as HashSet
 import Test.Hspec
+#if !MIN_VERSION_hspec(2,10,10)
+import Test.Hspec.Core.Spec
+#endif
 import Data.Default
 import System.IO.Temp (withSystemTempDirectory)
 


### PR DESCRIPTION
Without this, builds that solve against an older version of Hackage (i.e., the Nix-flake based Pact build) -- which picks hspec-2.10.6 -- will fail to build.