### PR TITLE
GH action cleanup + z3 version bump

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -29,9 +29,6 @@ jobs:
           cabal: '3.8'
           cabalcache: 'true'
           flags: '+build-tool'
-        # include:
-        # - os: 'windows-latest'
-        #   storepath: '--store-path=${HOME}/AppData/Roaming/cabal/store'
 
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.kadena_cabal_cache_aws_access_key_id }}
@@ -69,10 +66,6 @@ jobs:
       run: z3 -version
 
 
-    - name: Install non-Haskell dependencies (windows)
-      if: contains(matrix.os, 'windows')
-      run: choco install -y -r awscli
-
     # Haskell Setup
     - name: Set permissions for .ghcup (ubuntu)
       if: startsWith(matrix.os, 'ubuntu-')
@@ -86,21 +79,6 @@ jobs:
       run: |
         ghc --version
         cabal --version
-    - name: Setup PATHs (windows)
-      if: "contains(matrix.os, 'windows')"
-      shell: bash
-      run: |
-        echo "/c/ProgramData/chocolatey/lib/ghc/tools/ghc-${{ matrix.ghc }}/bin" >> $GITHUB_PATH
-        echo "C:\\ProgramData\\chocolatey\\lib\\ghc\\tools\\ghc-${{ matrix.ghc }}\\bin" >> $GITHUB_PATH
-        echo "/c/ProgramData/chocolatey/lib/cabal/tools/cabal-3.2.0.0" >> $GITHUB_PATH
-        echo "C:\\ProgramData\\chocolatey\\lib\\cabal\\tools\\cabal-3.2.0.0" >> $GITHUB_PATH
-        echo "/c/Users/runneradmin/AppData/Roaming/cabal/bin" >> $GITHUB_PATH
-        echo "C:\\Users\\runneradmin\\AppData\\Roaming\\cabal\\bin" >> $GITHUB_PATH
-        echo "/c/Program Files/Amazon/AWSCLI/bin" >> $GITHUB_PATH
-        echo "C:\\Program Files\\Amazon\\AWSCLI\\bin" >> $GITHUB_PATH
-
-        # these are needed for cabal-cache to work
-        ln -s /c/ProgramData/chocolatey/lib/ghc/tools/ghc-${{ matrix.ghc }}/bin/ghc-pkg.exe /c/ProgramData/chocolatey/lib/ghc/tools/ghc-${{ matrix.ghc }}/bin/ghc-pkg-${{ matrix.ghc }}
 
     # Project Setup
     - name: Create cabal.project.local
@@ -200,7 +178,7 @@ jobs:
 
     # Publish to S3
     - name: Publish applications to S3
-      if: "!contains(matrix.flags, '-build-tool') && !contains(matrix.os, 'windows')"
+      if: "!contains(matrix.flags, '-build-tool')"
       shell: bash
       run: |
         tar -C ./artifacts/pact/ -czf $BINFILE '.'

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -55,6 +55,7 @@ jobs:
       with:
         version: "4.12.1"
         architecture: "x64"
+        distribution: "glibc-2.35"
     - name: Install z3 (macOS)
       if: contains(matrix.os, 'mac')
       # uses: pavpanchekha/setup-z3@v0.3.0
@@ -62,7 +63,7 @@ jobs:
       with:
         version: "4.12.1"
         architecture: "x64"
-        distribution: "osx-10.15.7"
+        distribution: "osx-10.16"
 
 
     - name: Install non-Haskell dependencies (windows)

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -47,26 +47,24 @@ jobs:
       uses: actions/checkout@v3
 
     # Non Haskell dependencies
-    - name: Install z3 (ubuntu-20.04, ubuntu-22.04)
-      if: contains(matrix.os, 'ubuntu-20.04')
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y z3
-    - name: Install z3 (ubuntu-22.04)
-      if: contains(matrix.os, 'ubuntu-22.04')
-      # uses: pavpanchekha/setup-z3@v0.3.0
+
+    # Install Z3
+    - name: Install z3 (ubuntu-*)
+      if: contains(matrix.os, 'ubuntu')
       uses: larskuhtz/setup-z3@c209497f76e03a4c71ec92c0c6621fb3e1ea5fba
       with:
-        version: "4.11.2"
+        version: "4.12.1"
         architecture: "x64"
     - name: Install z3 (macOS)
       if: contains(matrix.os, 'mac')
       # uses: pavpanchekha/setup-z3@v0.3.0
       uses: larskuhtz/setup-z3@c209497f76e03a4c71ec92c0c6621fb3e1ea5fba
       with:
-        version: "4.8.10"
+        version: "4.12.1"
         architecture: "x64"
         distribution: "osx-10.15.7"
+
+
     - name: Install non-Haskell dependencies (windows)
       if: contains(matrix.os, 'windows')
       run: choco install -y -r awscli

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -64,6 +64,9 @@ jobs:
         version: "4.12.1"
         architecture: "x64"
         distribution: "osx-10.16"
+    - name: Print Z3 version
+      shell: bash
+      run: z3 -version
 
 
     - name: Install non-Haskell dependencies (windows)

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -46,8 +46,15 @@ jobs:
     # Non Haskell dependencies
 
     # Install Z3
-    - name: Install z3 (ubuntu-*)
-      if: contains(matrix.os, 'ubuntu')
+    - name: Install z3 (ubuntu-20.04)
+      if: contains(matrix.os, 'ubuntu-20.04')
+      uses: larskuhtz/setup-z3@c209497f76e03a4c71ec92c0c6621fb3e1ea5fba
+      with:
+        version: "4.11.2"
+        architecture: "x64"
+        distribution: "glibc-2.31"
+    - name: Install z3 (ubuntu-22.04)
+      if: contains(matrix.os, 'ubuntu-22.04')
       uses: larskuhtz/setup-z3@c209497f76e03a4c71ec92c0c6621fb3e1ea5fba
       with:
         version: "4.12.1"

--- a/README.md
+++ b/README.md
@@ -64,12 +64,14 @@ The easiest and quickest way to try Pact is [in the browser](http://pact.kadena.
 
 Pact can be installed via binary distribution for Linux or Mac by following the instructions below:
 
-- Install [z3](https://github.com/Z3Prover/z3/wiki).
+- Install [z3](https://github.com/Z3Prover/z3/wiki) `>= 4.11.2`.
 - Download the [prebuilt binaries](https://github.com/kadena-io/pact/releases) for either Linux or Mac, depending on your OS.
 - Once you've downloaded the binary, make sure that it is marked as executable by running `chmod +x <executable-file>`.
 - Put the binary somewhere in your PATH.
 
 Once you have Pact in your path, proceed to validating your installation by trying out [the repl](#verifying-installation).
+
+
 
 ### Instructions for Mac Users
 


### PR DESCRIPTION
This PR updates the Z3 version and (_tries to_) unify them across builds.
The version differences wrt architecture are as follows.

| OS | New Z3 Version | Old Z3 Version |
|------ | ------------ | ----- |
|Ubuntu 20.04 | 4.11.2 | 4.11.2 |
| Ubuntu 22.04 | 4.12.2 | 4.12.2 |
| OSX | 4.12.2 | 4.8.10 |


Ubuntu 20.04 uses an old `glibc` version preventing the simple update to `Z3 4.12.2`.


Additionally, this PR removes the Windows related steps which are not used anymore.

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
