### PR TITLE
Fix ReplSpec tests in GH action

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -168,7 +168,7 @@ jobs:
       run: cabal build
     - name: Test
       shell: bash
-      run: cabal test +RTS -N
+      run: cabal run tests
     - name: Benchmark
       shell: bash
       if: "!contains(matrix.flags, '-build-tool')"


### PR DESCRIPTION
Previously, we noticed failing tests of the `ReplSpec` which rely on a pseudo-terminal. The major reason is the parallel execution of the test-suite (using `cabal tests`). 

This PR (should) fix the behaviour. Test PR https://github.com/kadena-io/pact/pull/1215