### PR TITLE
tweak the nix-shell for docs building

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # --- Jump into Nix Shell --- #
-nix-shell --pure -p python3 python38Packages.sphinx python38Packages.sphinx_rtd_theme pandoc perl --run "./work.sh"
+nix-shell --pure -p 'python38.withPackages (ps: [ps.sphinx ps.sphinx_rtd_theme])' -p pandoc -p perl --run "./work.sh"


### PR DESCRIPTION
PR checklist:

* [x] n/a Test coverage for the proposed changes
* [x] n/a PR description contains example output from repl interaction or a snippet from unit test output
* [x] n/a Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] n/a Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] n/a In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [x] n/a Confirm replay/back compat
* [x] n/a Benchmark regressions
* [x] n/a (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
