### PR TITLE
Flag to disable return RTC, 4.7.1 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+4.7.1
+---
+
+- Revert runtime type checking on return types (#1209)
+
+### Formal Verification
+
+- Fixed empty list type defaulting to any (#1224)
+- Fixed partial biniding (#1127)
+
+### Tests
+
+- Refactored test to avoid `runIO` within tests (#1129)
+- Add `CoverageSpec` (#1228)
+- Fix `ReplSpec` tests (#1216)
+- Cleanup `PactContinuationSpec` (#1222)
+
+### Others
+
+- Cleanup [README.md](README.md) (#1225)
+- Bump Z3 versions in GH actions (#1126)
+
 4.7.0
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 4.7.1
 ---
 
-- Revert runtime type checking on return types (#1209)
+- Exchange runtime type checking on return types flag from `DisablePact47` to `DisableReturnRTC`.
 
 ### Formal Verification
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 4.7.1
 ---
 
-- Exchange runtime type checking on return types flag from `DisablePact47` to `DisableReturnRTC`.
+- Add feature flag `FlagDisableRuntimeTypeChecking` for disabling runtime typechecking
+  introduced in Pact 4.7 (#1231)
 
 ### Formal Verification
 

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1928,7 +1928,7 @@ Retreive any accumulated events and optionally clear event state. Object returne
  *&rarr;*&nbsp;`[string]`
 
 
-Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisableNewTrans","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePact45","DisablePact46","DisablePact47","DisablePactEvents","DisableReturnRTC","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
+Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisableNewTrans","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePact45","DisablePact46","DisablePact47","DisablePactEvents","EnableRuntimeRTC","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
 ```lisp
 pact> (env-exec-config ['DisableHistoryInTransactionalMode]) (env-exec-config)
 ["DisableHistoryInTransactionalMode"]

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1928,7 +1928,7 @@ Retreive any accumulated events and optionally clear event state. Object returne
  *&rarr;*&nbsp;`[string]`
 
 
-Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisableNewTrans","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePact45","DisablePact46","DisablePact47","DisablePactEvents","EnableRuntimeRTC","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
+Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisableNewTrans","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePact45","DisablePact46","DisablePact47","DisablePactEvents","DisableReturnRTC","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
 ```lisp
 pact> (env-exec-config ['DisableHistoryInTransactionalMode]) (env-exec-config)
 ["DisableHistoryInTransactionalMode"]

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -461,7 +461,7 @@ Return ID if called during current pact execution, failing if not.
 Obtain current pact build version.
 ```lisp
 pact> (pact-version)
-"4.7.0"
+"4.7.1"
 ```
 
 Top level only: this function will fail if used in module code.

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1928,7 +1928,7 @@ Retreive any accumulated events and optionally clear event state. Object returne
  *&rarr;*&nbsp;`[string]`
 
 
-Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisableNewTrans","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePact45","DisablePact46","DisablePact47","DisablePactEvents","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
+Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisableNewTrans","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePact45","DisablePact46","DisablePact47","DisablePactEvents","DisableReturnRTC","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
 ```lisp
 pact> (env-exec-config ['DisableHistoryInTransactionalMode]) (env-exec-config)
 ["DisableHistoryInTransactionalMode"]

--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1928,7 +1928,7 @@ Retreive any accumulated events and optionally clear event state. Object returne
  *&rarr;*&nbsp;`[string]`
 
 
-Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisableNewTrans","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePact45","DisablePact46","DisablePact47","DisablePactEvents","DisableReturnRTC","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
+Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisableNewTrans","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePact45","DisablePact46","DisablePact47","DisablePactEvents","DisableRuntimeReturnTypeChecking","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
 ```lisp
 pact> (env-exec-config ['DisableHistoryInTransactionalMode]) (env-exec-config)
 ["DisableHistoryInTransactionalMode"]

--- a/examples/cp/orders.pact
+++ b/examples/cp/orders.pact
@@ -48,7 +48,7 @@
 
   )
 
-  (defun with-order-status (order-id status)
+  (defun with-order-status:object{order} (order-id status)
     "Check that order status is correct, returning details"
     (let ((o (read orders order-id)))
       (enforce (= (at 'status o) status)

--- a/pact.cabal
+++ b/pact.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                pact
-version:             4.7.0
+version:             4.7.1
 -- ^ 4 digit is prerelease, 3- or 2-digit for prod release
 synopsis:            Smart contract language library and REPL
 description:

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -1172,7 +1172,12 @@ functionApp fnName funTy mod_ as fnBody docs ai = do
   let body = instantiate (resolveArg ai args') fnBody
       fname = asString fnName
       fa = FunApp ai fname mod_ Defun (funTypes fty) docs
-  guardRecursion fname mod_ $ appCall fa ai args' $ fmap (gas,) $ reduceBody body
+  retVal <- guardRecursion fname mod_ $ appCall fa ai args' $ fmap (gas,) $ reduceBody body
+
+  unlessExecutionFlagSet FlagDisableReturnRTC $
+    typecheckTerm ai (_ftReturn fty) retVal
+
+  pure retVal
 
 -- | Evaluate a dynamic ref to either a fully-reduced value from a 'TConst'
 -- or a module member 'Def' for applying.

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -1174,7 +1174,7 @@ functionApp fnName funTy mod_ as fnBody docs ai = do
       fa = FunApp ai fname mod_ Defun (funTypes fty) docs
   retVal <- guardRecursion fname mod_ $ appCall fa ai args' $ fmap (gas,) $ reduceBody body
 
-  whenExecutionFlagSet FlagEnableRuntimeRTC $
+  unlessExecutionFlagSet FlagDisableReturnRTC $
     typecheckTerm ai (_ftReturn fty) retVal
 
   pure retVal

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -1180,6 +1180,7 @@ functionApp fnName funTy mod_ as fnBody docs ai = do
 
   return returnVal
 
+
 -- | Evaluate a dynamic ref to either a fully-reduced value from a 'TConst'
 -- or a module member 'Def' for applying.
 reduceDynamic

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -1172,14 +1172,7 @@ functionApp fnName funTy mod_ as fnBody docs ai = do
   let body = instantiate (resolveArg ai args') fnBody
       fname = asString fnName
       fa = FunApp ai fname mod_ Defun (funTypes fty) docs
-
-  returnVal <- guardRecursion fname mod_ $ appCall fa ai args' $ fmap (gas,) $ reduceBody body
-
-  unlessExecutionFlagSet FlagDisablePact47 $
-    typecheckTerm ai (_ftReturn fty) returnVal
-
-  return returnVal
-
+  guardRecursion fname mod_ $ appCall fa ai args' $ fmap (gas,) $ reduceBody body
 
 -- | Evaluate a dynamic ref to either a fully-reduced value from a 'TConst'
 -- or a module member 'Def' for applying.

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -1172,12 +1172,13 @@ functionApp fnName funTy mod_ as fnBody docs ai = do
   let body = instantiate (resolveArg ai args') fnBody
       fname = asString fnName
       fa = FunApp ai fname mod_ Defun (funTypes fty) docs
-  retVal <- guardRecursion fname mod_ $ appCall fa ai args' $ fmap (gas,) $ reduceBody body
+
+  returnVal <- guardRecursion fname mod_ $ appCall fa ai args' $ fmap (gas,) $ reduceBody body
 
   unlessExecutionFlagSet FlagDisableReturnRTC $
-    typecheckTerm ai (_ftReturn fty) retVal
+    typecheckTerm ai (_ftReturn fty) returnVal
 
-  pure retVal
+  return returnVal
 
 -- | Evaluate a dynamic ref to either a fully-reduced value from a 'TConst'
 -- or a module member 'Def' for applying.

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -1175,7 +1175,7 @@ functionApp fnName funTy mod_ as fnBody docs ai = do
 
   returnVal <- guardRecursion fname mod_ $ appCall fa ai args' $ fmap (gas,) $ reduceBody body
 
-  unlessExecutionFlagSet FlagDisableReturnRTC $
+  unlessExecutionFlagSet FlagDisableRuntimeReturnTypeChecking $
     typecheckTerm ai (_ftReturn fty) returnVal
 
   return returnVal

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -1174,7 +1174,7 @@ functionApp fnName funTy mod_ as fnBody docs ai = do
       fa = FunApp ai fname mod_ Defun (funTypes fty) docs
   retVal <- guardRecursion fname mod_ $ appCall fa ai args' $ fmap (gas,) $ reduceBody body
 
-  unlessExecutionFlagSet FlagDisableReturnRTC $
+  whenExecutionFlagSet FlagEnableRuntimeRTC $
     typecheckTerm ai (_ftReturn fty) retVal
 
   pure retVal

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -188,7 +188,7 @@ data ExecutionFlag
   -- | Disable Pact 4.7 Features
   | FlagDisablePact47
   -- | Disable runtime return type checking.
-  | FlagDisableReturnRTC
+  | FlagEnableRuntimeRTC
   deriving (Eq,Ord,Show,Enum,Bounded)
 
 -- | Flag string representation

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -187,6 +187,8 @@ data ExecutionFlag
   | FlagDisablePact46
   -- | Disable Pact 4.7 Features
   | FlagDisablePact47
+  -- | Disable runtime return type checking.
+  | FlagDisableReturnRTC
   deriving (Eq,Ord,Show,Enum,Bounded)
 
 -- | Flag string representation

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -187,7 +187,7 @@ data ExecutionFlag
   | FlagDisablePact46
   -- | Disable Pact 4.7 Features
   | FlagDisablePact47
-  -- | Disable runtime return type checking.
+  -- | Enable runtime return type checking.
   | FlagEnableRuntimeRTC
   deriving (Eq,Ord,Show,Enum,Bounded)
 

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -188,7 +188,7 @@ data ExecutionFlag
   -- | Disable Pact 4.7 Features
   | FlagDisablePact47
   -- | Disable runtime return type checking.
-  | FlagDisableReturnRTC
+  | FlagDisableRuntimeReturnTypeChecking
   deriving (Eq,Ord,Show,Enum,Bounded)
 
 -- | Flag string representation

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -187,7 +187,7 @@ data ExecutionFlag
   | FlagDisablePact46
   -- | Disable Pact 4.7 Features
   | FlagDisablePact47
-  -- | Enable runtime return type checking.
+  -- | Disable runtime return type checking.
   | FlagEnableRuntimeRTC
   deriving (Eq,Ord,Show,Enum,Bounded)
 

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -188,7 +188,7 @@ data ExecutionFlag
   -- | Disable Pact 4.7 Features
   | FlagDisablePact47
   -- | Disable runtime return type checking.
-  | FlagEnableRuntimeRTC
+  | FlagDisableReturnRTC
   deriving (Eq,Ord,Show,Enum,Bounded)
 
 -- | Flag string representation

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -368,27 +368,3 @@
  "rtc object lists"
  1
  (rtc-object-list (let ((a {'a:1}) (b {'a: 2})) [a b])))
-
-;; A module with incorrect annotations for a function's return type.
-;; Runtime typechecking for function return types was added in
-;; pact-4.7.
-(module tc-test-function-return-types g
-  (defcap g () true)
-  (defun f:string () (+ 1 2))
-)
-
-(expect-failure
-  "evaluating a function whose type signature conflits with its body should fail"
-  (tc-test-function-return-types.f)
-  )
-
-(expect-failure
-  "composing an ill-typed function with another function should not evaluate"
-  (tc-test-function-return-types.g (tc-test-function-return-types.f 1))
-  )
-
-(env-exec-config ["DisablePact47"])
-(expect
-  "evaluating ill-typed function should succeed with pact-4.7 features disabled"
-  3
-  (tc-test-function-return-types.f))

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -371,7 +371,9 @@
 
 ;; A module with incorrect annotations for a function's return type.
 ;; Runtime typechecking for function return types was added in
-;; pact-4.7.1 and guarded via `DisableReturnRTC`.
+;; pact-4.7.1 and guarded via `EnableRuntimeRTC`.
+
+(env-exec-config ['EnableRuntimeRTC])
 
 (module tc-test-function-return-types g
   (defcap g () true)
@@ -388,7 +390,7 @@
   (tc-test-function-return-types.g (tc-test-function-return-types.f 1))
   )
 
-(env-exec-config ["DisableReturnRTC"])
+(env-exec-config [])
 (expect
   "evaluating ill-typed function should succeed with pact-4.7 features disabled"
   3

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -368,3 +368,28 @@
  "rtc object lists"
  1
  (rtc-object-list (let ((a {'a:1}) (b {'a: 2})) [a b])))
+
+;; A module with incorrect annotations for a function's return type.
+;; Runtime typechecking for function return types was added in
+;; pact-4.7.1 and guarded via `DisableReturnRTC`.
+
+(module tc-test-function-return-types g
+  (defcap g () true)
+  (defun f:string () (+ 1 2))
+)
+
+(expect-failure
+  "evaluating a function whose type signature conflits with its body should fail"
+  (tc-test-function-return-types.f)
+  )
+
+(expect-failure
+  "composing an ill-typed function with another function should not evaluate"
+  (tc-test-function-return-types.g (tc-test-function-return-types.f 1))
+  )
+
+(env-exec-config ["DisableReturnRTC"])
+(expect
+  "evaluating ill-typed function should succeed with pact-4.7 features disabled"
+  3
+  (tc-test-function-return-types.f))

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -371,7 +371,7 @@
 
 ;; A module with incorrect annotations for a function's return type.
 ;; Runtime typechecking for function return types was added in
-;; pact-4.7.1 and guarded via `DisableReturnRTC`.
+;; pact-4.7.1 and guarded via `DisableRuntimeReturnTypeChecking`.
 
 (module tc-test-function-return-types g
   (defcap g () true)

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -371,9 +371,7 @@
 
 ;; A module with incorrect annotations for a function's return type.
 ;; Runtime typechecking for function return types was added in
-;; pact-4.7.1 and guarded via `EnableRuntimeRTC`.
-
-(env-exec-config ['EnableRuntimeRTC])
+;; pact-4.7.1 and guarded via `DisableReturnRTC`.
 
 (module tc-test-function-return-types g
   (defcap g () true)
@@ -390,7 +388,7 @@
   (tc-test-function-return-types.g (tc-test-function-return-types.f 1))
   )
 
-(env-exec-config [])
+(env-exec-config ["DisableReturnRTC"])
 (expect
   "evaluating ill-typed function should succeed with pact-4.7 features disabled"
   3

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -388,7 +388,7 @@
   (tc-test-function-return-types.g (tc-test-function-return-types.f 1))
   )
 
-(env-exec-config ["DisableReturnRTC"])
+(env-exec-config ["DisableRuntimeReturnTypeChecking"])
 (expect
   "evaluating ill-typed function should succeed with pact-4.7 features disabled"
   3


### PR DESCRIPTION
This PR mainly puts changes introduced in a33ebb853028af5d4e3546f30d6c883abda99def under the `DisableRuntimeReturnTypeChecking` flag. 

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
