### PR TITLE
Pact 4.7 Release Prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+4.7.0
+---
+
+### Eval
+
+- Improve advice implementation (#1187)
+- Fix inconsistent trace output (#1153)
+- Fix coverage, restore defun advice (#1151)
+- Create persistence dirs if missing (#1148)
+- Differentiate between errors on-chain and off-chain (#1185)
+- Don't display function documentation in non-repl context (#1185)
+
+### Natives
+
+- Allow native function versioning in eval (#1195)
+- Add new native `dec` for integer to decimal conversion (#1150)
+- Implement `shift` in terms of other natives for better gas costing (#1208)
+- Intialize body of `env-data` to an empty object instead of Null (#1188)
+
+### Typechecking
+
+- Fix Typechecker treatment of special binding forms (#1212)
+
+### Formal Verification
+- Enable warnings during symbolic eval (#1175)
+- Remove `emit-event` shim (#1168)
+- Remove `hash` shims (#1158)
+- Remove `enumerate` shim (#1155)
+- Remove `distinct` shim (#1154)
+- Remove `describe-namespace` shim (#1156)
+
+### Documentation
+
+- Remove mention of private defpacts from the reference manual (#1207)
+- Add documentation for `enumerate` (#1176)
 4.6.0
 ---
 * Add `DisablePact46` execution flag (#1138)

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -461,7 +461,7 @@ Return ID if called during current pact execution, failing if not.
 Obtain current pact build version.
 ```lisp
 pact> (pact-version)
-"4.6.0"
+"4.7.0"
 ```
 
 Top level only: this function will fail if used in module code.

--- a/docs/en/pact-functions.rst
+++ b/docs/en/pact-functions.rst
@@ -245,7 +245,7 @@ returns true.
 .. code:: lisp
 
    pact> (enforce (!= (+ 2 2) 4) "Chaos reigns")
-   <interactive>:0:0: Chaos reigns
+   <interactive>:0:0:Error: Chaos reigns
 
 enforce-one
 ~~~~~~~~~~~
@@ -517,7 +517,7 @@ Obtain current pact build version.
 .. code:: lisp
 
    pact> (pact-version)
-   "4.6.0"
+   "4.7.0"
 
 Top level only: this function will fail if used in module code.
 
@@ -2222,7 +2222,7 @@ env-exec-config
 *→* ``[string]``
 
 Queries, or with arguments, sets execution config flags. Valid flags:
-[“AllowReadInLocal”,“DisableHistoryInTransactionalMode”,“DisableInlineMemCheck”,“DisableModuleInstall”,“DisableNewTrans”,“DisablePact40”,“DisablePact420”,“DisablePact43”,“DisablePact431”,“DisablePact44”,“DisablePact45”,“DisablePact46”,“DisablePactEvents”,“EnforceKeyFormats”,“OldReadOnlyBehavior”,“PreserveModuleIfacesBug”,“PreserveModuleNameBug”,“PreserveNsModuleInstallBug”,“PreserveShowDefs”]
+[“AllowReadInLocal”,“DisableHistoryInTransactionalMode”,“DisableInlineMemCheck”,“DisableModuleInstall”,“DisableNewTrans”,“DisablePact40”,“DisablePact420”,“DisablePact43”,“DisablePact431”,“DisablePact44”,“DisablePact45”,“DisablePact46”,“DisablePact47”,“DisablePactEvents”,“EnforceKeyFormats”,“OldReadOnlyBehavior”,“PreserveModuleIfacesBug”,“PreserveModuleNameBug”,“PreserveNsModuleInstallBug”,“PreserveShowDefs”]
 
 .. code:: lisp
 
@@ -2352,6 +2352,18 @@ list of associated capabilities.
 .. code:: lisp
 
    (env-sigs [{'key: "my-key", 'caps: [(accounts.USER_GUARD "my-account")]}, {'key: "admin-key", 'caps: []}
+
+env-simulate-onchain
+~~~~~~~~~~~~~~~~~~~~
+
+*on-chain* ``bool`` *→* ``string``
+
+Set a flag to simulate on-chain behavior that differs from the repl, in
+particular for observing things like errors and stack traces.
+
+.. code:: lisp
+
+   (env-simulate-onchain true)
 
 expect
 ~~~~~~

--- a/docs/en/pact-properties-api.rst
+++ b/docs/en/pact-properties-api.rst
@@ -627,6 +627,22 @@ or?
 
 Supported in either invariants or properties.
 
+.. _FBoolHash:
+
+hash
+~~~~
+
+.. code:: lisp
+
+   (hash s)
+
+-  takes ``s``: ``bool``
+-  produces ``string``
+
+BLAKE2b 256-bit hash of bool values
+
+Supported in properties only.
+
 .. _Object:
 
 Object operators
@@ -803,6 +819,24 @@ List / string / object contains
 
 Supported in either invariants or properties.
 
+.. _FEnumerate:
+
+enumerate
+~~~~~~~~~
+
+.. code:: lisp
+
+   (enumerate from to step)
+
+-  takes ``from``: ``integer``
+-  takes ``to``: ``integer``
+-  takes ``step``: ``integer``
+-  produces [``integer``]
+
+Returns a sequence of numbers as a list
+
+Supported in either invariants or properties.
+
 .. _FReverse:
 
 reverse
@@ -922,6 +956,22 @@ filter a list by keeping the values for which ``f`` returns ``true``
 
 Supported in either invariants or properties.
 
+.. _FDistinct:
+
+distinct
+~~~~~~~~
+
+.. code:: lisp
+
+   (distinct xs)
+
+-  takes ``xs``: [*a*]
+-  produces [*a*]
+
+returns a list of distinct values
+
+Supported in either invariants or properties.
+
 .. _FFold:
 
 fold
@@ -939,6 +989,24 @@ fold
 reduce a list by applying ``f`` to each element and the previous result
 
 Supported in either invariants or properties.
+
+.. _FListHash:
+
+hash
+~~~~
+
+.. code:: lisp
+
+   (hash xs)
+
+-  takes ``xs``: [*a*]
+-  produces ``string``
+-  where *a* is of type ``integer``, ``decimal``, ``bool``, or
+   ``string``
+
+BLAKE2b 256-bit hash of lists
+
+Supported in properties only.
 
 .. _String:
 
@@ -1045,6 +1113,39 @@ drop the first ``n`` values from ``xs`` (dropped from the end if ``n``
 is negative)
 
 Supported in either invariants or properties.
+
+.. _FStringHash:
+
+hash
+~~~~
+
+.. code:: lisp
+
+   (hash s)
+
+-  takes ``s``: ``string``
+-  produces ``string``
+
+BLAKE2b 256-bit hash of string values
+
+Supported in properties only.
+
+.. _FNumericalHash:
+
+hash
+~~~~
+
+.. code:: lisp
+
+   (hash s)
+
+-  takes ``s``: *a*
+-  produces ``string``
+-  where *a* is of type ``integer`` or ``decimal``
+
+BLAKE2b 256-bit hash of numerical values
+
+Supported in properties only.
 
 .. _Temporal:
 
@@ -1480,6 +1581,39 @@ row-enforced
 Whether the keyset in the row is enforced by the function under analysis
 
 Supported in properties only.
+
+.. _FIsPrincipal:
+
+is-principal
+~~~~~~~~~~~~
+
+.. code:: lisp
+
+   (is-principal s)
+
+-  takes ``s``: ``string``
+-  produces ``bool``
+
+Whether ``s`` conforms to the principal format without proving validity.
+
+Supported in either invariants or properties.
+
+.. _FTypeOfPrincipal:
+
+typeof-principal
+~~~~~~~~~~~~~~~~
+
+.. code:: lisp
+
+   (typeof-principal s)
+
+-  takes ``s``: ``string``
+-  produces ``string``
+
+Return the protocol type of the given ``s`` value. If input value is not
+a principal type, then the empty string is returned.
+
+Supported in either invariants or properties.
 
 .. _Function:
 

--- a/docs/en/pact-reference.rst
+++ b/docs/en/pact-reference.rst
@@ -2493,7 +2493,7 @@ sequential order.
        (credit payee amount)))
 
 Defpacts may be nested (though the recursion restrictions apply, so it
-must be a different defpact). They may be kicked off like a regular
+must be a different defpact). They may be executed like a regular
 function call within a defpact, but are continued after the first step
 by calling ``continue`` with the same arguments.
 

--- a/pact.cabal
+++ b/pact.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                pact
-version:             4.6.0
+version:             4.7.0
 -- ^ 4 digit is prerelease, 3- or 2-digit for prod release
 synopsis:            Smart contract language library and REPL
 description:


### PR DESCRIPTION
- [x] Changelog updated
- [x] Version changed 
- [x] Docs generated
- [ ] All relevant PRs are in

Awaiting merge:
- Transcendental functions using native Haskell: https://github.com/kadena-io/pact/pull/1204
  - Benchmarks pending
- Runtime check for return types: https://github.com/kadena-io/pact/pull/1209
  - Benchmarks pending
- Allow Namespaces to reset to root: https://github.com/kadena-io/pact/pull/1174

Merged:
- Native Versioning: https://github.com/kadena-io/pact/pull/1195
- Implement `dec` for integer to decimal coercion: https://github.com/kadena-io/pact/pull/1150
- Implement `shift`  natives in terms of other natives: https://github.com/kadena-io/pact/pull/1208
- Forked errors on-chain: https://github.com/kadena-io/pact/pull/1185
- Don't display function docs in non-repl context: https://github.com/kadena-io/pact/pull/1185 (edited)  
