### PR TITLE
Fix partial bind

### DIFF
--- a/src-tool/Pact/Analyze/Translate.hs
+++ b/src-tool/Pact/Analyze/Translate.hs
@@ -1395,12 +1395,10 @@ translateNode astNode = withAstContext astNode $ case astNode of
     _ -> unexpectedNode astNode
 
   AST_Bind node objectA bindings schemaNode body -> translateType schemaNode >>= \case
-    EType objTy@SObject{} -> typeOfPartialBind objTy bindings >>= \case
-      EType partialReadTy@SObject{} -> do
+    EType objTy@SObject{} -> do
         objectT <- translateNode objectA
         withNodeContext node $
-          translateObjBinding bindings partialReadTy body objectT
-      _ -> unexpectedNode astNode
+          translateObjBinding bindings objTy body objectT
     _ -> unexpectedNode astNode
 
   AST_WithCapability (AST_InlinedApp modName funName _ bindings appBodyA) withBodyA -> do

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -4564,3 +4564,26 @@ spec = describe "analyze" $ do
         (enforce false ""))
       |]
       "Vacuous property encountered!"
+
+  describe "partial bind (regression #1173)" $ do
+    expectVerified [text|
+      (defschema ty
+       ""
+       a: integer
+       b: time)
+
+      (defun test (x:object{ty})
+        @model[(property true)]
+        (bind x
+          {"b" := _}
+          1))|]
+
+    expectVerified [text|
+       (defun test(x:integer)
+       @model [ (property (>= x 0))]
+       (enforce (> x 0) "x must be greater than 0")
+       (bind (chain-data)
+         { "block-height" := block-height
+         , "block-time"   := block-time }
+         (* block-height  x)))
+      |]


### PR DESCRIPTION
Prior this PR, partial binds resulted in a sort-mismatch error (emitted from Z3). 
The following example just binds `b` and resulted in the subsequent error:
```
(module test G  (defcap G () true)
  (defschema ty
      ""
    a: integer
    b: time
    )
 
  (defun test (x:object{ty})
          @model[(property true)]
          (bind x
              {"b" := _}
            1))
)
(verify 'test true)
```

```
*** Data.SBV: Unexpected non-success response from Z3:
***
***    Sent      : (define-fun s6 () (_ BitVec 64) (proj_1_SBVTuple2 s0))
***    Expected  : success
***    Received  : (error "line 23 column 54: invalid function/constant definition, sort mismatch")
***
***    Exit code : ExitFailure (-15)
***    Executable: /home/rsoeldner/Downloads/z3-4.12.1-x64-glibc-2.35/bin/z3
***    Options   : -nw -in -smt2
***
***    Reason    : Check solver response for further information. If your code is correct,
***                please report this as an issue either with SBV or the solver itself!
```

The reason for this misbehavior is the fact, that we pass the binding schema (in this particular case `b`) to `translateObjBind`. The fix relies on the original object schema (here `a` and `b`) and our internal machinery to identify the current bind (see `evalObjAt` from [Core.hs](https://github.com/kadena-io/pact/blob/master/src-tool/Pact/Analyze/Eval/Core.hs#L738) where we loop through the elements to identify the bind).

Closes #1173 

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
