### PR TITLE
Make gas units more granular 

### DIFF
--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Pact.Bench where
 
@@ -172,7 +173,7 @@ loadCompile f = do
 
 
 prodGasEnv :: GasEnv
-prodGasEnv = GasEnv (gasLimitToMilliGasLimit 100000) 0.01 $ tableGasModel defaultGasConfig
+prodGasEnv = GasEnv (gasLimitToMilliGasLimit 100_000) 0.01 $ tableGasModel defaultGasConfig
 
 parseCode :: Text -> IO ParsedCode
 parseCode m = ParsedCode m <$> eitherDie "parseCode" (parseExprs m)

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -172,7 +172,7 @@ loadCompile f = do
 
 
 prodGasEnv :: GasEnv
-prodGasEnv = GasEnv 100000 0.01 $ tableGasModel defaultGasConfig
+prodGasEnv = GasEnv (gasLimitToMicroGasLimit 100000) 0.01 $ tableGasModel defaultGasConfig
 
 parseCode :: Text -> IO ParsedCode
 parseCode m = ParsedCode m <$> eitherDie "parseCode" (parseExprs m)

--- a/src-ghc/Pact/Bench.hs
+++ b/src-ghc/Pact/Bench.hs
@@ -172,7 +172,7 @@ loadCompile f = do
 
 
 prodGasEnv :: GasEnv
-prodGasEnv = GasEnv (gasLimitToMicroGasLimit 100000) 0.01 $ tableGasModel defaultGasConfig
+prodGasEnv = GasEnv (gasLimitToMilliGasLimit 100000) 0.01 $ tableGasModel defaultGasConfig
 
 parseCode :: Text -> IO ParsedCode
 parseCode m = ParsedCode m <$> eitherDie "parseCode" (parseExprs m)

--- a/src-ghc/Pact/GasModel/Types.hs
+++ b/src-ghc/Pact/GasModel/Types.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NumericUnderscores #-}
 
 
 module Pact.GasModel.Types
@@ -240,7 +241,7 @@ defEvalEnv db = do
   setupEvalEnv db entity Transactional (initMsgData pactInitialHash) (versionedNativesRefStore noPact44EC)
     prodGasModel permissiveNamespacePolicy noSPVSupport def noPact44EC
   where entity = Just $ EntityName "entity"
-        prodGasModel = GasEnv (gasLimitToMilliGasLimit 10000000) 0.01 $ tableGasModel defaultGasConfig
+        prodGasModel = GasEnv (gasLimitToMilliGasLimit 10_000_000) 0.01 $ tableGasModel defaultGasConfig
         noPact44EC = mkExecutionConfig [FlagDisablePact44]
 
 -- MockDb

--- a/src-ghc/Pact/GasModel/Types.hs
+++ b/src-ghc/Pact/GasModel/Types.hs
@@ -240,7 +240,7 @@ defEvalEnv db = do
   setupEvalEnv db entity Transactional (initMsgData pactInitialHash) (versionedNativesRefStore noPact44EC)
     prodGasModel permissiveNamespacePolicy noSPVSupport def noPact44EC
   where entity = Just $ EntityName "entity"
-        prodGasModel = GasEnv (gasLimitToMicroGasLimit 10000000) 0.01 $ tableGasModel defaultGasConfig
+        prodGasModel = GasEnv (gasLimitToMilliGasLimit 10000000) 0.01 $ tableGasModel defaultGasConfig
         noPact44EC = mkExecutionConfig [FlagDisablePact44]
 
 -- MockDb

--- a/src-ghc/Pact/GasModel/Types.hs
+++ b/src-ghc/Pact/GasModel/Types.hs
@@ -240,7 +240,7 @@ defEvalEnv db = do
   setupEvalEnv db entity Transactional (initMsgData pactInitialHash) (versionedNativesRefStore noPact44EC)
     prodGasModel permissiveNamespacePolicy noSPVSupport def noPact44EC
   where entity = Just $ EntityName "entity"
-        prodGasModel = GasEnv 10000000 0.01 $ tableGasModel defaultGasConfig
+        prodGasModel = GasEnv (gasLimitToMicroGasLimit 10000000) 0.01 $ tableGasModel defaultGasConfig
         noPact44EC = mkExecutionConfig [FlagDisablePact44]
 
 -- MockDb

--- a/src-ghc/Pact/Interpreter.hs
+++ b/src-ghc/Pact/Interpreter.hs
@@ -313,7 +313,7 @@ interpret runner evalEnv terms = do
   where
     -- Round up by 1 if the `MilliGas` amount is in any way fractional.
     gasRem (MilliGas milliGas) =
-      let (d, r) = milliGas `divMod` millisPerGas
+      let (d, r) = milliGas `quotRem` millisPerGas
       in Gas (if r == 0 then d else d+1)
 
 evalTerms :: Interpreter e -> EvalInput -> Eval e EvalOutput

--- a/src-ghc/Pact/Interpreter.hs
+++ b/src-ghc/Pact/Interpreter.hs
@@ -185,7 +185,7 @@ setupEvalEnv
   -> ExecutionConfig
   -> IO (EvalEnv e)
 setupEvalEnv dbEnv ent mode msgData refStore gasEnv np spv pd ec = do
-  gasRef <- newIORef (MilliGas 0)
+  gasRef <- newIORef mempty
   warnRef <- newIORef mempty
   pure EvalEnv {
     _eeRefStore = refStore
@@ -296,7 +296,7 @@ interpret :: Interpreter e -> EvalEnv e -> EvalInput -> IO EvalResult
 interpret runner evalEnv terms = do
   ((rs,logs,txid),state) <-
     runEval def evalEnv $ evalTerms runner terms
-  microGas <- readIORef (_eeGas evalEnv)
+  milliGas <- readIORef (_eeGas evalEnv)
   warnings <- readIORef (_eeWarnings evalEnv)
   let gasLogs = _evalLogGas state
       pactExec = _evalPactExec state
@@ -305,7 +305,7 @@ interpret runner evalEnv terms = do
   return $! EvalResult
     terms
     (map (elideModRefInfo . toPactValueLenient) rs)
-    logs pactExec (milliGasToGas microGas) modules txid gasLogs (_evalEvents state) warnings
+    logs pactExec (milliGasToGas milliGas) modules txid gasLogs (_evalEvents state) warnings
 
 evalTerms :: Interpreter e -> EvalInput -> Eval e EvalOutput
 evalTerms interp input = withRollback (start (interpreter interp runInput) >>= end)

--- a/src-ghc/Pact/Interpreter.hs
+++ b/src-ghc/Pact/Interpreter.hs
@@ -185,7 +185,7 @@ setupEvalEnv
   -> ExecutionConfig
   -> IO (EvalEnv e)
 setupEvalEnv dbEnv ent mode msgData refStore gasEnv np spv pd ec = do
-  gasRef <- newIORef (MicroGas 0)
+  gasRef <- newIORef (MilliGas 0)
   warnRef <- newIORef mempty
   pure EvalEnv {
     _eeRefStore = refStore
@@ -305,7 +305,7 @@ interpret runner evalEnv terms = do
   return $! EvalResult
     terms
     (map (elideModRefInfo . toPactValueLenient) rs)
-    logs pactExec (microGasToGas microGas) modules txid gasLogs (_evalEvents state) warnings
+    logs pactExec (milliGasToGas microGas) modules txid gasLogs (_evalEvents state) warnings
 
 evalTerms :: Interpreter e -> EvalInput -> Eval e EvalOutput
 evalTerms interp input = withRollback (start (interpreter interp runInput) >>= end)

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -99,7 +99,7 @@ applyCmd logger conf dbv gasModel bh _ pbh spv exConfig exMode _ (ProcSucc cmd) 
   blocktime <-  (((*) 1000000) <$> systemSeconds <$> getSystemTime)
 
   let payload = _cmdPayload cmd
-      gasLimit = gasLimitToMicroGasLimit (_pmGasLimit pubMeta)
+      gasLimit = gasLimitToMilliGasLimit (_pmGasLimit pubMeta)
       gasEnv = GasEnv gasLimit (_pmGasPrice pubMeta) gasModel
       pd = PublicData pubMeta bh blocktime pbh
       pubMeta = _pMeta payload

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -99,7 +99,8 @@ applyCmd logger conf dbv gasModel bh _ pbh spv exConfig exMode _ (ProcSucc cmd) 
   blocktime <-  (((*) 1000000) <$> systemSeconds <$> getSystemTime)
 
   let payload = _cmdPayload cmd
-      gasEnv = GasEnv (_pmGasLimit pubMeta) (_pmGasPrice pubMeta) gasModel
+      gasLimit = gasLimitToMicroGasLimit (_pmGasLimit pubMeta)
+      gasEnv = GasEnv gasLimit (_pmGasPrice pubMeta) gasModel
       pd = PublicData pubMeta bh blocktime pbh
       pubMeta = _pMeta payload
       nid = _pNetworkId payload

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -454,13 +454,13 @@ loadModule
   -> Eval e (ModuleData Ref)
 loadModule m bod1 mi = do
   mapM_ evalUse $ _mImports m
-  mdefs <- collectNames (GModuleMember $ MDModule m) bod1 $ \t -> case t of
+  mdefs <- collectNames (GModuleMember $ MDModule m) bod1 $ \case
     TDef d _ -> return $ Just $ asString (_dDefName d)
     TConst a _ _ _ _ -> return $ Just $ _aName a
     TSchema n _ _ _ _ -> return $ Just $ asString n
     tt@TTable{} -> return $ Just $ asString (_tTableName tt)
     TUse _ _ -> return Nothing
-    _ -> evalError' t "Invalid module member"
+    t -> evalError' t "Invalid module member"
   let mangled = mangleDefs (_mName m) <$> mdefs
   (evaluatedDefs, deps) <-
     ifExecutionFlagSet FlagDisablePact43
@@ -479,12 +479,12 @@ loadInterface
   -> Eval e (ModuleData Ref)
 loadInterface i body info = do
   mapM_ evalUse $ _interfaceImports i
-  idefs <- collectNames (GModuleMember $ MDInterface i) body $ \t -> case t of
+  idefs <- collectNames (GModuleMember $ MDInterface i) body $ \case
     TDef d _ -> return $ Just $ asString (_dDefName d)
     TConst a _ _ _ _ -> return $ Just $ _aName a
     TSchema n _ _ _ _ -> return $ Just $ asString n
     TUse _ _ -> return Nothing
-    _ -> evalError' t "Invalid interface member"
+    t -> evalError' t "Invalid interface member"
   evaluatedDefs <- evaluateDefs info (MDInterface i) $
       mangleDefs (_interfaceName i) <$> idefs
   let md = ModuleData (MDInterface i) evaluatedDefs mempty

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -291,7 +291,7 @@ eval' ::  Term Name ->  Eval e (Term Name)
 eval' (TUse u@Use{..} i) = topLevelCall i "use" (GUse _uModuleName _uModuleHash) $
   evalUse u >> return (tStr $ renderCompactText' $ "Using " <> pretty _uModuleName)
 eval' (TModule _tm@(MDModule m) bod i) =
-  topLevelCall i "module" (GModuleDecl (_mName m) (_mCode m)) $do
+  topLevelCall i "module" (GModuleDecl (_mName m) (_mCode m)) $ do
     endAdvice <- eAdvise i (AdviceModule _tm)
     checkAllowModule i
     mNs <- use $ evalRefs . rsNamespace

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -217,9 +217,9 @@ apply :: App (Term Ref) -> [Term Name] -> Eval e (Term Name)
 apply app as = reduceApp $ over appArgs (++ map liftTerm as) app
 
 topLevelCall
-  :: Info -> Text -> GasArgs -> (Gas -> Eval e (Gas, a)) -> Eval e a
+  :: Info -> Text -> GasArgs -> Eval e a -> Eval e a
 topLevelCall i name gasArgs action = call (StackFrame name i Nothing) $
-  computeGas (Left (i,name)) gasArgs >>= action
+  computeGas (Left (i,name)) gasArgs *> action
 
 -- | Acquire module admin with enforce.
 acquireModuleAdmin :: Info -> ModuleName -> Governance (Def Ref) -> Eval e CapEvalResult
@@ -234,8 +234,8 @@ enforceModuleAdmin i modGov =
       Right d@Def{..} -> case _dDefType of
         Defcap -> do
           af <- prepareUserAppArgs d [] _dInfo
-          g <- computeUserAppGas d _dInfo
-          void $ evalUserAppBody d af _dInfo g reduceBody
+          computeUserAppGas d _dInfo
+          void $ evalUserAppBody d af _dInfo reduceBody
         _ -> evalError i "enforceModuleAdmin: module governance must be defcap"
 
 
@@ -288,10 +288,10 @@ eval t =
 
 -- | Evaluate top-level term.
 eval' ::  Term Name ->  Eval e (Term Name)
-eval' (TUse u@Use{..} i) = topLevelCall i "use" (GUse _uModuleName _uModuleHash) $ \g ->
-  evalUse u >> return (g,tStr $ renderCompactText' $ "Using " <> pretty _uModuleName)
+eval' (TUse u@Use{..} i) = topLevelCall i "use" (GUse _uModuleName _uModuleHash) $
+  evalUse u >> return (tStr $ renderCompactText' $ "Using " <> pretty _uModuleName)
 eval' (TModule _tm@(MDModule m) bod i) =
-  topLevelCall i "module" (GModuleDecl (_mName m) (_mCode m)) $ \g0 -> do
+  topLevelCall i "module" (GModuleDecl (_mName m) (_mCode m)) $do
     endAdvice <- eAdvise i (AdviceModule _tm)
     checkAllowModule i
     mNs <- use $ evalRefs . rsNamespace
@@ -321,16 +321,16 @@ eval' (TModule _tm@(MDModule m) bod i) =
           ifExecutionFlagSet' FlagPreserveNsModuleInstallBug (_mName m) (_mName mangledM)
         void $ acquireModuleAdminCapability capMName $ return ()
     -- build/install module from defs
-    (g,govM) <- loadModule mangledM bod i g0
+    govM <- loadModule mangledM bod i
     szVer <- getSizeOfVersion
     _ <- computeGas (Left (i,"module")) (GPreWrite (WriteModule (_mName m) (_mCode m)) szVer)
     writeRow i Write Modules (_mName mangledM) =<< traverse (traverse toPersistDirect') govM
     endAdvice govM
-    return (g, msg $ "Loaded module " <> pretty (_mName mangledM) <> ", hash " <> pretty (_mHash mangledM))
+    return (msg $ "Loaded module " <> pretty (_mName mangledM) <> ", hash " <> pretty (_mHash mangledM))
 
 
 eval' (TModule _tm@(MDInterface m) bod i) =
-  topLevelCall i "interface" (GInterfaceDecl (_interfaceName m) (_interfaceCode m)) $ \gas -> do
+  topLevelCall i "interface" (GInterfaceDecl (_interfaceName m) (_interfaceCode m)) $ do
     endAdvice <- eAdvise i (AdviceModule _tm)
     checkAllowModule i
     mNs <- use $ evalRefs . rsNamespace
@@ -340,12 +340,12 @@ eval' (TModule _tm@(MDInterface m) bod i) =
     -- enforce no upgrades
     void $ lookupModule i (_interfaceName mangledI) >>= traverse
       (const $ evalError i $ "Existing interface found (interfaces cannot be upgraded)")
-    (g,govI) <- loadInterface mangledI bod i gas
+    govI <- loadInterface mangledI bod i
     szVer <- getSizeOfVersion
-    _ <- computeGas (Left (i, "interface")) (GPreWrite (WriteInterface (_interfaceName m) (_interfaceCode m)) szVer)
+    computeGas (Left (i, "interface")) (GPreWrite (WriteInterface (_interfaceName m) (_interfaceCode m)) szVer)
     writeRow i Write Modules (_interfaceName mangledI) =<< traverse (traverse toPersistDirect') govI
     endAdvice govI
-    return (g, msg $ "Loaded interface " <> pretty (_interfaceName mangledI))
+    return (msg $ "Loaded interface " <> pretty (_interfaceName mangledI))
 eval' t = enscope t >>= reduceEnscoped
 
 reduceEnscoped :: Term Ref -> Eval e (Term Name)
@@ -451,11 +451,10 @@ loadModule
   :: Module (Term Name)
   -> Scope n Term Name
   -> Info
-  -> Gas
-  -> Eval e (Gas,ModuleData Ref)
-loadModule m bod1 mi g0 = do
+  -> Eval e (ModuleData Ref)
+loadModule m bod1 mi = do
   mapM_ evalUse $ _mImports m
-  (g1,mdefs) <- collectNames g0 (GModuleMember $ MDModule m) bod1 $ \t -> case t of
+  mdefs <- collectNames (GModuleMember $ MDModule m) bod1 $ \t -> case t of
     TDef d _ -> return $ Just $ asString (_dDefName d)
     TConst a _ _ _ _ -> return $ Just $ _aName a
     TSchema n _ _ _ _ -> return $ Just $ asString n
@@ -471,17 +470,16 @@ loadModule m bod1 mi g0 = do
   mGov <- resolveGovernance solvedDefs m'
   let md = ModuleData mGov solvedDefs deps
   installModule True md Nothing
-  return (g1,md)
+  return md
 
 loadInterface
   :: Interface
   -> Scope n Term Name
   -> Info
-  -> Gas
-  -> Eval e (Gas,ModuleData Ref)
-loadInterface i body info gas0 = do
+  -> Eval e (ModuleData Ref)
+loadInterface i body info = do
   mapM_ evalUse $ _interfaceImports i
-  (gas1,idefs) <- collectNames gas0 (GModuleMember $ MDInterface i) body $ \t -> case t of
+  idefs <- collectNames (GModuleMember $ MDInterface i) body $ \t -> case t of
     TDef d _ -> return $ Just $ asString (_dDefName d)
     TConst a _ _ _ _ -> return $ Just $ _aName a
     TSchema n _ _ _ _ -> return $ Just $ asString n
@@ -491,29 +489,27 @@ loadInterface i body info gas0 = do
       mangleDefs (_interfaceName i) <$> idefs
   let md = ModuleData (MDInterface i) evaluatedDefs mempty
   installModule True md Nothing
-  return (gas1,md)
+  return md
 
 -- | Retrieve map of definition names to their corresponding terms
 -- and compute their gas value
 --
 collectNames
-  :: Gas
-    -- ^ initial gas value
-  -> GasArgs
+  :: GasArgs
     -- ^ gas args (should be GModuleMember)
   -> Scope n Term Name
     -- ^ module body
   -> (Term Name -> Eval e (Maybe Text))
     -- ^ function extracting definition names
-  -> Eval e (Gas, HM.HashMap Text (Term Name))
-collectNames g0 args body k = case instantiate' body of
+  -> Eval e (HM.HashMap Text (Term Name))
+collectNames args body k = case instantiate' body of
     TList bd _ _ -> do
       ns <- view $ eeRefStore . rsNatives
-      foldM (go ns) (g0, mempty) bd
+      foldM (go ns) mempty bd
     t -> evalError' t $ "malformed declaration"
   where
-    go ns (g,ds) t = k t >>= \dnm -> case dnm of
-      Nothing -> return (g, ds)
+    go ns ds t = k t >>= \dnm -> case dnm of
+      Nothing -> return ds
       Just dn -> do
         -- disallow native overlap
         when (isJust $ HM.lookup dn ns) $
@@ -522,8 +518,8 @@ collectNames g0 args body k = case instantiate' body of
         when (isJust $ HM.lookup dn ds) $
           evalError' t $ "definition name conflict: " <> pretty dn
 
-        g' <- computeGas (Left (_tInfo t,dn)) args
-        return (g + g',HM.insert dn t ds)
+        computeGas (Left (_tInfo t,dn)) args
+        return (HM.insert dn t ds)
 
 
 resolveGovernance
@@ -1112,7 +1108,7 @@ resolveArg ai as i = case as ^? ix i of
   Nothing -> appError ai $ "Missing argument value at index " <> pretty i
   Just i' -> i'
 
-appCall :: Pretty t => FunApp -> Info -> [Term t] -> Eval e (Gas,a) -> Eval e a
+appCall :: Pretty t => FunApp -> Info -> [Term t] -> Eval e a -> Eval e a
 appCall fa ai as = call (StackFrame (_faName fa) ai (Just (fa,map abbrev as)))
 
 enforcePactValue :: Pretty n => (Term n) -> Eval e PactValue
@@ -1134,9 +1130,9 @@ reduceApp (App (TDef d@Def{..} _) as ai) = do
       c r
       pure r
     Defpact -> do
-      g <- computeUserAppGas d ai
+      computeUserAppGas d ai
       af <- prepareUserAppArgs d as ai
-      evalUserAppBody d af ai g $ \bod' -> do
+      evalUserAppBody d af ai $ \bod' -> do
         continuation <-
           PactContinuation (QName (QualifiedName _dModule (asString _dDefName) def))
           . map elideModRefInfo
@@ -1147,7 +1143,7 @@ reduceApp (App (TLam (Lam lamName funTy body _) _) as ai) =
   functionApp (DefName lamName) funTy Nothing as body Nothing ai
 reduceApp (App (TLitString errMsg) _ i) = evalError i $ pretty errMsg
 reduceApp (App (TDynamic tref tmem ti) as ai) =
-  reduceDynamic tref tmem ti >>= \rd -> case rd of
+  reduceDynamic tref tmem ti >>= \case
     Left v -> evalError ti $ "reduceApp: expected module member for dynamic: " <> pretty v
     Right d -> reduceApp $ App (TDef d (getInfo d)) as ai
 reduceApp (App r _ ai) = evalError' ai $ "Expected def: " <> pretty r
@@ -1164,7 +1160,7 @@ functionApp
   -> Info
   -> Eval e (Term Name)
 functionApp fnName funTy mod_ as fnBody docs ai = do
-  gas <- computeGas (Left (ai, asString fnName)) (GUserApp Defun)
+  computeGas (Left (ai, asString fnName)) (GUserApp Defun)
   args <- traverse reduce as
   fty <- traverse reduce funTy
   typecheckArgs ai fnName fty args
@@ -1173,7 +1169,7 @@ functionApp fnName funTy mod_ as fnBody docs ai = do
       fname = asString fnName
       fa = FunApp ai fname mod_ Defun (funTypes fty) docs
 
-  returnVal <- guardRecursion fname mod_ $ appCall fa ai args' $ fmap (gas,) $ reduceBody body
+  returnVal <- guardRecursion fname mod_ $ appCall fa ai args' $ reduceBody body
 
   unlessExecutionFlagSet FlagDisableRuntimeReturnTypeChecking $
     typecheckTerm ai (_ftReturn fty) returnVal
@@ -1212,7 +1208,7 @@ reduceDynamic tref tmem i = do
 
 
 -- | precompute "UserApp" cost
-computeUserAppGas :: Def Ref -> Info -> Eval e Gas
+computeUserAppGas :: Def Ref -> Info -> Eval e ()
 computeUserAppGas Def{..} ai = computeGas (Left (ai, asString _dDefName)) (GUserApp _dDefType)
 
 -- | prepare reduced args and funtype, and typecheck
@@ -1234,11 +1230,11 @@ guardRecursion fname m act  =
     sfn == fname && (_faModule . fst =<< app) == m
 
 -- | Instantiate args in body and evaluate using supplied action.
-evalUserAppBody :: Def Ref -> ([Term Name], FunType (Term Name)) -> Info -> Gas
+evalUserAppBody :: Def Ref -> ([Term Name], FunType (Term Name)) -> Info
                 -> (Term Ref -> Eval e (Term Name)) -> Eval e (Term Name)
-evalUserAppBody _d@Def{..} (as',ft') ai g run = guardRecursion fname (Just _dModule) $ do
+evalUserAppBody _d@Def{..} (as',ft') ai run = guardRecursion fname (Just _dModule) $ do
   c <- eAdvise ai (AdviceUser _d)
-  !r <- appCall fa ai as' $ fmap (g,) $ run bod'
+  !r <- appCall fa ai as' $ run bod'
   c r
   pure r
   where
@@ -1544,7 +1540,7 @@ resumeNestedPactExec i def' req ctx = do
 
   let args = map (liftTerm . fromPactValue) (_pcArgs (_npeContinuation ctx))
 
-  g <- computeUserAppGas def' i
+  computeUserAppGas def' i
   af <- prepareUserAppArgs def' args i
 
   -- if resume is in step, use that, otherwise get from exec state
@@ -1554,7 +1550,7 @@ resumeNestedPactExec i def' req ctx = do
 
   -- run local environment with yield from pact exec
   local (set eePactStep (Just $ set psResume resume req)) $
-    evalUserAppBody def' af i g $ \bod ->
+    evalUserAppBody def' af i $ \bod ->
       applyNestedPact i (_npeContinuation ctx) bod req
 
 
@@ -1588,7 +1584,7 @@ resumePactExec i req ctx = do
 
   let args = map (liftTerm . fromPactValue) (_pcArgs (_peContinuation ctx))
 
-  g <- computeUserAppGas def' i
+  computeUserAppGas def' i
   af <- prepareUserAppArgs def' args i
 
   -- if resume is in step, use that, otherwise get from exec state
@@ -1598,7 +1594,7 @@ resumePactExec i req ctx = do
 
   -- run local environment with yield from pact exec
   local (set eePactStep (Just $ set psResume resume req)) $
-    evalUserAppBody def' af i g $ \bod ->
+    evalUserAppBody def' af i $ \bod ->
       applyPact i (_peContinuation ctx) bod req (_peNested ctx)
 
 

--- a/src/Pact/Gas.hs
+++ b/src/Pact/Gas.hs
@@ -83,8 +83,9 @@ computeGasCommit info name args = do
       gUsed = milliGasToGas gMillisUsed
   evalLogGas %= fmap ((renderCompactText' (pretty name <> ":" <> pretty args <> ":currTotalGas=" <> pretty gUsed),milliGasToGas g1):)
   putGas gMillisUsed
-  let (MilliGasLimit gasLimit) = _geGasLimit
-  when (gMillisUsed > gasLimit) $
+  let (MilliGasLimit milliGasLimit) = _geGasLimit
+  when (gMillisUsed > milliGasLimit) $ do
+    let gasLimit = milliGasToGas milliGasLimit
     throwErr GasError info $ "Gas limit (" <> pretty gasLimit <> ") exceeded: " <> pretty gUsed
     -- else return gUsed
 

--- a/src/Pact/Gas.hs
+++ b/src/Pact/Gas.hs
@@ -106,4 +106,4 @@ constGasModel :: Word64 -> GasModel
 constGasModel r = GasModel
   { gasModelName = "fixed " <> tShow r
   , gasModelDesc = "constant rate gas model with fixed rate " <> tShow r
-  , runGasModel = \_ _ -> MilliGas (fromIntegral r) }
+  , runGasModel = \_ _ -> gasToMilliGas (fromIntegral r) }

--- a/src/Pact/Gas.hs
+++ b/src/Pact/Gas.hs
@@ -17,6 +17,7 @@ module Pact.Gas
 
 import Data.Text
 import Data.IORef
+import Pact.Types.Gas
 import Pact.Types.Runtime
 import Control.Lens
 import Control.Arrow
@@ -24,18 +25,20 @@ import Data.Word
 import Pact.Types.Pretty
 
 -- | Compute gas for some application or evaluation.
-computeGas :: Either (Info,Text) FunApp -> GasArgs -> Eval e Gas
+computeGas :: Either (Info,Text) FunApp -> GasArgs -> Eval e MicroGas
 computeGas i args = do
   GasEnv {..} <- view eeGasEnv
   g0 <- getGas
   let
     (info,name) = either id (_faInfo &&& _faName) i
     g1 = runGasModel _geGasModel name args
-  let gUsed = g0 + g1
-  evalLogGas %= fmap ((renderCompactText' (pretty name <> ":" <> pretty args <> ":currTotalGas=" <> pretty gUsed),g1):)
+  let gUsed = g0 <> g1
+      gUsed' = microGasToGas gUsed
+  evalLogGas %= fmap ((renderCompactText' (pretty name <> ":" <> pretty args <> ":currTotalGas=" <> pretty gUsed'),microGasToGas g1):)
   putGas gUsed
-  if gUsed > fromIntegral _geGasLimit then
-    throwErr GasError info $ "Gas limit (" <> pretty _geGasLimit <> ") exceeded: " <> pretty gUsed
+  let (MicroGasLimit gasLimit) = _geGasLimit
+  if gUsed > gasLimit then
+    throwErr GasError info $ "Gas limit (" <> pretty gasLimit <> ") exceeded: " <> pretty gUsed
     else return gUsed
 {-# INLINABLE computeGas #-}
 
@@ -43,57 +46,60 @@ computeGas i args = do
 --   - Checks the gas calculations against the gas limit
 --   - Does not emit gas logs
 --   - Commit gas calc depending on `commit`
-computeGasNoLog :: (Gas -> Eval e ()) -> Info -> Text -> GasArgs -> Eval e Gas
+computeGasNoLog :: (MicroGas -> Eval e ()) -> Info -> Text -> GasArgs -> Eval e MicroGas
 computeGasNoLog commit info name args = do
   GasEnv {..} <- view eeGasEnv
   g0 <- getGas
-  let !gUsed = g0 + runGasModel _geGasModel name args
+  let !gUsed = g0 <> runGasModel _geGasModel name args
   commit gUsed
-  if gUsed > fromIntegral _geGasLimit then
-    throwErr GasError info $ "Gas limit (" <> pretty _geGasLimit <> ") exceeded: " <> pretty gUsed
+  let (MicroGasLimit gl) = _geGasLimit
+  if gUsed > gl then
+    throwErr GasError info $ "Gas limit (" <> pretty gl <> ") exceeded: " <> pretty gUsed
     else return gUsed
 
-putGas :: Gas -> Eval e ()
+putGas :: MicroGas -> Eval e ()
 putGas !g = do
   gasRef <- view eeGas
   liftIO (writeIORef gasRef g)
 
-getGas :: Eval e Gas
+getGas :: Eval e MicroGas
 getGas = view eeGas >>= liftIO . readIORef
 
 -- | See: ComputeGasNoLog, does not commit gas calculation.
-computeGasNonCommit :: Info -> Text -> GasArgs -> Eval e Gas
+computeGasNonCommit :: Info -> Text -> GasArgs -> Eval e MicroGas
 computeGasNonCommit = computeGasNoLog (const (pure ()))
 
 -- | See: ComputeGasNoLog, save currently used `evalGas`
-computeGasCommit :: Info -> Text -> GasArgs -> Eval e Gas
+computeGasCommit :: Info -> Text -> GasArgs -> Eval e MicroGas
 computeGasCommit info name args = do
   GasEnv {..} <- view eeGasEnv
   g0 <- getGas
   let !g1 = runGasModel _geGasModel name args
-      !gUsed = g0 + g1
-  evalLogGas %= fmap ((renderCompactText' (pretty name <> ":" <> pretty args <> ":currTotalGas=" <> pretty gUsed),g1):)
+      !gUsed = g0 <> g1
+      gUsed' = microGasToGas gUsed
+  evalLogGas %= fmap ((renderCompactText' (pretty name <> ":" <> pretty args <> ":currTotalGas=" <> pretty gUsed'),microGasToGas g1):)
   putGas gUsed
-  if gUsed > fromIntegral _geGasLimit then
-    throwErr GasError info $ "Gas limit (" <> pretty _geGasLimit <> ") exceeded: " <> pretty gUsed
+  let (MicroGasLimit gl) = _geGasLimit
+  if gUsed > gl then
+    throwErr GasError info $ "Gas limit (" <> pretty gl <> ") exceeded: " <> pretty gUsed
     else return gUsed
 
 
 -- | Pre-compute gas for some application before some action.
-computeGas' :: Gas -> FunApp -> GasArgs -> Eval e a -> Eval e (Gas,a)
-computeGas' g0 i gs action = computeGas (Right i) gs >>= \g -> (g0 + g,) <$> action
+computeGas' :: Gas -> FunApp -> GasArgs -> Eval e a -> Eval e (MicroGas,a)
+computeGas' g0 i gs action = computeGas (Right i) gs >>= \g -> (gasToMicroGas g0 <> g,) <$> action
 
 -- | Pre-compute gas for some application with unreduced args before some action.
-gasUnreduced :: FunApp -> [Term Ref] -> Eval e a -> Eval e (Gas,a)
+gasUnreduced :: FunApp -> [Term Ref] -> Eval e a -> Eval e (MicroGas,a)
 gasUnreduced i as = computeGas' 0 i (GUnreduced as)
 
 -- | GasEnv for suppressing gas charging.
 freeGasEnv :: GasEnv
-freeGasEnv = GasEnv 0 0.0 (constGasModel 0)
+freeGasEnv = GasEnv (MicroGasLimit mempty) 0.0 (constGasModel 0)
 
 -- | Gas model that charges a fixed (positive) rate per tracked operation.
 constGasModel :: Word64 -> GasModel
 constGasModel r = GasModel
   { gasModelName = "fixed " <> tShow r
   , gasModelDesc = "constant rate gas model with fixed rate " <> tShow r
-  , runGasModel = \_ _ -> fromIntegral r }
+  , runGasModel = \_ _ -> MicroGas (fromIntegral r) }

--- a/src/Pact/Gas.hs
+++ b/src/Pact/Gas.hs
@@ -15,6 +15,7 @@ module Pact.Gas
  , putGas)
  where
 
+import Control.Monad(when)
 import Control.Monad.State.Strict
 import Data.Text
 import Data.IORef
@@ -35,17 +36,22 @@ computeGas i args = do
     g1 = runGasModel _geGasModel name args
   let gMillisUsed = g0 <> g1
       gUsed = milliGasToGas gMillisUsed
-  evalLogGas %= fmap ((msg name gUsed, milliGasToGas g1):)
-  -- evalLogGas %= fmap ((renderCompactText' (pretty name <> ":" <> pretty args <> ":currTotalGas=" <> pretty gUsed),milliGasToGas g1):)
+  evalLogGas %= fmap ((gasLogMsg name args gUsed, milliGasToGas g1):)
   putGas gMillisUsed
   let (MilliGasLimit gasLimit) = _geGasLimit
   when (gMillisUsed > gasLimit) $ do
     let oldGasLimit = milliGasToGas gasLimit
     throwErr GasError info $ "Gas limit (" <> pretty oldGasLimit <> ") exceeded: " <> pretty gUsed
-  where
-    msg name used = renderCompactText' (pretty name <> ":" <> pretty args <> ":currTotalGas=" <> pretty used)
     -- else return gUsed
 {-# INLINABLE computeGas #-}
+
+gasLogMsg
+  :: Text
+  -> GasArgs
+  -> Gas
+  -> Text
+gasLogMsg name args used =
+  renderCompactText' (pretty name <> ":" <> pretty args <> ":currTotalGas=" <> pretty used)
 
 -- | Performs gas calculation for incremental computations with some caveats:
 --   - Checks the gas calculations against the gas limit
@@ -84,7 +90,7 @@ computeGasCommit info name args = do
   let !g1 = runGasModel _geGasModel name args
       !gMillisUsed = g0 <> g1
       gUsed = milliGasToGas gMillisUsed
-  evalLogGas %= fmap ((renderCompactText' (pretty name <> ":" <> pretty args <> ":currTotalGas=" <> pretty gUsed),milliGasToGas g1):)
+  evalLogGas %= fmap ((gasLogMsg name args gUsed,milliGasToGas g1):)
   putGas gMillisUsed
   let (MilliGasLimit milliGasLimit) = _geGasLimit
   when (gMillisUsed > milliGasLimit) $ do

--- a/src/Pact/Gas.hs
+++ b/src/Pact/Gas.hs
@@ -86,12 +86,12 @@ computeGasCommit info name args = do
 
 
 -- | Pre-compute gas for some application before some action.
-computeGas' :: Gas -> FunApp -> GasArgs -> Eval e a -> Eval e (MicroGas,a)
-computeGas' g0 i gs action = computeGas (Right i) gs >>= \g -> (gasToMicroGas g0 <> g,) <$> action
+computeGas' :: FunApp -> GasArgs -> Eval e a -> Eval e a
+computeGas' i gs action = computeGas (Right i) gs *> action
 
 -- | Pre-compute gas for some application with unreduced args before some action.
-gasUnreduced :: FunApp -> [Term Ref] -> Eval e a -> Eval e (MicroGas,a)
-gasUnreduced i as = computeGas' 0 i (GUnreduced as)
+gasUnreduced :: FunApp -> [Term Ref] -> Eval e a -> Eval e a
+gasUnreduced i as = computeGas' i (GUnreduced as)
 
 -- | GasEnv for suppressing gas charging.
 freeGasEnv :: GasEnv

--- a/src/Pact/Gas/Table.hs
+++ b/src/Pact/Gas/Table.hs
@@ -229,36 +229,37 @@ tableGasModel :: GasCostConfig -> GasModel
 tableGasModel gasConfig =
   let run name ga = case ga of
         GUnreduced _ts -> case Map.lookup name (_gasCostConfig_primTable gasConfig) of
-          Just g -> g
+          Just g -> gasToMicroGas g
           Nothing -> error $ "Unknown primitive \"" <> T.unpack name <> "\" in determining cost of GUnreduced"
         GUserApp t -> case t of
-          Defpact -> (_gasCostConfig_defPactCost gasConfig) * _gasCostConfig_functionApplicationCost gasConfig
-          _ -> _gasCostConfig_functionApplicationCost gasConfig
+          Defpact -> gasToMicroGas $ (_gasCostConfig_defPactCost gasConfig) * _gasCostConfig_functionApplicationCost gasConfig
+          _ -> gasToMicroGas $ _gasCostConfig_functionApplicationCost gasConfig
         GIntegerOpCost i j ->
-          intCost (fst i) + intCost (fst j)
-        GDecimalOpCost _ _ -> 0
-        GMakeList v -> expLengthPenalty v
-        GSort len -> expLengthPenalty len
-        GDistinct len -> expLengthPenalty len
-        GSelect mColumns -> case mColumns of
+          gasToMicroGas $ intCost (fst i) + intCost (fst j)
+        GDecimalOpCost _ _ -> MicroGas 0
+        GMakeList v -> gasToMicroGas $ expLengthPenalty v
+        GSort len -> gasToMicroGas $ expLengthPenalty len
+        GDistinct len -> gasToMicroGas $ expLengthPenalty len
+        GSelect mColumns -> gasToMicroGas $ case mColumns of
           Nothing -> 1
           Just [] -> 1
-          Just cs -> _gasCostConfig_selectColumnCost gasConfig * (fromIntegral (length cs))
+          Just cs -> _gasCostConfig_selectColumnCost gasConfig * fromIntegral (length cs)
         GSortFieldLookup n ->
-          fromIntegral n * _gasCostConfig_sortFactor gasConfig
+          gasToMicroGas $ fromIntegral n * _gasCostConfig_sortFactor gasConfig
         GConcatenation i j ->
-          fromIntegral (i + j) * _gasCostConfig_concatenationFactor gasConfig
-        GFoldDB -> _gasCostConfig_foldDBCost gasConfig
-        GPostRead r -> case r of
+          gasToMicroGas $ fromIntegral (i + j) * _gasCostConfig_concatenationFactor gasConfig
+        GFoldDB ->
+          gasToMicroGas $ _gasCostConfig_foldDBCost gasConfig
+        GPostRead r -> gasToMicroGas $ case r of
           ReadData cols -> _gasCostConfig_readColumnCost gasConfig * fromIntegral (Map.size (_objectMap $ _rdData cols))
           ReadKey _rowKey -> _gasCostConfig_readColumnCost gasConfig
           ReadTxId -> _gasCostConfig_readColumnCost gasConfig
-          ReadModule _moduleName _mCode ->  _gasCostConfig_readColumnCost gasConfig
-          ReadInterface _moduleName _mCode ->  _gasCostConfig_readColumnCost gasConfig
-          ReadNamespace _ns ->  _gasCostConfig_readColumnCost gasConfig
-          ReadKeySet _ksName _ks ->  _gasCostConfig_readColumnCost gasConfig
+          ReadModule _moduleName _mCode -> _gasCostConfig_readColumnCost gasConfig
+          ReadInterface _moduleName _mCode -> _gasCostConfig_readColumnCost gasConfig
+          ReadNamespace _ns -> _gasCostConfig_readColumnCost gasConfig
+          ReadKeySet _ksName _ks -> _gasCostConfig_readColumnCost gasConfig
           ReadYield (Yield _obj _ _) -> _gasCostConfig_readColumnCost gasConfig * fromIntegral (Map.size (_objectMap _obj))
-        GPreWrite w szVer -> case w of
+        GPreWrite w szVer -> gasToMicroGas $ case w of
           WriteData _type key obj ->
             (memoryCost szVer key (_gasCostConfig_writeBytesCost gasConfig))
             + (memoryCost szVer obj (_gasCostConfig_writeBytesCost gasConfig))
@@ -277,17 +278,17 @@ tableGasModel gasConfig =
             + (memoryCost szVer ks (_gasCostConfig_writeBytesCost gasConfig))
           WriteYield obj ->
             (memoryCost szVer (_yData obj) (_gasCostConfig_writeBytesCost gasConfig))
-        GModuleMember _module -> _gasCostConfig_moduleMemberCost gasConfig
-        GModuleDecl _moduleName _mCode -> (_gasCostConfig_moduleCost gasConfig)
-        GUse _moduleName _mHash -> (_gasCostConfig_useModuleCost gasConfig)
+        GModuleMember _module -> gasToMicroGas $ _gasCostConfig_moduleMemberCost gasConfig
+        GModuleDecl _moduleName _mCode -> gasToMicroGas (_gasCostConfig_moduleCost gasConfig)
+        GUse _moduleName _mHash -> gasToMicroGas (_gasCostConfig_useModuleCost gasConfig)
           -- The above seems somewhat suspect (perhaps cost should scale with the module?)
-        GInterfaceDecl _interfaceName _iCode -> (_gasCostConfig_interfaceCost gasConfig)
-        GModuleMemory i -> moduleMemoryCost i
-        GPrincipal g -> fromIntegral g * _gasCostConfig_principalCost gasConfig
+        GInterfaceDecl _interfaceName _iCode -> gasToMicroGas (_gasCostConfig_interfaceCost gasConfig)
+        GModuleMemory i -> gasToMicroGas $ moduleMemoryCost i
+        GPrincipal g -> gasToMicroGas $ fromIntegral g * _gasCostConfig_principalCost gasConfig
         GMakeList2 len msz ->
           let glen = fromIntegral len
-          in glen + maybe 0 ((* glen) . intCost) msz
-        GZKArgs arg -> case arg of
+          in gasToMicroGas $ glen + maybe 0 ((* glen) . intCost) msz
+        GZKArgs arg -> gasToMicroGas $ case arg of
           PointAdd g -> pointAddGas g
           ScalarMult g -> scalarMulGas g
           Pairing np -> pairingGas np
@@ -376,8 +377,8 @@ pact421GasModel = gasModel { runGasModel = modifiedRunFunction }
   gasModel = tableGasModel gasConfig
   gasConfig = defaultGasConfig { _gasCostConfig_primTable = updTable }
   updTable = Map.union upd defaultGasTable
-  unknownOperationPenalty = 1000000
-  multiRowOperation = 40000
+  unknownOperationPenalty = gasToMicroGas (Gas 1000000)
+  multiRowOperation = Gas 40000
   upd = Map.fromList
     [("keys",    multiRowOperation)
     ,("select",  multiRowOperation)
@@ -385,6 +386,6 @@ pact421GasModel = gasModel { runGasModel = modifiedRunFunction }
     ]
   modifiedRunFunction name ga = case ga of
     GUnreduced _ts -> case Map.lookup name updTable of
-      Just g -> g
+      Just g -> gasToMicroGas g
       Nothing -> unknownOperationPenalty
     _ -> runGasModel defaultGasModel name ga

--- a/src/Pact/Gas/Table.hs
+++ b/src/Pact/Gas/Table.hs
@@ -229,28 +229,28 @@ tableGasModel :: GasCostConfig -> GasModel
 tableGasModel gasConfig =
   let run name ga = case ga of
         GUnreduced _ts -> case Map.lookup name (_gasCostConfig_primTable gasConfig) of
-          Just g -> gasToMicroGas g
+          Just g -> gasToMilliGas g
           Nothing -> error $ "Unknown primitive \"" <> T.unpack name <> "\" in determining cost of GUnreduced"
         GUserApp t -> case t of
-          Defpact -> gasToMicroGas $ (_gasCostConfig_defPactCost gasConfig) * _gasCostConfig_functionApplicationCost gasConfig
-          _ -> gasToMicroGas $ _gasCostConfig_functionApplicationCost gasConfig
+          Defpact -> gasToMilliGas $ (_gasCostConfig_defPactCost gasConfig) * _gasCostConfig_functionApplicationCost gasConfig
+          _ -> gasToMilliGas $ _gasCostConfig_functionApplicationCost gasConfig
         GIntegerOpCost i j ->
-          gasToMicroGas $ intCost (fst i) + intCost (fst j)
-        GDecimalOpCost _ _ -> MicroGas 0
-        GMakeList v -> gasToMicroGas $ expLengthPenalty v
-        GSort len -> gasToMicroGas $ expLengthPenalty len
-        GDistinct len -> gasToMicroGas $ expLengthPenalty len
-        GSelect mColumns -> gasToMicroGas $ case mColumns of
+          gasToMilliGas $ intCost (fst i) + intCost (fst j)
+        GDecimalOpCost _ _ -> MilliGas 0
+        GMakeList v -> gasToMilliGas $ expLengthPenalty v
+        GSort len -> gasToMilliGas $ expLengthPenalty len
+        GDistinct len -> gasToMilliGas $ expLengthPenalty len
+        GSelect mColumns -> gasToMilliGas $ case mColumns of
           Nothing -> 1
           Just [] -> 1
           Just cs -> _gasCostConfig_selectColumnCost gasConfig * fromIntegral (length cs)
         GSortFieldLookup n ->
-          gasToMicroGas $ fromIntegral n * _gasCostConfig_sortFactor gasConfig
+          gasToMilliGas $ fromIntegral n * _gasCostConfig_sortFactor gasConfig
         GConcatenation i j ->
-          gasToMicroGas $ fromIntegral (i + j) * _gasCostConfig_concatenationFactor gasConfig
+          gasToMilliGas $ fromIntegral (i + j) * _gasCostConfig_concatenationFactor gasConfig
         GFoldDB ->
-          gasToMicroGas $ _gasCostConfig_foldDBCost gasConfig
-        GPostRead r -> gasToMicroGas $ case r of
+          gasToMilliGas $ _gasCostConfig_foldDBCost gasConfig
+        GPostRead r -> gasToMilliGas $ case r of
           ReadData cols -> _gasCostConfig_readColumnCost gasConfig * fromIntegral (Map.size (_objectMap $ _rdData cols))
           ReadKey _rowKey -> _gasCostConfig_readColumnCost gasConfig
           ReadTxId -> _gasCostConfig_readColumnCost gasConfig
@@ -259,7 +259,7 @@ tableGasModel gasConfig =
           ReadNamespace _ns -> _gasCostConfig_readColumnCost gasConfig
           ReadKeySet _ksName _ks -> _gasCostConfig_readColumnCost gasConfig
           ReadYield (Yield _obj _ _) -> _gasCostConfig_readColumnCost gasConfig * fromIntegral (Map.size (_objectMap _obj))
-        GPreWrite w szVer -> gasToMicroGas $ case w of
+        GPreWrite w szVer -> gasToMilliGas $ case w of
           WriteData _type key obj ->
             (memoryCost szVer key (_gasCostConfig_writeBytesCost gasConfig))
             + (memoryCost szVer obj (_gasCostConfig_writeBytesCost gasConfig))
@@ -278,17 +278,17 @@ tableGasModel gasConfig =
             + (memoryCost szVer ks (_gasCostConfig_writeBytesCost gasConfig))
           WriteYield obj ->
             (memoryCost szVer (_yData obj) (_gasCostConfig_writeBytesCost gasConfig))
-        GModuleMember _module -> gasToMicroGas $ _gasCostConfig_moduleMemberCost gasConfig
-        GModuleDecl _moduleName _mCode -> gasToMicroGas (_gasCostConfig_moduleCost gasConfig)
-        GUse _moduleName _mHash -> gasToMicroGas (_gasCostConfig_useModuleCost gasConfig)
+        GModuleMember _module -> gasToMilliGas $ _gasCostConfig_moduleMemberCost gasConfig
+        GModuleDecl _moduleName _mCode -> gasToMilliGas (_gasCostConfig_moduleCost gasConfig)
+        GUse _moduleName _mHash -> gasToMilliGas (_gasCostConfig_useModuleCost gasConfig)
           -- The above seems somewhat suspect (perhaps cost should scale with the module?)
-        GInterfaceDecl _interfaceName _iCode -> gasToMicroGas (_gasCostConfig_interfaceCost gasConfig)
-        GModuleMemory i -> gasToMicroGas $ moduleMemoryCost i
-        GPrincipal g -> gasToMicroGas $ fromIntegral g * _gasCostConfig_principalCost gasConfig
+        GInterfaceDecl _interfaceName _iCode -> gasToMilliGas (_gasCostConfig_interfaceCost gasConfig)
+        GModuleMemory i -> gasToMilliGas $ moduleMemoryCost i
+        GPrincipal g -> gasToMilliGas $ fromIntegral g * _gasCostConfig_principalCost gasConfig
         GMakeList2 len msz ->
           let glen = fromIntegral len
-          in gasToMicroGas $ glen + maybe 0 ((* glen) . intCost) msz
-        GZKArgs arg -> gasToMicroGas $ case arg of
+          in gasToMilliGas $ glen + maybe 0 ((* glen) . intCost) msz
+        GZKArgs arg -> gasToMilliGas $ case arg of
           PointAdd g -> pointAddGas g
           ScalarMult g -> scalarMulGas g
           Pairing np -> pairingGas np
@@ -377,7 +377,7 @@ pact421GasModel = gasModel { runGasModel = modifiedRunFunction }
   gasModel = tableGasModel gasConfig
   gasConfig = defaultGasConfig { _gasCostConfig_primTable = updTable }
   updTable = Map.union upd defaultGasTable
-  unknownOperationPenalty = gasToMicroGas (Gas 1000000)
+  unknownOperationPenalty = gasToMilliGas (Gas 1000000)
   multiRowOperation = Gas 40000
   upd = Map.fromList
     [("keys",    multiRowOperation)
@@ -386,6 +386,6 @@ pact421GasModel = gasModel { runGasModel = modifiedRunFunction }
     ]
   modifiedRunFunction name ga = case ga of
     GUnreduced _ts -> case Map.lookup name updTable of
-      Just g -> gasToMicroGas g
+      Just g -> gasToMilliGas g
       Nothing -> unknownOperationPenalty
     _ -> runGasModel defaultGasModel name ga

--- a/src/Pact/Gas/Table.hs
+++ b/src/Pact/Gas/Table.hs
@@ -236,7 +236,7 @@ tableGasModel gasConfig =
           _ -> gasToMilliGas $ _gasCostConfig_functionApplicationCost gasConfig
         GIntegerOpCost i j ->
           gasToMilliGas $ intCost (fst i) + intCost (fst j)
-        GDecimalOpCost _ _ -> MilliGas 0
+        GDecimalOpCost _ _ -> mempty
         GMakeList v -> gasToMilliGas $ expLengthPenalty v
         GSort len -> gasToMilliGas $ expLengthPenalty len
         GDistinct len -> gasToMilliGas $ expLengthPenalty len

--- a/src/Pact/Gas/Table.hs
+++ b/src/Pact/Gas/Table.hs
@@ -232,7 +232,7 @@ tableGasModel gasConfig =
           Just g -> gasToMilliGas g
           Nothing -> error $ "Unknown primitive \"" <> T.unpack name <> "\" in determining cost of GUnreduced"
         GUserApp t -> case t of
-          Defpact -> gasToMilliGas $ (_gasCostConfig_defPactCost gasConfig) * _gasCostConfig_functionApplicationCost gasConfig
+          Defpact -> gasToMilliGas $ _gasCostConfig_defPactCost gasConfig * _gasCostConfig_functionApplicationCost gasConfig
           _ -> gasToMilliGas $ _gasCostConfig_functionApplicationCost gasConfig
         GIntegerOpCost i j ->
           gasToMilliGas $ intCost (fst i) + intCost (fst j)

--- a/src/Pact/Gas/Table.hs
+++ b/src/Pact/Gas/Table.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Pact.Gas.Table where
@@ -378,8 +379,8 @@ pact421GasModel = gasModel { runGasModel = modifiedRunFunction }
   gasModel = tableGasModel gasConfig
   gasConfig = defaultGasConfig { _gasCostConfig_primTable = updTable }
   updTable = Map.union upd defaultGasTable
-  unknownOperationPenalty = gasToMilliGas (Gas 1000000)
-  multiRowOperation = Gas 40000
+  unknownOperationPenalty = gasToMilliGas (Gas 1_000_000)
+  multiRowOperation = Gas 40_000
   upd = Map.fromList
     [("keys",    multiRowOperation)
     ,("select",  multiRowOperation)

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -460,13 +460,13 @@ describeNamespaceDef = setTopLevelOnly $ defGasRNative
     dnTy = TyUser (snd describeNamespaceSchema)
 
     describeNamespace :: GasRNativeFun e
-    describeNamespace g0 i as = case as of
+    describeNamespace i as = case as of
       [TLitString nsn] -> do
         readRow (getInfo i) Namespaces (NamespaceName nsn) >>= \case
           Just ns@(Namespace nsn' user admin) -> do
             let guardTermOf g = TGuard (fromPactValue <$> g) def
 
-            computeGas' g0 i (GPostRead (ReadNamespace ns)) $
+            computeGas' i (GPostRead (ReadNamespace ns)) $
               pure $ toTObject dnTy def
                 [ (dnUserGuard, guardTermOf user)
                 , (dnAdminGuard, guardTermOf admin)
@@ -484,13 +484,13 @@ defineNamespaceDef = setTopLevelOnly $ defGasRNative "define-namespace" defineNa
   \and GUARD will be rotated in its place."
   where
     defineNamespace :: GasRNativeFun e
-    defineNamespace g i as = case as of
+    defineNamespace i as = case as of
       [TLitString nsn, TGuard userg _, TGuard adming _] -> case parseName (_faInfo i) nsn of
         Left _ -> evalError' i $ "invalid namespace name format: " <> pretty nsn
-        Right _ -> go g i nsn userg adming
+        Right _ -> go i nsn userg adming
       _ -> argsError i as
 
-    go g0 fi nsn ug ag = do
+    go fi nsn ug ag = do
       let name = NamespaceName nsn
           info = _faInfo fi
           newNs = Namespace name ug ag
@@ -501,13 +501,13 @@ defineNamespaceDef = setTopLevelOnly $ defGasRNative "define-namespace" defineNa
         Just ns@(Namespace _ _ oldg) -> do
           -- if namespace is defined, enforce old guard
           nsPactValue <- toNamespacePactValue info ns
-          (g1,_) <- computeGas' g0 fi (GPostRead (ReadNamespace nsPactValue)) $ return ()
+          computeGas (Right fi) (GPostRead (ReadNamespace nsPactValue))
           enforceGuard fi oldg
-          computeGas' g1 fi (GPreWrite (WriteNamespace newNsPactValue) szVer) $
+          computeGas' fi (GPreWrite (WriteNamespace newNsPactValue) szVer) $
             writeNamespace info name newNsPactValue
         Nothing -> do
           enforcePolicy info name newNs
-          computeGas' g0 fi (GPreWrite (WriteNamespace newNsPactValue) szVer) $
+          computeGas' fi (GPreWrite (WriteNamespace newNsPactValue) szVer) $
             writeNamespace info name newNsPactValue
 
     enforcePolicy info nn ns = do
@@ -552,28 +552,28 @@ namespaceDef = setTopLevelOnly $ defGasRNative "namespace" namespace
   \until either the next namespace declaration, or the end of the tx."
   where
     namespace :: GasRNativeFun e
-    namespace g i as = case as of
+    namespace i as = case as of
       [TLitString nsn] ->
         ifExecutionFlagSet FlagDisablePact47
-          (go g i nsn)
+          (go i nsn)
           (if T.null nsn then
-             goEmpty g i
-           else go g i nsn)
+             goEmpty i
+           else go i nsn)
       _ -> argsError i as
 
-    goEmpty g0 fa = computeGas' g0 fa (GUnreduced [])
+    goEmpty fa = computeGas' fa (GUnreduced [])
       $ success "Namespace reset to root"
       $ evalRefs . rsNamespace .= Nothing
 
-    go g0 fa ns = do
+    go fa ns = do
       let name = NamespaceName ns
           info = _faInfo fa
 
       mNs <- readRow info Namespaces name
-      case (fromNamespacePactValue <$> mNs) of
+      case fromNamespacePactValue <$> mNs of
         Just n@(Namespace ns' g _) -> do
           nsPactValue <- toNamespacePactValue info n
-          computeGas' g0 fa (GPostRead (ReadNamespace nsPactValue)) $ do
+          computeGas' fa (GPostRead (ReadNamespace nsPactValue)) $ do
             -- Old behavior enforces ns at declaration.
             -- New behavior enforces at ns-related action:
             -- 1. Module install (NOT at module upgrade)
@@ -929,16 +929,16 @@ list :: RNativeFun e
 list i as = return $ TList (V.fromList as) TyAny (_faInfo i) -- TODO, could set type here
 
 makeList :: GasRNativeFun e
-makeList g i [TLitInteger len,value] = case typeof value of
+makeList i [TLitInteger len,value] = case typeof value of
   Right ty -> do
     ga <- ifExecutionFlagSet' FlagDisablePact45 (GMakeList len) (GMakeList2 len Nothing)
-    computeGas' g i ga $ return $
+    computeGas' i ga $ return $
       toTListV ty def $ V.replicate (fromIntegral len) value
   Left ty -> evalError' i $ "make-list: invalid value type: " <> pretty ty
-makeList _ i as = argsError i as
+makeList i as = argsError i as
 
 enumerate :: GasRNativeFun e
-enumerate g i = \case
+enumerate i = \case
     [TLitInteger from', TLitInteger to', TLitInteger inc] ->
       createEnumerateList from' to' inc
     [TLitInteger from', TLitInteger to'] ->
@@ -953,10 +953,10 @@ enumerate g i = \case
       -- ^ size of the largest element.
       -> V.Vector Integer
       -- ^ The generated vector
-      -> Eval e (Gas, Term Name)
+      -> Eval e (Term Name)
     computeList len sz v = do
       ga <- ifExecutionFlagSet' FlagDisablePact45 (GMakeList len) (GMakeList2 len (Just sz))
-      computeGas' g i ga $ pure $ toTListV tTyInteger def $ fmap toTerm v
+      computeGas' i ga $ pure $ toTListV tTyInteger def $ fmap toTerm v
 
     step to' inc acc
       | acc > to', inc > 0 = Nothing
@@ -1121,7 +1121,7 @@ listModules i _ = do
   return $ toTermList tTyString $ map asString mods
 
 yield :: GasRNativeFun e
-yield g i as = case as of
+yield i as = case as of
   [u@(TObject t _)] -> go t Nothing u
   [u@(TObject t _), (TLitString cid)] -> go t (Just $ ChainId cid) u
   _ -> argsError i as
@@ -1141,58 +1141,58 @@ yield g i as = case as of
                 then evalError' i "Cross-chain yield not allowed in step with rollback"
                 else fmap (\p -> Yield o' p sourceChain) $ provenanceOf i t
           szVer <- getSizeOfVersion
-          computeGas' g i (GPreWrite (WriteYield y) szVer) $ do
+          computeGas' i (GPreWrite (WriteYield y) szVer) $ do
             evalPactExec . _Just . peYield .= Just y
             return u
 
 resume :: NativeFun e
 resume i as = case as of
   [TBinding ps bd (BindSchema _) bi] -> do
-    (g0,_) <- gasUnreduced i as $ return ()
+    computeGas (Right i) (GUnreduced as)
     rm <- preview $ eePactStep . _Just . psResume . _Just
     case rm of
       Nothing -> evalError' i "Resume: no yielded value in context"
       Just y -> do
-        computeGas' g0 i (GPostRead (ReadYield y)) $ do
+        computeGas' i (GPostRead (ReadYield y)) $ do
           o <- fmap fromPactValue . _yData <$> enforceYield i y
           l <- bindObjectLookup (toTObjectMap TyAny def o)
           bindReduce ps bd bi l
   _ -> argsError' i as
 
 where' :: NativeFun e
-where' i as@[k',tLamToApp -> app@TApp{},r'] = gasUnreduced i as $ ((,) <$> reduce k' <*> reduce r') >>= \kr -> case kr of
+where' i as@[k',tLamToApp -> app@TApp{},r'] = gasUnreduced i as $ ((,) <$> reduce k' <*> reduce r') >>= \case
   (k,r@TObject {}) -> lookupObj k (_oObject $ _tObject r) >>= \v -> apply (_tApp app) [v]
   _ -> argsError' i as
 where' i as = argsError' i as
 
 distinct :: GasRNativeFun e
-distinct g i = \case
-    [l@(TList v _ _ )] | V.null v -> pure (g,l)
+distinct i = \case
+    [l@(TList v _ _ )] | V.null v -> pure l
     [TList{..}] -> _tList
         & V.toList
         & L.nubBy termEq
         & V.fromList
         & toTListV _tListType def
         & pure
-        & computeGas' g i (GDistinct $ V.length _tList)
+        & computeGas' i (GDistinct $ V.length _tList)
     as -> argsError i as
 
 
 sort' :: GasRNativeFun e
-sort' g _ [l@(TList v _ _)] | V.null v = pure (g,l)
-sort' g i [TList{..}] = computeGas' g i (GSort (V.length _tList)) $ liftIO $ do
+sort' _ [l@(TList v _ _)] | V.null v = pure l
+sort' i [TList{..}] = computeGas' i (GSort (V.length _tList)) $ liftIO $ do
   m <- V.thaw _tList
   (`V.sortBy` m) $ \x y -> case (x,y) of
     (TLiteral xl _,TLiteral yl _) -> xl `compare` yl
     _ -> EQ
   toTListV _tListType def <$> V.freeze m
-sort' g0 fa [TList fields _ fi,l@(TList vs lty _)]
+sort' fa [TList fields _ fi,l@(TList vs lty _)]
   | V.null fields = evalError fi "Empty fields list"
-  | V.null vs = return (g0,l)
+  | V.null vs = return l
   | otherwise = do
-      (g1,_) <- computeGas' g0 fa (GSort (V.length vs)) $ return ()
+      computeGas (Right fa) (GSort (V.length vs))
       fields' <- asKeyList fields
-      computeGas' g1 fa (GSortFieldLookup (S.size fields')) $ liftIO $ do
+      computeGas' fa (GSortFieldLookup (S.size fields')) $ liftIO $ do
         m <- V.thaw vs
         (`V.sortBy` m) $ \x y -> case (x,y) of
           (TObject (Object (ObjectMap xo) _ _ _) _,TObject (Object (ObjectMap yo) _ _ _) _) ->
@@ -1203,7 +1203,7 @@ sort' g0 fa [TList fields _ fi,l@(TList vs lty _)]
             in foldr go EQ fields'
           _ -> EQ
         toTListV lty def <$> V.freeze m
-sort' _ i as = argsError i as
+sort' i as = argsError i as
 
 
 -- See: note in pact-version native
@@ -1260,7 +1260,7 @@ identity _ [a'] = return a'
 identity i as = argsError i as
 
 concat' :: GasRNativeFun e
-concat' g i [TList ls _ _] = computeGas' g i (GMakeList $ fromIntegral $ V.length ls) $ let
+concat' i [TList ls _ _] = computeGas' i (GMakeList $ fromIntegral $ V.length ls) $ let
   -- Use GMakeList because T.concat is O(n) on the number of strings in the list
   ls' = V.toList ls
   concatTextList = flip TLiteral def . LString . T.concat
@@ -1269,7 +1269,7 @@ concat' g i [TList ls _ _] = computeGas' g i (GMakeList $ fromIntegral $ V.lengt
     t -> isOffChainForkedError >>= \case
       OffChainError -> evalError' i $ "concat: expecting list of strings: " <> pretty t
       OnChainError -> evalError' i $ "concat: expected list of strings, received value of type: " <> pretty (typeof' t)
-concat' _ i as = argsError i as
+concat' i as = argsError i as
 
 -- | Converts a string to a vector of single character strings
 -- Ex. "kda" -> [ "k", "d", "a"]
@@ -1277,11 +1277,11 @@ stringToCharList :: Text -> V.Vector (Term a)
 stringToCharList t = V.fromList $ tLit . LString . T.singleton <$> T.unpack t
 
 strToList :: GasRNativeFun e
-strToList g i [TLitString s] = do
+strToList i [TLitString s] = do
   let len = fromIntegral $ T.length s
   ga <- ifExecutionFlagSet' FlagDisablePact45 (GMakeList len) (GMakeList2 len Nothing)
-  computeGas' g i ga $ return $ toTListV tTyString def $ stringToCharList s
-strToList _ i as = argsError i as
+  computeGas' i ga $ return $ toTListV tTyString def $ stringToCharList s
+strToList i as = argsError i as
 
 strToInt :: RNativeFun e
 strToInt i as =

--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -128,8 +128,8 @@ evalCap i scope inModule a@App{..} = do
       (cap,d,prep) <- appToCap a
       when inModule $ guardForModuleCall _appInfo (_dModule d) $ return ()
       evalUserCapability i capFuns scope cap d $ do
-        g <- computeUserAppGas d _appInfo
-        void $ evalUserAppBody d prep _appInfo g reduceBody
+        computeUserAppGas d _appInfo
+        void $ evalUserAppBody d prep _appInfo reduceBody
 
 
 -- | Continuation to tie the knot with Pact.Eval (ie, 'apply') and also because the capDef is

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -24,7 +24,6 @@ module Pact.Native.Db
     where
 
 import Bound
--- import Control.Arrow hiding (app)
 import Control.Lens hiding ((.=))
 import Control.Monad
 import Control.Monad.Reader (ask)

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -24,14 +24,14 @@ module Pact.Native.Db
     where
 
 import Bound
-import Control.Arrow hiding (app)
+-- import Control.Arrow hiding (app)
 import Control.Lens hiding ((.=))
 import Control.Monad
 import Control.Monad.Reader (ask)
 import Data.Default
 import qualified Data.HashSet as HS
 import qualified Data.Map.Strict as M
-import Data.Foldable (foldlM)
+import Data.Foldable (foldlM, traverse_)
 import qualified Data.Vector as V
 import Data.Text (pack)
 
@@ -178,7 +178,7 @@ descTable _ [TTable {..}] = return $ toTObject TyAny def [
 descTable i as = argsError i as
 
 descKeySet :: GasRNativeFun e
-descKeySet g i [TLitString t] = do
+descKeySet i [TLitString t] = do
   k <- ifExecutionFlagSet FlagDisablePact44
     (pure $ KeySetName t Nothing)
     (case parseAnyKeysetName t of
@@ -187,10 +187,10 @@ descKeySet g i [TLitString t] = do
 
   r <- readRow (_faInfo i) KeySets k
   case r of
-    Just v -> computeGas' g i (GPostRead (ReadKeySet k v)) $
+    Just v -> computeGas' i (GPostRead (ReadKeySet k v)) $
               return $ toTerm v
     Nothing -> evalError' i $ "Keyset not found: " <> pretty t
-descKeySet _ i as = argsError i as
+descKeySet i as = argsError i as
 
 descModule :: RNativeFun e
 descModule i [TLitString t] = do
@@ -227,7 +227,7 @@ userTable' t = error $ "creating user table from non-TTable: " ++ show t
 
 
 read' :: GasRNativeFun e
-read' g0 i as@(table@TTable {}:TLitString key:rest) = do
+read' i as@(table@TTable {}:TLitString key:rest) = do
   cols <- case rest of
     [] -> return []
     [l] -> colsToList (argsError i as) l
@@ -237,12 +237,12 @@ read' g0 i as@(table@TTable {}:TLitString key:rest) = do
   case mrow of
     Nothing -> failTx (_faInfo i) $ "read: row not found: " <> pretty key
     Just cs -> do
-      g <- gasPostRead i g0 cs
-      fmap (g,) $ case cols of
+      gasPostRead i cs
+      case cols of
         [] -> return $ columnsToObject (_tTableType table) cs
         _ -> columnsToObject' (_tTableType table) cols cs
 
-read' _ i as = argsError i as
+read' i as = argsError i as
 
 
 foldDB' :: NativeFun e
@@ -252,11 +252,11 @@ foldDB' i [tbl, tLamToApp -> TApp qry _, tLamToApp -> TApp consumer _] = do
     t -> isOffChainForkedError >>= \case
       OffChainError -> evalError' i $ "Expected table as first argument to foldDB, got: " <> pretty t
       OnChainError -> evalError' i $ "Expected table as first argument to foldDB, got argument of type: " <> pretty (typeof' t)
-  !g0 <- computeGas (Right i) (GUnreduced [])
-  !g1 <- computeGas (Right i) GFoldDB
+  computeGas (Right i) (GUnreduced [])
+  computeGas (Right i) GFoldDB
   ks <- getKeys table
-  (!g2, xs) <- foldlM (fdb table) (g0+g1, []) ks
-  pure (g2, TList (V.fromList (reverse xs)) TyAny def)
+  xs <- foldlM (fdb table) [] ks
+  pure (TList (V.fromList (reverse xs)) TyAny def)
   where
   asBool (TLiteral (LBool satisfies) _) = return satisfies
   asBool t = isOffChainForkedError >>= \case
@@ -265,33 +265,34 @@ foldDB' i [tbl, tLamToApp -> TApp qry _, tLamToApp -> TApp consumer _] = do
   getKeys table = do
     guardTable i table GtKeys
     keys (_faInfo i) (userTable table)
-  fdb table (!g0, acc) key = do
+  fdb table acc key = do
     mrow <- readRow (_faInfo i) (userTable table) key
     case mrow of
       Just row -> do
-        g1 <- gasPostRead i g0 row
+        gasPostRead i row
         let obj = columnsToObject (_tTableType table) row
         let key' = toTerm key
         cond <- asBool =<< apply qry [key', obj]
         if cond then do
           r' <- apply consumer [key', obj]
-          pure (g1, r':acc)
-        else pure (g1, acc)
+          pure (r':acc)
+        else pure acc
       Nothing -> evalError (_faInfo i) $ "foldDb: unexpected error, key: "
                  <> pretty key <> " not found in table: " <> pretty table
 foldDB' i as = argsError' i as
 
-gasPostRead :: Readable r => FunApp -> Gas -> r -> Eval e Gas
-gasPostRead i g0 row = (g0 +) <$> computeGas (Right i) (GPostRead $ readable row)
+gasPostRead :: Readable r => FunApp -> r -> Eval e ()
+gasPostRead i row = computeGas (Right i) (GPostRead $ readable row)
 
-gasPostRead' :: Readable r => FunApp -> Gas -> r -> Eval e a -> Eval e (Gas,a)
-gasPostRead' i g0 row action = gasPostRead i g0 row >>= \g -> (g,) <$> action
+gasPostRead' :: Readable r => FunApp -> r -> Eval e a -> Eval e a
+gasPostRead' i row action = gasPostRead i row *> action
 
 -- | TODO improve post-streaming
-gasPostReads :: Readable r => FunApp -> Gas -> ([r] -> a) -> Eval e [r] -> Eval e (Gas,a)
-gasPostReads i g0 postProcess action = do
+gasPostReads :: Readable r => FunApp -> ([r] -> a) -> Eval e [r] -> Eval e a
+gasPostReads i postProcess action = do
   rs <- action
-  (,postProcess rs) <$> foldM (gasPostRead i) g0 rs
+  traverse_ (gasPostRead i) rs
+  pure $ postProcess rs
 
 columnsToObject :: Type (Term Name) -> RowData -> Term Name
 columnsToObject ty m = TObject (Object (fmap (fromPactValue . rowDataToPactValue) (_rdData m)) ty def def) def
@@ -315,26 +316,26 @@ select i as@[tbl',app] = reduce tbl' >>= select' i as Nothing app
 select i as = argsError' i as
 
 select' :: FunApp -> [Term Ref] -> Maybe [(Info,FieldKey)] ->
-           Term Ref -> Term Name -> Eval e (Gas,Term Name)
+           Term Ref -> Term Name -> Eval e (Term Name)
 select' i _ cols' app@TApp{} tbl@TTable{} = do
-    g0 <- computeGas (Right i) (GUnreduced [])
-    g1 <- computeGas (Right i) $ GSelect cols'
+    computeGas (Right i) (GUnreduced [])
+    computeGas (Right i) $ GSelect cols'
     guardTable i tbl GtSelect
     let fi = _faInfo i
         tblTy = _tTableType tbl
     ks <- keys fi (userTable tbl)
-    fmap (second (\b -> TList (V.fromList (reverse b)) tblTy def)) $
-      (\f -> foldM f (g0 + g1, []) ks) $ \(gPrev,rs) k -> do
+    fmap (\b -> TList (V.fromList (reverse b)) tblTy def) $
+      (\f -> foldM f [] ks) $ \rs k -> do
 
       mrow <- readRow fi (userTable tbl) k
       case mrow of
         Nothing -> evalError fi $ "select: unexpected error, key not found in select: "
                    <> pretty k <> ", table: " <> pretty tbl
         Just row -> do
-          g <- gasPostRead i gPrev row
+          gasPostRead i row
           let obj = columnsToObject tblTy row
           result <- apply (_tApp app) [obj]
-          fmap (g,) $ case result of
+          case result of
             (TLiteral (LBool include) _)
               | include -> case cols' of
                   Nothing -> return (obj:rs)
@@ -349,28 +350,28 @@ select' i as _ _ _ = argsError' i as
 withDefaultRead :: NativeFun e
 withDefaultRead fi as@[table',key',defaultRow',b@(TBinding ps bd (BindSchema _) _)] = do
   let argsToReduce = [table',key',defaultRow']
-  (!g0,!tkd) <- gasUnreduced fi argsToReduce (mapM reduce argsToReduce)
+  !tkd <- gasUnreduced fi argsToReduce (mapM reduce argsToReduce)
   case tkd of
     [table@TTable {}, TLitString key, TObject (Object defaultRow _ _ _) _] -> do
       guardTable fi table GtWithDefaultRead
       mrow <- readRow (_faInfo fi) (userTable table) (RowKey key)
       case mrow of
-        Nothing -> (g0,) <$> (bindToRow ps bd b =<< enforcePactValue' defaultRow)
-        (Just row) -> gasPostRead' fi g0 row $ bindToRow ps bd b (rowDataToPactValue <$> _rdData row)
+        Nothing -> bindToRow ps bd b =<< enforcePactValue' defaultRow
+        (Just row) -> gasPostRead' fi row $ bindToRow ps bd b (rowDataToPactValue <$> _rdData row)
     _ -> argsError' fi as
 withDefaultRead fi as = argsError' fi as
 
 withRead :: NativeFun e
 withRead fi as@[table',key',b@(TBinding ps bd (BindSchema _) _)] = do
   let argsToReduce = [table',key']
-  (!g0,!tk) <- gasUnreduced fi argsToReduce (mapM reduce argsToReduce)
+  !tk <- gasUnreduced fi argsToReduce (mapM reduce argsToReduce)
   case tk of
     [table@TTable {},TLitString key] -> do
       guardTable fi table GtWithRead
       mrow <- readRow (_faInfo fi) (userTable table) (RowKey key)
       case mrow of
         Nothing -> failTx (_faInfo fi) $ "with-read: row not found: " <> pretty key
-        (Just row) -> gasPostRead' fi g0 row $ bindToRow ps bd b (rowDataToPactValue <$> _rdData row)
+        (Just row) -> gasPostRead' fi row $ bindToRow ps bd b (rowDataToPactValue <$> _rdData row)
     _ -> argsError' fi as
 withRead fi as = argsError' fi as
 
@@ -380,30 +381,30 @@ bindToRow ps bd b (ObjectMap row) =
   bindReduce ps bd (_tInfo b) (\s -> fromPactValue <$> M.lookup (FieldKey s) row)
 
 keys' :: GasRNativeFun e
-keys' g i [table@TTable {}] = do
-  gasPostReads i g
+keys' i [table@TTable {}] = do
+  gasPostReads i
     ((\b -> TList (V.fromList b) tTyString def) . map toTerm) $ do
       guardTable i table GtKeys
       keys (_faInfo i) (userTable table)
-keys' _ i as = argsError i as
+keys' i as = argsError i as
 
 
 txids' :: GasRNativeFun e
-txids' g i [table@TTable {},TLitInteger key] = do
+txids' i [table@TTable {},TLitInteger key] = do
   checkNonLocalAllowed i
-  gasPostReads i g
+  gasPostReads i
     ((\b -> TList (V.fromList b) tTyInteger def) . map toTerm) $ do
       guardTable i table GtTxIds
       txids (_faInfo i) (userTable' table) (fromIntegral key)
-txids' _ i as = argsError i as
+txids' i as = argsError i as
 
 txlog :: GasRNativeFun e
-txlog g i [table@TTable {},TLitInteger tid] = do
+txlog i [table@TTable {},TLitInteger tid] = do
   checkNonLocalAllowed i
-  gasPostReads i g (toTList TyAny def . map txlogToObj) $ do
+  gasPostReads i (toTList TyAny def . map txlogToObj) $ do
       guardTable i table GtTxLog
       getTxLog (_faInfo i) (userTable table) (fromIntegral tid)
-txlog _ i as = argsError i as
+txlog i as = argsError i as
 
 txlogToObj :: TxLog RowData -> Term Name
 txlogToObj TxLog{..} = toTObject TyAny def
@@ -421,48 +422,47 @@ checkNonLocalAllowed i = do
     "Operation only permitted in local execution mode"
 
 keylog :: GasRNativeFun e
-keylog g i [table@TTable {..},TLitString key,TLitInteger utid] = do
+keylog i [table@TTable {..},TLitString key,TLitInteger utid] = do
   checkNonLocalAllowed i
   let postProc = toTList TyAny def . map toTxidObj
         where toTxidObj (t,r) =
                 toTObject TyAny def [("txid", toTerm t),("value",columnsToObject _tTableType (_txValue r))]
-  gasPostReads i g postProc $ do
+  gasPostReads i postProc $ do
     guardTable i table GtKeyLog
     tids <- txids (_faInfo i) (userTable' table) (fromIntegral utid)
     logs <- fmap concat $ forM tids $ \tid -> map (tid,) <$> getTxLog (_faInfo i) (userTable table) tid
     return $ filter (\(_,TxLog {..}) -> _txKey == key) logs
 
-keylog _ i as = argsError i as
+keylog i as = argsError i as
 
 write :: WriteType -> SchemaPartial -> NativeFun e
 write wt partial i as = do
   ts <- mapM reduce as
   case ts of
-    [table@TTable {..},TLitString key,(TObject (Object ps _ _ _) _)] -> do
+    [table@TTable {..},TLitString key, TObject (Object ps _ _ _) _] -> do
       ps' <- enforcePactValue' ps
-      cost0 <- computeGas (Right i) (GUnreduced [])
+      computeGas (Right i) (GUnreduced [])
       szVer <- getSizeOfVersion
-      cost1 <- computeGas (Right i) (GPreWrite (WriteData wt (asString key) ps') szVer)
+      computeGas (Right i) (GPreWrite (WriteData wt (asString key) ps') szVer)
       guardTable i table GtWrite
       case _tTableType of
         TyAny -> return ()
         TyVar {} -> return ()
         tty -> void $ checkUserType partial (_faInfo i) ps tty
       rdv <- ifExecutionFlagSet' FlagDisablePact420 RDV0 RDV1
-      r <- success "Write succeeded" $ writeRow (_faInfo i) wt (userTable table) (RowKey key) $
+      success "Write succeeded" $ writeRow (_faInfo i) wt (userTable table) (RowKey key) $
           RowData rdv (pactValueToRowData <$> ps')
-      return (cost0 + cost1, r)
     _ -> argsError i ts
 
 
 createTable' :: GasRNativeFun e
-createTable' g i [t@TTable {..}] = do
+createTable' i [t@TTable {..}] = do
   guardTable i t GtCreateTable
   let (UserTables tn) = userTable t
   szVer <- getSizeOfVersion
-  computeGas' g i (GPreWrite (WriteTable (asString tn)) szVer) $
+  computeGas' i (GPreWrite (WriteTable (asString tn)) szVer) $
     success "TableCreated" $ createUserTable (_faInfo i) tn _tModuleName
-createTable' _ i as = argsError i as
+createTable' i as = argsError i as
 
 guardTable :: Pretty n => FunApp -> Term n -> GuardTableOp -> Eval e ()
 guardTable i TTable {..} dbop =
@@ -482,7 +482,7 @@ guardTable i t _ = isOffChainForkedError >>= \case
   OnChainError -> evalError' i $ "Internal error: guardTable called with non-table term: " <> pretty (typeof' t)
 
 enforceBlessedHashes :: FunApp -> ModuleName -> ModuleHash -> Eval e ()
-enforceBlessedHashes i mn h = getModule i mn >>= \m -> case (_mdModule m) of
+enforceBlessedHashes i mn h = getModule i mn >>= \m -> case _mdModule m of
         MDModule Module{..}
           | h == _mHash -> return () -- current version ok
           | h `HS.member` _mBlessed -> return () -- hash is blessed

--- a/src/Pact/Native/Internal.hs
+++ b/src/Pact/Native/Internal.hs
@@ -108,7 +108,7 @@ bindReduce ps bd bi lkpFun = do
   let prettyBindings = list $ pretty . fmap abbrev <$> vs
       textBindings   = renderCompactText' $ "(bind: " <> prettyBindings <> ")"
       frame          = StackFrame textBindings bi Nothing
-  call frame $! (0,) <$> reduceBody bd''
+  call frame $! reduceBody bd''
 
 setTopLevelOnly :: NativeDef -> NativeDef
 setTopLevelOnly = set (_2 . tNativeTopLevelOnly) True
@@ -121,12 +121,12 @@ defNative n fun ftype examples docs =
 -- | Specify a 'GasRNativeFun'
 defGasRNative :: NativeDefName -> GasRNativeFun e -> FunTypes (Term Name) -> [Example] -> Text -> NativeDef
 defGasRNative name fun = defNative name (reduced fun)
-    where reduced f fi as = gasUnreduced fi as (mapM reduce as) >>= \(g,as') -> f g fi as'
+    where reduced f fi as = gasUnreduced fi as (mapM reduce as) >>= \as' -> f fi as'
 
 -- | Specify a 'RNativeFun'
 defRNative :: NativeDefName -> RNativeFun e -> FunTypes (Term Name) -> [Example] -> Text -> NativeDef
 defRNative name fun = defNative name (reduced fun)
-    where reduced f fi as = gasUnreduced fi as (mapM reduce as) >>= \(g,as') -> (g,) <$> f fi as'
+    where reduced f fi as = gasUnreduced fi as (mapM reduce as) >>= \as' -> f fi as'
 
 
 defSchema :: NativeDefName -> Text -> [(FieldKey, Type (Term Name))] -> NativeDef

--- a/src/Pact/Native/Ops.hs
+++ b/src/Pact/Native/Ops.hs
@@ -67,25 +67,24 @@ addDef = defGasRNative "+" plus plusTy
   "Add numbers, concatenate strings/lists, or merge objects."
   where
     plus :: GasRNativeFun e
-    plus g fi [TLitString a,TLitString b] = gasConcat g fi (T.length a) (T.length b) $
+    plus fi [TLitString a,TLitString b] = gasConcat fi (T.length a) (T.length b) $
       (return (tStr $ a <> b))
-    plus g fi [TList a aty _,TList b bty _] = gasConcat g fi (length a) (length b) $
+    plus fi [TList a aty _,TList b bty _] = gasConcat fi (length a) (length b) $
       return (TList
       (a <> b)
       (if aty == bty then aty else TyAny)
       def)
-    plus g fi [TObject (Object (ObjectMap as) aty _ _) _,TObject (Object (ObjectMap bs) bty _ _) _] =
-      gasConcat g fi (M.size as) (M.size bs) $
+    plus fi [TObject (Object (ObjectMap as) aty _ _) _,TObject (Object (ObjectMap bs) bty _ _) _] =
+      gasConcat fi (M.size as) (M.size bs) $
       return ((`TObject` def) $ Object
            (ObjectMap $ M.union as bs)
            (if aty == bty then aty else TyAny)
            def
            def)
-    plus g i as =
-      (g,) <$> binop' "+" (+) (+) i as
+    plus i as = binop' "+" (+) (+) i as
     {-# INLINE plus #-}
 
-    gasConcat g fi aLength bLength = computeGas' g fi (GConcatenation aLength bLength)
+    gasConcat fi aLength bLength = computeGas' fi (GConcatenation aLength bLength)
 
     plusTy :: FunTypes n
     plusTy = coerceBinNum <> binTy plusA plusA plusA
@@ -162,11 +161,11 @@ powImpl i as@[TLiteral a _,TLiteral b _] = do
     | otherwise = twoArgIntOpGas x x *> odds (x * x) (y `quot` 2) (x * z)
 powImpl i as = argsError i as
 
-twoArgIntOpGas :: Integer -> Integer -> Eval e Gas
+twoArgIntOpGas :: Integer -> Integer -> Eval e ()
 twoArgIntOpGas loperand roperand =
   computeGasCommit def "" (GIntegerOpCost (loperand, Nothing) (roperand, Nothing))
 
-twoArgDecOpGas :: Decimal -> Decimal -> Eval e Gas
+twoArgDecOpGas :: Decimal -> Decimal -> Eval e ()
 twoArgDecOpGas loperand roperand =
   computeGasCommit def ""
   (GIntegerOpCost

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -131,12 +131,12 @@ initPureEvalEnv verifyUri = do
 initEvalEnv :: LibState -> IO (EvalEnv LibState)
 initEvalEnv ls = do
   mv <- newMVar ls
-  gasRef <- newIORef 0
+  gasRef <- newIORef mempty
   warnRef <- newIORef mempty
   return $ EvalEnv
     { _eeRefStore = RefStore nativeDefs
     , _eeMsgSigs = mempty
-    , _eeMsgBody = A.Object HM.empty 
+    , _eeMsgBody = A.Object HM.empty
     , _eeMode = Transactional
     , _eeEntity = Nothing
     , _eePactStep = Nothing

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -706,15 +706,15 @@ envHash i as = argsError i as
 
 setGasLimit :: RNativeFun LibState
 setGasLimit _ [TLitInteger l] = do
-  setenv (eeGasEnv . geGasLimit) (gasLimitToMicroGasLimit (fromIntegral l))
+  setenv (eeGasEnv . geGasLimit) (gasLimitToMilliGasLimit (fromIntegral l))
   return $ tStr $ "Set gas limit to " <> tShow l
 setGasLimit i as = argsError i as
 
 envGas :: RNativeFun LibState
 envGas _ [] = do
-  getGas >>= \g -> return (tLit $ LInteger $ fromIntegral (microGasToGas g))
+  getGas >>= \g -> return (tLit $ LInteger $ fromIntegral (milliGasToGas g))
 envGas _ [TLitInteger g] = do
-  putGas $ gasToMicroGas (fromIntegral g)
+  putGas $ gasToMilliGas (fromIntegral g)
   return $ tStr $ "Set gas to " <> tShow g
 envGas i as = argsError i as
 

--- a/src/Pact/Types/Gas.hs
+++ b/src/Pact/Types/Gas.hs
@@ -227,7 +227,7 @@ instance Wrapped GasLimit
 -- Todo: this probably overflows but do we care?
 gasLimitToMicroGasLimit :: GasLimit -> MicroGasLimit
 gasLimitToMicroGasLimit (GasLimit (ParsedInteger i)) =
-  MicroGasLimit (MicroGas (fromIntegral i))
+  MicroGasLimit (gasToMicroGas (fromIntegral i))
 
 newtype MicroGasLimit
   = MicroGasLimit MicroGas

--- a/src/Pact/Types/Gas.hs
+++ b/src/Pact/Types/Gas.hs
@@ -23,10 +23,10 @@ module Pact.Types.Gas
   , GasModel(..)
   , GasArgs(..)
   , GasLimit(..)
-  , MicroGasLimit(..)
+  , MilliGasLimit(..)
   , ZKGroup(..)
   , ZKArg(..)
-  , gasLimitToMicroGasLimit
+  , gasLimitToMilliGasLimit
     -- * optics
   , geGasLimit
   , geGasPrice
@@ -225,21 +225,21 @@ instance FromJSON GasLimit where
 instance Wrapped GasLimit
 
 -- Todo: this probably overflows but do we care?
-gasLimitToMicroGasLimit :: GasLimit -> MicroGasLimit
-gasLimitToMicroGasLimit (GasLimit (ParsedInteger i)) =
-  MicroGasLimit (gasToMicroGas (fromIntegral i))
+gasLimitToMilliGasLimit :: GasLimit -> MilliGasLimit
+gasLimitToMilliGasLimit (GasLimit (ParsedInteger i)) =
+  MilliGasLimit (gasToMilliGas (fromIntegral i))
 
-newtype MicroGasLimit
-  = MicroGasLimit MicroGas
+newtype MilliGasLimit
+  = MilliGasLimit MilliGas
   deriving (Eq, Ord)
 
-instance Show MicroGasLimit where
-  show (MicroGasLimit (MicroGas i)) = show i
+instance Show MilliGasLimit where
+  show (MilliGasLimit (MilliGas i)) = show i
 
 data GasModel = GasModel
   { gasModelName :: !Text
   , gasModelDesc :: !Text
-  , runGasModel :: Text -> GasArgs -> MicroGas
+  , runGasModel :: Text -> GasArgs -> MilliGas
   }
 
 instance Show GasModel where
@@ -249,7 +249,7 @@ instance Pretty GasModel where
   pretty m = viaShow m
 
 data GasEnv = GasEnv
-  { _geGasLimit :: !MicroGasLimit
+  { _geGasLimit :: !MilliGasLimit
   , _geGasPrice :: !GasPrice
   , _geGasModel :: !GasModel
   }

--- a/src/Pact/Types/Gas.hs
+++ b/src/Pact/Types/Gas.hs
@@ -23,6 +23,7 @@ module Pact.Types.Gas
   , GasModel(..)
   , GasArgs(..)
   , GasLimit(..)
+  , MicroGasLimit(..)
   , ZKGroup(..)
   , ZKArg(..)
     -- * optics
@@ -222,10 +223,17 @@ instance FromJSON GasLimit where
 
 instance Wrapped GasLimit
 
+newtype MicroGasLimit
+  = MicroGasLimit MicroGas
+  deriving (Eq, Ord)
+
+instance Show MicroGasLimit where
+  show (MicroGasLimit (MicroGas i)) = show i
+
 data GasModel = GasModel
   { gasModelName :: !Text
   , gasModelDesc :: !Text
-  , runGasModel :: !(Text -> GasArgs -> Gas)
+  , runGasModel :: Text -> GasArgs -> MicroGas
   }
 
 instance Show GasModel where
@@ -235,7 +243,7 @@ instance Pretty GasModel where
   pretty m = viaShow m
 
 data GasEnv = GasEnv
-  { _geGasLimit :: !GasLimit
+  { _geGasLimit :: !MicroGasLimit
   , _geGasPrice :: !GasPrice
   , _geGasModel :: !GasModel
   }

--- a/src/Pact/Types/Gas.hs
+++ b/src/Pact/Types/Gas.hs
@@ -26,6 +26,7 @@ module Pact.Types.Gas
   , MicroGasLimit(..)
   , ZKGroup(..)
   , ZKArg(..)
+  , gasLimitToMicroGasLimit
     -- * optics
   , geGasLimit
   , geGasPrice
@@ -222,6 +223,11 @@ instance FromJSON GasLimit where
   parseJSON = fmap GasLimit . parseGT0
 
 instance Wrapped GasLimit
+
+-- Todo: this probably overflows but do we care?
+gasLimitToMicroGasLimit :: GasLimit -> MicroGasLimit
+gasLimitToMicroGasLimit (GasLimit (ParsedInteger i)) =
+  MicroGasLimit (MicroGas (fromIntegral i))
 
 newtype MicroGasLimit
   = MicroGasLimit MicroGas

--- a/src/Pact/Types/Native.hs
+++ b/src/Pact/Types/Native.hs
@@ -43,10 +43,10 @@ isSpecialForm = (`M.lookup` sfLookup)
 
 -- | Native function with un-reduced arguments that computes gas.
 --   Operation cost implemented in definition.
-type NativeFun e = FunApp -> [Term Ref] -> Eval e (Gas,Term Name)
+type NativeFun e = FunApp -> [Term Ref] -> Eval e (Term Name)
 
 -- | Native function with reduced arguments, initial gas pre-compute that computes final gas.
-type GasRNativeFun e = Gas -> FunApp -> [Term Name] -> Eval e (Gas,Term Name)
+type GasRNativeFun e = FunApp -> [Term Name] -> Eval e (Term Name)
 
 -- | Native function with reduced arguments, final gas pre-computed.
 --   Operations with fixed cost.

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -361,10 +361,10 @@ unlessExecutionFlagSet f onFalse =
   ifExecutionFlagSet f (return ()) (void onFalse)
 
 -- | Bracket interpreter action pushing and popping frame on call stack.
-call :: StackFrame -> Eval e (Gas,a) -> Eval e a
+call :: StackFrame -> Eval e a -> Eval e a
 call s act = do
   evalCallStack %= (s:)
-  (_gas,r) <- act
+  r <- act
   evalCallStack %= drop 1
   return r
 {-# INLINE call #-}

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -245,7 +245,7 @@ data EvalEnv e = EvalEnv {
       -- | Gas Environment
     , _eeGasEnv :: GasEnv
       -- | Tallied gas
-    , _eeGas :: IORef MicroGas
+    , _eeGas :: IORef MilliGas
       -- | Namespace Policy
     , _eeNamespacePolicy :: NamespacePolicy
       -- | SPV backend

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -245,7 +245,7 @@ data EvalEnv e = EvalEnv {
       -- | Gas Environment
     , _eeGasEnv :: GasEnv
       -- | Tallied gas
-    , _eeGas :: IORef Gas
+    , _eeGas :: IORef MicroGas
       -- | Namespace Policy
     , _eeNamespacePolicy :: NamespacePolicy
       -- | SPV backend

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -924,7 +924,7 @@ instance (SizeOf d) => SizeOf (Ref' d)
 
 data NativeDFun = NativeDFun
   { _nativeName :: !NativeDefName
-  , _nativeFun :: !(forall m . Monad m => FunApp -> [Term Ref] -> m (Gas,Term Name))
+  , _nativeFun :: !(forall m . Monad m => FunApp -> [Term Ref] -> m (Term Name))
   }
 
 instance Eq NativeDFun where a == b = _nativeName a == _nativeName b

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -90,7 +90,8 @@ module Pact.Types.Term
    prettyTypeTerm,
    pattern TLitString,pattern TLitInteger,pattern TLitBool,
    tLit,tStr,termEq,termEq1,termRefEq,canEq,refEq,
-   Gas(..),
+   Gas(..), MicroGas(..),
+   gasToMicroGas, microGasToGas,
    module Pact.Types.Names
    ) where
 
@@ -252,6 +253,29 @@ instance Semigroup Gas where
 
 instance Monoid Gas where
   mempty = 0
+
+newtype MicroGas
+  = MicroGas Int64
+  deriving (Eq, Ord, ToJSON, FromJSON, NFData, Generic)
+
+instance Semigroup MicroGas where
+  (MicroGas a) <> (MicroGas b) = MicroGas (a + b)
+
+instance Monoid MicroGas where
+  mempty = MicroGas 0
+
+instance Pretty MicroGas where
+  pretty (MicroGas i) = pretty i
+
+microsPerGas :: Int64
+microsPerGas = 1000
+
+gasToMicroGas :: Gas -> MicroGas
+gasToMicroGas (Gas n) = MicroGas (n * microsPerGas)
+
+microGasToGas :: MicroGas -> Gas
+microGasToGas (MicroGas n) = Gas (n `div` microsPerGas)
+
 
 -- -------------------------------------------------------------------------- --
 -- BindType

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -254,9 +254,12 @@ instance Semigroup Gas where
 instance Monoid Gas where
   mempty = 0
 
+-- | Gas compute cost unit that represents smaller units of compute time.
+-- 1 Gas = 1000 MilliGas, and in terms of compute time, 1 Gas = 2500 ns,
+-- thus 1 MilliGas = 2.5ns
 newtype MilliGas
   = MilliGas Int64
-  deriving (Eq, Ord, ToJSON, FromJSON, NFData, Generic)
+  deriving (Eq, Ord, NFData, Generic)
 
 instance Semigroup MilliGas where
   (MilliGas a) <> (MilliGas b) = MilliGas (a + b)
@@ -264,14 +267,14 @@ instance Semigroup MilliGas where
 instance Monoid MilliGas where
   mempty = MilliGas 0
 
-microsPerGas :: Int64
-microsPerGas = 1000
+millisPerGas :: Int64
+millisPerGas = 1000
 
 gasToMilliGas :: Gas -> MilliGas
-gasToMilliGas (Gas n) = MilliGas (n * microsPerGas)
+gasToMilliGas (Gas n) = MilliGas (n * millisPerGas)
 
 milliGasToGas :: MilliGas -> Gas
-milliGasToGas (MilliGas n) = Gas (n `div` microsPerGas)
+milliGasToGas (MilliGas n) = Gas (n `div` millisPerGas)
 
 
 -- -------------------------------------------------------------------------- --

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -90,8 +90,8 @@ module Pact.Types.Term
    prettyTypeTerm,
    pattern TLitString,pattern TLitInteger,pattern TLitBool,
    tLit,tStr,termEq,termEq1,termRefEq,canEq,refEq,
-   Gas(..), MicroGas(..),
-   gasToMicroGas, microGasToGas,
+   Gas(..), MilliGas(..),
+   gasToMilliGas, milliGasToGas,
    module Pact.Types.Names
    ) where
 
@@ -254,27 +254,27 @@ instance Semigroup Gas where
 instance Monoid Gas where
   mempty = 0
 
-newtype MicroGas
-  = MicroGas Int64
+newtype MilliGas
+  = MilliGas Int64
   deriving (Eq, Ord, ToJSON, FromJSON, NFData, Generic)
 
-instance Semigroup MicroGas where
-  (MicroGas a) <> (MicroGas b) = MicroGas (a + b)
+instance Semigroup MilliGas where
+  (MilliGas a) <> (MilliGas b) = MilliGas (a + b)
 
-instance Monoid MicroGas where
-  mempty = MicroGas 0
+instance Monoid MilliGas where
+  mempty = MilliGas 0
 
-instance Pretty MicroGas where
-  pretty (MicroGas i) = pretty i
+instance Pretty MilliGas where
+  pretty (MilliGas i) = pretty i
 
 microsPerGas :: Int64
 microsPerGas = 1000
 
-gasToMicroGas :: Gas -> MicroGas
-gasToMicroGas (Gas n) = MicroGas (n * microsPerGas)
+gasToMilliGas :: Gas -> MilliGas
+gasToMilliGas (Gas n) = MilliGas (n * microsPerGas)
 
-microGasToGas :: MicroGas -> Gas
-microGasToGas (MicroGas n) = Gas (n `div` microsPerGas)
+milliGasToGas :: MilliGas -> Gas
+milliGasToGas (MilliGas n) = Gas (n `div` microsPerGas)
 
 
 -- -------------------------------------------------------------------------- --

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -91,7 +91,7 @@ module Pact.Types.Term
    pattern TLitString,pattern TLitInteger,pattern TLitBool,
    tLit,tStr,termEq,termEq1,termRefEq,canEq,refEq,
    Gas(..), MilliGas(..),
-   gasToMilliGas, milliGasToGas,
+   gasToMilliGas, milliGasToGas, millisPerGas,
    module Pact.Types.Names
    ) where
 

--- a/src/Pact/Types/Term.hs
+++ b/src/Pact/Types/Term.hs
@@ -264,9 +264,6 @@ instance Semigroup MilliGas where
 instance Monoid MilliGas where
   mempty = MilliGas 0
 
-instance Pretty MilliGas where
-  pretty (MilliGas i) = pretty i
-
 microsPerGas :: Int64
 microsPerGas = 1000
 

--- a/src/Pact/Types/Term/Internal.hs
+++ b/src/Pact/Types/Term/Internal.hs
@@ -280,7 +280,7 @@ gasToMilliGas :: Gas -> MilliGas
 gasToMilliGas (Gas n) = MilliGas (n * millisPerGas)
 
 milliGasToGas :: MilliGas -> Gas
-milliGasToGas (MilliGas n) = Gas (n `div` millisPerGas)
+milliGasToGas (MilliGas n) = Gas (n `quot` millisPerGas)
 
 
 -- -------------------------------------------------------------------------- --

--- a/tests/GasModelSpec.hs
+++ b/tests/GasModelSpec.hs
@@ -131,7 +131,7 @@ runTest t = runGasUnitTests t run run
         writeIORef (_eeGas e) mempty
         res <- mockRun expr (e,s)
         gas <- readIORef (_eeGas e)
-        return ((microGasToGas gas,) <$> res)
+        return ((milliGasToGas gas,) <$> res)
       res' <- eitherDie (getDescription expr dbSetup) res
       return (res', st, gas)
     setupEnv' dbs = do

--- a/tests/GasModelSpec.hs
+++ b/tests/GasModelSpec.hs
@@ -128,10 +128,10 @@ runTest t = runGasUnitTests t run run
   where
     run expr dbSetup = do
       (res, (gas, st)) <- bracket (setupEnv' dbSetup) (gasSetupCleanup dbSetup) $ \(e,s) -> do
-        writeIORef (_eeGas e) 0
+        writeIORef (_eeGas e) mempty
         res <- mockRun expr (e,s)
         gas <- readIORef (_eeGas e)
-        return ((gas,) <$> res)
+        return ((microGasToGas gas,) <$> res)
       res' <- eitherDie (getDescription expr dbSetup) res
       return (res', st, gas)
     setupEnv' dbs = do


### PR DESCRIPTION
This is a change primarily to our _units_ of gas, wherein 1 `Gas` = 1000 `MilliGas`. With our current gas metering, we have 1 `Gas` = 2500 ns, thus, 1 `MilliGas` = 2.5 ns. 

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
