### PR TITLE
Add CoverageSpec to PactTests

### DIFF
--- a/tests/PactTests.hs
+++ b/tests/PactTests.hs
@@ -29,6 +29,7 @@ import qualified TypecheckSpec
 import qualified PactCLISpec
 import qualified ZkSpec
 import qualified ReplSpec
+import qualified CoverageSpec
 # endif
 #endif
 
@@ -64,7 +65,7 @@ main = hspec $ parallel $ do
   describe "PactCLISpec" PactCLISpec.spec
   describe "ZkSpec" ZkSpec.spec
   describe "ReplSpec" ReplSpec.spec
-
+  describe "CoverageSpec" CoverageSpec.spec
 
 # endif
 #endif


### PR DESCRIPTION
This PR adds `CoverageSpec` to the Pact test suite. It was not enabled during https://github.com/kadena-io/pact/pull/1151, but passes locally, and via `cabal run tests`. 

PR checklist:

* [x] *(N/A)* Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] *(N/A)* Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] *(N/A)* Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] *(N/A)* In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [x] *(N/A)* Confirm replay/back compat
* [x] *(N/A)* Benchmark regressions
* [x] *(N/A)* (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
