### PR TITLE
remove unnecessary traversals of enrichdynamic

### DIFF
--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -585,7 +585,8 @@ abstractBody :: Compile (Term Name) -> [Arg (Term Name)] -> Compile (Scope Int T
 abstractBody term args = abstractBody' args =<< bodyForm term
 
 abstractBody' :: [Arg (Term Name)] -> Term Name -> Compile (Scope Int Term Name)
-abstractBody' args body = traverse enrichDynamic $ abstract (`elemIndex` bNames) body
+abstractBody' args body =
+  (if M.null modRefArgs then pure else traverse enrichDynamic) $ abstract (`elemIndex` bNames) body
   where
     bNames = map arg2Name args
 


### PR DESCRIPTION
PR checklist:

* [x] Test coverage for the proposed changes
 Existing tests should cover the change.
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
 No, but there's no specific repl output to observe from this
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
Replay pending
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
