### PR TITLE
add benchmarks for user-function application

### DIFF
--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -326,6 +326,9 @@ main = do
   replS <- setReplLib <$> initReplState Quiet Nothing
   let tt = evalReplEval def replS (mapM eval timeTest)
   void $! eitherDie "timeTest failed" . fmapL show =<< tt
+  wrap10Cmd <- parseCode "(bench.wrap10 100)"
+  wrap10MonoCmd <- parseCode "(bench.wrap10_integer 100)"
+  accumCmd <- parseCode "(bench.accum (enumerate 1 100))"
 
 
   let cleanupSqlite = do
@@ -384,4 +387,9 @@ main = do
       , benchNFIO "round4" $ runPactExec def "round4" [] Null Nothing pureDb round4
       ]
     , benchNFIO "time" $ fmap fst <$> evalReplEval def replS (mapM eval timeTest)
+    , bgroup "defun"
+      [ benchNFIO "wrap10" $ runPactExec def "wrap10" [] Null Nothing pureDb wrap10Cmd
+      , benchNFIO "wrap10_mono" $ runPactExec def "wrap10_mono" [] Null Nothing pureDb wrap10MonoCmd
+      , benchNFIO "accum" $ runPactExec def "accum" [] Null Nothing pureDb accumCmd
+      ]
     ]

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -326,10 +326,22 @@ main = do
   replS <- setReplLib <$> initReplState Quiet Nothing
   let tt = evalReplEval def replS (mapM eval timeTest)
   void $! eitherDie "timeTest failed" . fmapL show =<< tt
+
   wrap10Cmd <- parseCode "(bench.wrap10 100)"
   wrap10MonoCmd <- parseCode "(bench.wrap10_integer 100)"
-  accumCmd <- parseCode "(bench.accum (enumerate 1 100))"
 
+  arityCmd0 <- parseCode "(bench.arity_tc_0)"
+  arityCmd1 <- parseCode "(bench.arity_tc_1 1)"
+  arityCmd10 <- parseCode "(bench.arity_tc_10 1 1 1 1 1 1 1 1 1 1)"
+  arityCmd40 <- parseCode "(bench.arity_tc_40 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1)"
+
+  aritySmallObj <- parseCode "(bench.arity_small_obj {\"a\": 1})"
+  arityMediumObj <- parseCode "(bench.arity_medium_obj {\"a\":1, \"b\":true, \"c\":1, \"d\":{\"a\":1}, \"e\":1, \"f\":true, \"g\":1, \"h\":{\"a\":1} })"
+  arityLargeObj <- parseCode "(bench.arity_large_obj {\"a\":1, \"b\":true, \"c\":1, \"d\":{\"a\":1}, \"e\":1, \"f\":true, \"g\":1, \"h\":{\"a\":1}, \"i\":1, \"j\":true, \"k\":1, \"l\":{\"a\":1}, \"m\":1, \"n\":true, \"o\":1, \"p\":{\"a\":1} })"
+
+  accumCmd0 <- parseCode "(bench.accum (enumerate 1 0))"
+  accumCmd1 <- parseCode "(bench.accum (enumerate 1 1))"
+  accumCmd100 <- parseCode "(bench.accum (enumerate 1 100))"
 
   let cleanupSqlite = do
         c <- readMVar $ pdPactDbVar sqliteDb
@@ -388,8 +400,26 @@ main = do
       ]
     , benchNFIO "time" $ fmap fst <$> evalReplEval def replS (mapM eval timeTest)
     , bgroup "defun"
-      [ benchNFIO "wrap10" $ runPactExec def "wrap10" [] Null Nothing pureDb wrap10Cmd
-      , benchNFIO "wrap10_mono" $ runPactExec def "wrap10_mono" [] Null Nothing pureDb wrap10MonoCmd
-      , benchNFIO "accum" $ runPactExec def "accum" [] Null Nothing pureDb accumCmd
+      [ bgroup "return-type-tc"
+        [ benchNFIO "wrap10" $ runPactExec def "wrap10" [] Null Nothing pureDb wrap10Cmd
+        , benchNFIO "wrap10_mono" $ runPactExec def "wrap10_mono" [] Null Nothing pureDb wrap10MonoCmd
+        , benchNFIO "accum100" $ runPactExec def "accum100" [] Null Nothing pureDb accumCmd100
+        ]
+      , bgroup "arity"
+        [ benchNFIO "00-args" $ runPactExec def "00-args" [] Null Nothing pureDb arityCmd0
+        , benchNFIO "01-args" $ runPactExec def "01-args" [] Null Nothing pureDb arityCmd1
+        , benchNFIO "10-args" $ runPactExec def "10-args" [] Null Nothing pureDb arityCmd10
+        , benchNFIO "40-args" $ runPactExec def "40-args" [] Null Nothing pureDb arityCmd40
+        ]
+      , bgroup "object-size"
+        [ benchNFIO "small-obj" $ runPactExec def "small-obj" [] Null Nothing pureDb aritySmallObj
+        , benchNFIO "medium-obj" $ runPactExec def "medium-obj" [] Null Nothing pureDb arityMediumObj
+        , benchNFIO "large-obj" $ runPactExec def "large-obj" [] Null Nothing pureDb arityLargeObj
+        ]
+      , bgroup "list-tc"
+        [ benchNFIO "000-items" $ runPactExec def "000-items" [] Null Nothing pureDb accumCmd0
+        , benchNFIO "001-items" $ runPactExec def "001-items" [] Null Nothing pureDb accumCmd1
+        , benchNFIO "100-items" $ runPactExec def "100-items" [] Null Nothing pureDb accumCmd100
+        ]
       ]
     ]

--- a/tests/bench/bench.pact
+++ b/tests/bench/bench.pact
@@ -89,13 +89,18 @@
 
  (defun wrap10 (a) (id (id (id (id (id (id (id (id (id (id a)))))))))))
 
+ (defun wrap10_integer:integer (a:integer) (id_integer (id_integer (id_integer (id_integer (id_integer (id_integer (id_integer (id_integer (id_integer (id_integer a)))))))))))
+
  (defun rep10 (a) (id a) (id a) (id a) (id a) (id a) (id a) (id a) (id a) (id a) (id a))
 
  (defun withr () (with-read bench-accounts "Acct1" { "balance":= b } b))
 
+ (defun accum:integer (xs) (fold (+) 0 xs))
+
  (defun fst (a b) a)
  (defun snd (a b) b)
  (defun id (a) a)
+ (defun id_integer:integer (a:integer) a)
 
 )
 

--- a/tests/bench/bench.pact
+++ b/tests/bench/bench.pact
@@ -102,6 +102,36 @@
  (defun id (a) a)
  (defun id_integer:integer (a:integer) a)
 
+ (defun arity_tc_0:integer
+    () 1)
+
+ (defun arity_tc_1:integer
+    (a:integer) 1)
+
+ (defun arity_tc_10:integer
+    (a:integer b:integer c:integer d:integer e:integer f:integer g:integer h:integer i:integer j:integer) 1)
+
+ (defun arity_tc_40:integer
+    (a1:integer b1:integer c1:integer d1:integer e1:integer f1:integer g1:integer h1:integer i1:integer j1:integer a2:integer b2:integer c2:integer d2:integer e2:integer f2:integer g2:integer h2:integer i2:integer j2:integer a3:integer b3:integer c3:integer d3:integer e3:integer f3:integer g3:integer h3:integer i3:integer j3:integer a4:integer b4:integer c4:integer d4:integer e4:integer f4:integer g4:integer h4:integer i4:integer j4:integer) 1)
+
+
+ (defschema small_object
+     a:integer)
+ (defun arity_small_obj:integer (arg:object{small_object}) 1)
+
+ (defschema medium_object
+     a:integer b:bool c:integer d:object{small_object}
+     e:integer f:bool g:integer h:object{small_object}
+   )
+ (defun arity_medium_obj:integer (arg:object{medium_object}) 1)
+
+ (defschema large_object
+     a:integer b:bool c:integer d:object{small_object}
+     e:integer f:bool g:integer h:object{small_object}
+     i:integer j:bool k:integer l:object{small_object}
+     m:integer n:bool o:integer p:object{small_object}
+     )
+ (defun arity_large_obj:integer (arg:object{large_object}) 1)
 )
 
 (create-table bench-accounts)


### PR DESCRIPTION
These new benchmarks are meant to exercise user-defined function application. The `wrap10_integer` nests 10 monomorphic user-defined functions calls. `accum` applies a function to a list of integers.

These benchmarks are added to measure the impact of adding return-type checking for user-defined functions in #1209.

Cherry-picking these benchmarks onto #1209 and modifying it to run return-type checking an arbitrary number of times gives the following timing results:

```
$ cabal run -O2 benchmark:bench -- -m prefix defun
```

## Summary for return-type checking

`wrap10` and `wrap10_integer` cost about 3 microseconds per run per return-type check replicate. `accum` costs about 0.3 microseconds per run with return-type check replicate. These two results are compatible because `wrap10` involves 11 function applications, so when we instrument the code to repeat type checking N times, `wrap10` will end up type checking 11*N function applications.

## Details for return-type checking

Check return types 0 times:
```
benchmarking defun/wrap10
time                 173.3 μs   (167.2 μs .. 180.3 μs)
                     0.987 R²   (0.976 R² .. 0.996 R²)
mean                 175.3 μs   (170.3 μs .. 181.3 μs)
std dev              20.09 μs   (14.03 μs .. 29.00 μs)
variance introduced by outliers: 84% (severely inflated)

benchmarking defun/wrap10_mono
time                 177.0 μs   (167.9 μs .. 187.5 μs)
                     0.983 R²   (0.977 R² .. 0.994 R²)
mean                 176.8 μs   (167.3 μs .. 207.2 μs)
std dev              52.42 μs   (16.38 μs .. 106.8 μs)
variance introduced by outliers: 98% (severely inflated)

benchmarking defun/accum
time                 394.6 μs   (353.8 μs .. 437.6 μs)
                     0.922 R²   (0.873 R² .. 0.989 R²)
mean                 376.0 μs   (360.5 μs .. 408.4 μs)
std dev              67.60 μs   (39.69 μs .. 122.5 μs)
variance introduced by outliers: 92% (severely inflated)
```

Check return types 1 time:
```
benchmarking defun/wrap10
time                 178.2 μs   (173.4 μs .. 183.6 μs)
                     0.992 R²   (0.988 R² .. 0.994 R²)
mean                 184.8 μs   (180.0 μs .. 191.5 μs)
std dev              19.71 μs   (15.90 μs .. 24.55 μs)
variance introduced by outliers: 82% (severely inflated)

benchmarking defun/wrap10_mono
time                 169.8 μs   (164.2 μs .. 176.1 μs)
                     0.985 R²   (0.976 R² .. 0.993 R²)
mean                 176.6 μs   (169.8 μs .. 194.6 μs)
std dev              35.87 μs   (21.92 μs .. 57.75 μs)
variance introduced by outliers: 95% (severely inflated)

benchmarking defun/accum
time                 323.1 μs   (312.1 μs .. 333.4 μs)
                     0.984 R²   (0.973 R² .. 0.994 R²)
mean                 341.5 μs   (329.9 μs .. 362.0 μs)
std dev              54.05 μs   (35.27 μs .. 75.81 μs)
variance introduced by outliers: 90% (severely inflated)
```

Check return types 1000 times:
```
benchmarking defun/wrap10
time                 3.522 ms   (2.786 ms .. 4.312 ms)
                     0.828 R²   (0.721 R² .. 0.941 R²)
mean                 3.877 ms   (3.621 ms .. 4.510 ms)
std dev              1.162 ms   (600.3 μs .. 1.976 ms)
variance introduced by outliers: 95% (severely inflated)

benchmarking defun/wrap10_mono
time                 2.499 ms   (2.283 ms .. 2.718 ms)
                     0.942 R²   (0.917 R² .. 0.969 R²)
mean                 2.534 ms   (2.390 ms .. 2.716 ms)
std dev              504.2 μs   (377.6 μs .. 704.6 μs)
variance introduced by outliers: 90% (severely inflated)

benchmarking defun/accum
time                 575.5 μs   (561.1 μs .. 589.0 μs)
                     0.992 R²   (0.984 R² .. 0.996 R²)
mean                 618.5 μs   (599.8 μs .. 643.7 μs)
std dev              73.04 μs   (53.25 μs .. 100.8 μs)
variance introduced by outliers: 82% (severely inflated)
```

## Function arity

`arity-tc/**-args` measure the application of user-defined functions with different arity.

```
00-args: 166us +/- 9us
01-args: 174us +/- 6us
10-args: 186 +/- 6us
40-args: 261 +/- 55us
=> About 2.5us per argument.
```

## Object argument size

`object-size/*-object` tests user-defined functions applied to various sizes of object.
`small-object` has a single `integer` field. `medium-object` has 8 fields of type `integer`, `bool` and `small-object`. `large-object` has 16 fields with those same types.

```
small-object (1 field): 182us +/- 18us
medium-object (8 fields): 236us +/- 16us
large-object (16 fields): 300us +/- 20us
=> About 8us per record field
```

## List argument size

```
list-tc/000-items: 185us +/- 10us
list-tc/001-items: 171us +/- 4us
list-tc/100-items: 385us +/- 11us
=> About 2.2us / item
```
