### PR TITLE
Package docs in nix flake

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # --- Jump into Nix Shell --- #
-nix-shell --pure -p python3 python38Packages.sphinx python38Packages.sphinx_rtd_theme pandoc perl --run "./work.sh"
+nix-shell --pure -p 'python38.withPackages (ps: [ps.sphinx ps.sphinx_rtd_theme])' -p pandoc -p perl --run "./work.sh"

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # --- Jump into Nix Shell --- #
-nix-shell --pure -p 'python38.withPackages (ps: [ps.sphinx ps.sphinx_rtd_theme])' -p pandoc -p perl --run "./work.sh"
+nix-shell --pure -p python3 python38Packages.sphinx python38Packages.sphinx_rtd_theme pandoc perl --run "./work.sh"

--- a/docs/work.sh
+++ b/docs/work.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # --- English Docs --- #
 cd en/

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,8 @@
         ];
         buildPhase = ''
           source ./work.sh
+        '';
+        installPhase = ''
           mkdir $out
           cp -r _build/* $out
         '';

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
                 zlib
                 z3
                 pkgconfig
-                python3 python3Packages.sphinx python3Packages.sphinx_rtd_theme
+                (python3.withPackages (ps: [ps.sphinx ps.sphinx_rtd_theme]))
                 pandoc perl
               ];
               # shell.crossPlatforms = p: [ p.ghcjs ];
@@ -43,6 +43,21 @@
       ];
     in flake // {
       packages.default = flake.packages."pact:exe:pact";
+
+      packages.docs = pkgs.stdenv.mkDerivation {
+        name = "pact-docs";
+        src = ./docs;
+        buildInputs = [
+          (pkgs.python3.withPackages (ps: [ps.sphinx ps.sphinx_rtd_theme]))
+          pkgs.pandoc
+          pkgs.perl
+        ];
+        buildPhase = ''
+          source ./work.sh
+          mkdir $out
+          cp -r _build/* $out
+        '';
+      };
 
       devShell = pkgs.haskellPackages.shellFor {
         buildInputs = with pkgs.haskellPackages; [


### PR DESCRIPTION
Add `.#docs` package to the nix flake. Flake users may build the docs and check their results like this:

```
nix build .#docs
cd result/html
python3 -m http.server 8002
```

Then browse to `localhost:8002` and click around.

This seems to only build the English version. I'm not sure of the details around the rest of our docs publishing process, presumably we could update that process to use `.#docs` in order to avoid depending on the impure `NIX_PATH` and enjoy more deterministic dependencies.

PR checklist:

* [x] n/a Test coverage for the proposed changes
* [x] n/a PR description contains example output from repl interaction or a snippet from unit test output
* [x] n/a Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] n/a Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] n/a In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [x] n/a Confirm replay/back compat
* [x] n/a Benchmark regressions
* [x] n/a (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
