### PR TITLE
Fix swapped type assignment in fold symeval

### DIFF
--- a/src-tool/Pact/Analyze/Eval/Core.hs
+++ b/src-tool/Pact/Analyze/Eval/Core.hs
@@ -402,8 +402,8 @@ evalCore (ListFold tya tyb (Open vid1 _ (Open vid2 _ f)) a bs)
   S _ bs' <- eval bs
   result <- bfoldrM listBound
     (\sbvb sbva -> fmap _sSbv $
-      withVar vid1 (mkAVal' sbvb) $
-        withVar vid2 (mkAVal' sbva) $
+      withVar vid1 (mkAVal' sbva) $
+        withVar vid2 (mkAVal' sbvb) $
           eval f)
     a' bs'
   pure $ sansProv result

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -4167,6 +4167,11 @@ spec = describe "analyze" $ do
         @model [(property (= result 115))]
         (fold (+) 0 [100 10 5]))
       |]
+    expectVerified [text|
+      (defun test:bool ()
+        @model[(property (= result false))]
+        (fold (lambda (p: bool curr:string) false) false [""]))
+      |]
 
   describe "and?" $ do
     expectVerified [text|


### PR DESCRIPTION
Fixes #1249. Also added a test where the accumulator and elements folded over have different types.

No feature flags since that's presumably not needed for FV stuff.

---
PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
