### PR TITLE
read-msg recoverable under some key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+4.7.0
+---
+* `read-*` functions are now recoverable if the key doesn't exist
+
+
 4.6.0
 ---
 * Add `DisablePact46` execution flag (#1138)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 4.7.0
 ---
-* `read-*` functions are now recoverable if the key doesn't exist
+* `read-*` functions are now recoverable if the key doesn't exist. That is, a call such as `(read-string 'key)` is recoverable
+if `'key` does not exist in the data payload by surrounding it with `try`. As an example, `(try "string if key isn't present" (read-string "key"))`. This applies to
+`read-integer`, `read-string`, `read-decimal`, `read-keyset` and `read-msg` (as long as `read-msg` has a key supplied as an argument).
 
 
 4.6.0

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -75,7 +75,7 @@ colsToList argFail _ = argFail
 parseMsgKey :: (FromJSON t) => FunApp -> String -> Text -> Eval e t
 parseMsgKey f s t = parseMsgKey' f s (Just t)
 
-parseMsgKey' :: (FromJSON t) => FunApp -> String -> (Maybe Text) -> Eval e t
+parseMsgKey' :: (FromJSON t) => FunApp -> String -> Maybe Text -> Eval e t
 parseMsgKey' i msg key = do
   b <- view eeMsgBody
   let go v = case fromJSON v of
@@ -85,7 +85,12 @@ parseMsgKey' i msg key = do
   case key of
     Nothing -> go b
     Just k -> case preview (A.key k) b of
-      Nothing -> evalError' i $ "No such key in message: " <> pretty k
+      Nothing ->
+        isExecutionFlagSet FlagDisablePact47 >>= \case
+            True ->
+              evalError' i $ "No such key in message: " <> pretty k
+            False ->
+              failTx' i $ "No such key in message: " <> pretty k
       Just v -> go v
 
 

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -86,11 +86,9 @@ parseMsgKey' i msg key = do
     Nothing -> go b
     Just k -> case preview (A.key k) b of
       Nothing ->
-        isExecutionFlagSet FlagDisablePact47 >>= \case
-            True ->
-              evalError' i $ "No such key in message: " <> pretty k
-            False ->
-              failTx' i $ "No such key in message: " <> pretty k
+        ifExecutionFlagSet FlagDisablePact47
+          (evalError' i $ "No such key in message: " <> pretty k)
+          (failTx' i $ "No such key in message: " <> pretty k)
       Just v -> go v
 
 

--- a/tests/pact/try.repl
+++ b/tests/pact/try.repl
@@ -131,3 +131,28 @@
 ;; require-cap works in enforce-one post-fork
 (expect "require-cap works sin enforce-one" true (enforce-cap))
 (commit-tx)
+
+; read-* functions made recoverable
+
+(begin-tx)
+(env-data {})
+(env-exec-config ["DisablePact47"])
+(expect-failure "read-integer fails on non-existent key" (try 1 (read-integer "somekey")))
+(expect-failure "read-string fails on non-existent key" (try 1 (read-string "somekey")))
+(expect-failure "read-keyset fails on non-existent key" (try 1 (read-keyset "somekey")))
+(expect-failure "read-decimal fails on non-existent key" (try 1 (read-decimal "somekey")))
+(expect-failure "read-msg fails on non-existent key" (try 1 (read-msg "somekey")))
+(commit-tx)
+
+; Post-fork, they are recoverable
+(begin-tx)
+
+(env-data {})
+(env-exec-config [])
+(expect "read-integer fails on non-existent key but is recoverable" 1 (try 1 (read-integer "somekey")))
+(expect "read-string fails on non-existent key but is recoverable" 1 (try 1 (read-string "somekey")))
+(expect "read-keyset fails on non-existent key but is recoverable" 1 (try 1 (read-keyset "somekey")))
+(expect "read-decimal fails on non-existent key but is recoverable" 1 (try 1 (read-decimal "somekey")))
+(expect "read-msg fails on non-existent key but is recoverable" 1 (try 1 (read-msg "somekey")))
+(commit-tx)
+


### PR DESCRIPTION
PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
```
"Setting transaction data"
["DisablePact47"]
"Expect failure: success: read-integer fails on non-existent key"
"Expect failure: success: read-string fails on non-existent key"
"Expect failure: success: read-keyset fails on non-existent key"
"Expect failure: success: read-decimal fails on non-existent key"
"Expect failure: success: read-msg fails on non-existent key"
"Commit Tx 4"
"Begin Tx 5"
"Setting transaction data"
[]
"Expect: success: read-integer fails on non-existent key but is recoverable"
"Expect: success: read-string fails on non-existent key but is recoverable"
"Expect: success: read-keyset fails on non-existent key but is recoverable"
"Expect: success: read-decimal fails on non-existent key but is recoverable"
"Expect: success: read-msg fails on non-existent key but is recoverable"
"Commit Tx 5"
```
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)

Additionally, please justify why you should or should not do the following:

* [x] Confirm replay/back compat
Forked. Needs replay
* [x] Benchmark regressions
No point in this PR.