### PR TITLE
Fix unexpected free variable in FV

### DIFF
--- a/src-tool/Pact/Analyze/Translate.hs
+++ b/src-tool/Pact/Analyze/Translate.hs
@@ -44,8 +44,7 @@ import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import           Data.Traversable           (for)
 import           Data.Type.Equality         ((:~:) (Refl))
-import           Numeric.Natural            (Natural)
-import           GHC.TypeLits               (SomeSymbol(..), someSymbolVal, symbolVal)
+import           GHC.TypeLits hiding (SSymbol)
 
 import qualified Pact.Types.Info as P
 import           Pact.Types.Lang
@@ -1649,7 +1648,7 @@ translateNode astNode = withAstContext astNode $ case astNode of
     -- `a` encountered first, `b` will be consed on top of it, resulting in the
     -- variables coming out backwards.
     liftM2 (,) captureFreeVar captureFreeVar >>= \case
-      ((vida, varNamea, EType tya), (vidb, varNameb, EType tyb)) -> do
+      ((vidb, varNameb, EType tyb), (vida, varNamea, EType tya)) -> do
         Some aTy' a' <- translateNode a
         translateNode l >>= \case
           Some (SList listTy) l' -> do

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -4198,6 +4198,24 @@ spec = describe "analyze" $ do
         (typeof "foo"))
       |]
 
+  describe "nested application of higher-order functions (regression #1250)" $ do
+    expectVerified [text|
+        (defun child: bool (accParent: bool l: [integer])
+           (fold (lambda (acc:bool x:integer) (and (= x 0) acc)) accParent l))
+
+        (defun parent: bool ()
+           @model[(property (= result false))]
+           (fold (child) true [[1]]))
+     |]
+
+    expectVerified [text|
+        (defun child: [bool] (l : [integer])
+          (map (= 0) l))
+
+        (defun parent: [[bool]] ()
+          (map (child) [[1]]))
+     |]
+
   -- TODO: pending sbv unicode fix
   -- describe "unicode strings" $
   --   let code = [text|


### PR DESCRIPTION
Addresses #1250

This PR makes use of a stack of free variables to allow for nested application of higher-order functions such as `fold` or `map`.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [x] Confirm replay/back compat
* [x] Benchmark regressions
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
