### PR TITLE
Remove some redundant fields from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,5 @@
 ---
-name: Pact Pull Request
 about: I would like to submit code to the Pact project
-title: ''
-labels: 'status: needs triage'
-assignees: ''
 ---
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,4 @@
----
-about: I would like to submit code to the Pact project
----
-
-
-Please include the following checklist in your PR:
+PR checklist:
 
 * [ ] Test coverage for the proposed changes
 * [ ] PR description contains example output from repl interaction or a snippet from unit test output


### PR DESCRIPTION
---
name: Remove some redundant fields from PR template
about: The PR template contains some fields that are already covered by github UI
title: Remove some redundant fields from PR template
labels: []
assignees: @emilypi 
---


Please include the following checklist in your PR:

* [x] Test coverage for the proposed changes (n/a, PR template is untested)
* [x] PR description contains example output from repl interaction or a snippet from unit test output (n/a, PR templates can't be previewed until they're deployed)
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated. (n/a)
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md) (n/a)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync. (n/a)

Additionally, please justify why you should or should not do the following:

* [x] Confirm replay/back compat. PR template doesn't factor in to repla
* [x] Benchmark regressions. n/a
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact. n/a
