### PR TITLE
Cleanup README (add pact-lsp, remove stack instructions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ pact> (+ "hello, " "world")
 ## Supported Editors
 
 Pact is supported by a variety of editors ranging from full-fledged IDE environments to syntax highlighting.
-Moreover, our offering includes a Pact Language Server, which can be seamlessly integrated with a wide range of editors.
+Moreover, we also provide a Pact Language Server, which can be seamlessly integrated with a wide range of editors.
 The Pact Language Server can be found [here](https://github.com/kadena-io/pact-lsp).
 
 ### Chainweaver

--- a/README.md
+++ b/README.md
@@ -140,36 +140,6 @@ cabal v2-exec pact
 Alternatively, running `cabal v2-install exe:pact` inside this repository's root will install the binary to `~/.cabal/bin/`, which
 you may need to add to your path. Then, you can call `pact` as-is.
 
-#### Building with Stack
-
-***(stack is no longer supported)***
-
-Stack is a Haskell build tool that manages compiler and dependency versions for
-you. It's easy to install and use.
-
-##### Dependencies
-
-- `stack >= 1.9`
-  - (Mac only) Homebrew: `brew install haskell-stack`
-  - (Linux/Mac) [Installer](https://docs.haskellstack.org/en/stable/README/)
-
-(You may also need to install `zlib`, `z3`, and `sqlite`)
-
-To build a Pact binary:
-
-```bash
-stack build
-```
-
-This will compile a runnable version of Pact, which you can run via:
-
-```bash
-stack exec pact
-```
-
-Alternatively, `stack install` will install the binary to `~/.local/bin/`, which
-you may need to add to your path. Then, you can call `pact` as-is.
-
 #### Building with Nix
 
 The fastest way to build and run Pact is to use the Nix package manager
@@ -199,6 +169,8 @@ pact> (+ "hello, " "world")
 ## Supported Editors
 
 Pact is supported by a variety of editors ranging from full-fledged IDE environments to syntax highlighting.
+Moreover, our offering includes a Pact Language Server, which can be seamlessly integrated with a wide range of editors.
+The Pact Language Server can be found [here](https://github.com/kadena-io/pact-lsp).
 
 ### Chainweaver
 


### PR DESCRIPTION
This PR adds a note on the Pact Language Server.  
Additionally it removes the `stack` building instructions (the corresponding `stack.yaml` file does not exists anymore).


PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
