### PR TITLE
Avoid use of runIO in test code

### DIFF
--- a/tests/CoverageSpec.hs
+++ b/tests/CoverageSpec.hs
@@ -22,18 +22,21 @@ spec = do
 
 testCover :: Spec
 testCover = do
-  rpt <- runIO $ do
-    let fn = "tests/lcov/lcov.repl"
-    (ref,adv) <- mkCoverageAdvice
-    s <- initReplState (Script False fn) Nothing
-    void $! execScriptState' fn s (set (rEnv . eeAdvice) adv)
-    readIORef ref
-  it "matches golden coverage" $ Golden
-      { output = T.unpack (showReport rpt)
-      , encodePretty = id
-      , writeToFile = writeFile
-      , readFromFile = readFile
-      , testName = "lcov"
-      , directory = "golden"
-      , failFirstTime = False
-      }
+  before rpt $
+    it "matches golden coverage" $ \a ->
+      Golden
+        { output = T.unpack (showReport a)
+        , encodePretty = id
+        , writeToFile = writeFile
+        , readFromFile = readFile
+        , testName = "lcov"
+        , directory = "golden"
+        , failFirstTime = False
+        }
+  where
+    rpt = do
+      let fn = "tests/lcov/lcov.repl"
+      (ref,adv) <- mkCoverageAdvice
+      s <- initReplState (Script False fn) Nothing
+      void $! execScriptState' fn s (set (rEnv . eeAdvice) adv)
+      readIORef ref


### PR DESCRIPTION
PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
