### PR TITLE
Add parsing of `and?` and `or?` for properties

### DIFF
--- a/src-tool/Pact/Analyze/Parse/Prop.hs
+++ b/src-tool/Pact/Analyze/Parse/Prop.hs
@@ -517,6 +517,12 @@ inferPreProp preProp = case preProp of
       _               -> throwErrorIn preProp $
         pretty op' <> " applied to wrong number of arguments"
 
+  PreApp s [PreApp a p1, PreApp b p2 , c] | s == SOrQ ->
+    inferPreProp (PreApp SLogicalDisjunction [PreApp a (p1 ++ [c]), PreApp b (p2 ++ [c])])
+
+  PreApp s [PreApp a p1, PreApp b p2 , c] | s == SAndQ ->
+    inferPreProp (PreApp SLogicalConjunction [PreApp a (p1 ++ [c]), PreApp b (p2 ++ [c])])
+
   PreApp s [a, b] | s == SLogicalImplication -> do
     propNotA <- PNot <$> checkPreProp SBool a
     Some SBool . POr propNotA <$> checkPreProp SBool b

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -4616,3 +4616,16 @@ spec = describe "analyze" $ do
        @model [ (property (and? (> 1) (> 2) 3))]
          true)
       |]
+
+    expectVerified [text|
+       (defun test(x: integer y: integer z: integer)
+       @model [ (property (or? (> x) (> y) z))]
+       (enforce (or? (> x) (> y) z) "")
+         true)
+      |]
+    expectVerified [text|
+       (defun test(x: integer y: integer z: integer)
+       @model [ (property (and? (> x) (> y) z))]
+       (enforce (and? (> x) (> y) z) "")
+         true)
+      |]

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -4594,3 +4594,25 @@ spec = describe "analyze" $ do
          , "block-time"   := block-time }
          (* block-height  x)))
       |]
+
+  describe "Properties involving `or?` and `and?` are handled" $ do
+    expectVerified [text|
+       (defun test()
+       @model [ (property (or? (> 1) (> 2) 1))]
+         true)
+      |]
+    expectFalsified [text|
+       (defun test()
+       @model [ (property (or? (> 1) (> 2) 3))]
+         true)
+      |]
+    expectVerified [text|
+       (defun test()
+       @model [ (property (and? (> 1) (> 2) 0))]
+         true)
+      |]
+    expectFalsified [text|
+       (defun test()
+       @model [ (property (and? (> 1) (> 2) 3))]
+         true)
+      |]


### PR DESCRIPTION
This PR adds the desugaring of `and?` and `or?` within properties. So-far, we emitted the following error message: `could not parse (???) in (or? ...), couldn't find property named or?`

As this is FV only, no replay needed.

Thanks to @EnoF  for identifying this issue.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [x] Confirm replay/back compat
* [x] Benchmark regressions
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
