### PR TITLE
fix docs for `env-sigs`

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -2022,7 +2022,7 @@ pact> (env-hash (hash "hello"))
 *keys*&nbsp;`[string]` *&rarr;*&nbsp;`string`
 
 
-DEPRECATED in favor of 'set-sigs'. Set transaction signer KEYS. See 'env-sigs' for setting keys with associated capabilities.
+DEPRECATED in favor of 'env-sigs'. Set transaction signer KEYS. See 'env-sigs' for setting keys with associated capabilities.
 ```lisp
 pact> (env-keys ["my-key" "admin-key"])
 "Setting transaction keys"

--- a/docs/en/pact-functions.rst
+++ b/docs/en/pact-functions.rst
@@ -2319,7 +2319,7 @@ env-keys
 
 *keys* ``[string]`` *→* ``string``
 
-DEPRECATED in favor of ‘set-sigs’. Set transaction signer KEYS. See
+DEPRECATED in favor of ‘env-sigs’. Set transaction signer KEYS. See
 ‘env-sigs’ for setting keys with associated capabilities.
 
 .. code:: lisp

--- a/docs/en/pact-reference.md
+++ b/docs/en/pact-reference.md
@@ -923,10 +923,10 @@ new `env-sigs` REPL function as follows:
   ...
 )
 
-(set-sigs [{'key: "alice", 'caps: ["(accounts.PAY \"alice\" \"bob\" 10.0)"]}])
+(env-sigs [{'key: "alice", 'caps: ["(accounts.PAY \"alice\" \"bob\" 10.0)"]}])
 (accounts.pay "alice" "bob" 10.0) ;; works as the cap match the signature caps
 
-(set-sigs [('key: "alice", 'caps: ["(accounts.PAY \"alice\" "\carol\" 10.0)"]}])
+(env-sigs [('key: "alice", 'caps: ["(accounts.PAY \"alice\" "\carol\" 10.0)"]}])
 (expect-failure "payment to bob will no longer be able to enforce alice's keyset"
   (accounts.pay "alice" "bob" 10.0))
 ```

--- a/docs/en/pact-reference.rst
+++ b/docs/en/pact-reference.rst
@@ -1189,10 +1189,10 @@ as follows:
      ...
    )
 
-   (set-sigs [{'key: "alice", 'caps: ["(accounts.PAY \"alice\" \"bob\" 10.0)"]}])
+   (env-sigs [{'key: "alice", 'caps: ["(accounts.PAY \"alice\" \"bob\" 10.0)"]}])
    (accounts.pay "alice" "bob" 10.0) ;; works as the cap match the signature caps
 
-   (set-sigs [('key: "alice", 'caps: ["(accounts.PAY \"alice\" "\carol\" 10.0)"]}])
+   (env-sigs [('key: "alice", 'caps: ["(accounts.PAY \"alice\" "\carol\" 10.0)"]}])
    (expect-failure "payment to bob will no longer be able to enforce alice's keyset"
      (accounts.pay "alice" "bob" 10.0))
 

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -120,7 +120,7 @@ replDefs = ("Repl",
       "Transform PUBLIC-KEY into an address (i.e. a Pact Runtime Public Key) depending on its SCHEME."
      ,defZRNative "env-keys" setsigs (funType tTyString [("keys",TyList tTyString)])
       ["(env-keys [\"my-key\" \"admin-key\"])"]
-      ("DEPRECATED in favor of 'set-sigs'. Set transaction signer KEYS. "<>
+      ("DEPRECATED in favor of 'env-sigs'. Set transaction signer KEYS. "<>
        "See 'env-sigs' for setting keys with associated capabilities.")
      ,defZNative "env-sigs" setsigs' (funType tTyString [("sigs",TyList (tTyObject TyAny))])
       [LitExample $ "(env-sigs [{'key: \"my-key\", 'caps: [(accounts.USER_GUARD \"my-account\")]}, " <>


### PR DESCRIPTION
This PR corrects the use of `set-sigs` within our docs. As the change effects `repl-only` documentation, the other items below are not relevant.

before:
```
pact> env-keys
native `env-keys`
  
  DEPRECATED in favor of 'set-sigs'. Set transaction signer KEYS. See 'env-sigs'
  for setting keys with associated capabilities.
  
  Type:
  keys:[string] -> string
  
  Examples:
  > (env-keys ["my-key" "admin-key"])
```

after:
```
pact> env-keys
native `env-keys`
  
  DEPRECATED in favor of 'env-sigs'. Set transaction signer KEYS. See 'env-sigs'
  for setting keys with associated capabilities.
  
  Type:
  keys:[string] -> string
  
  Examples:
  > (env-keys ["my-key" "admin-key"])
```

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
