### PR TITLE
use mtl >=2.3

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -42,9 +42,9 @@ allow-newer: *:base
 -- Patch merged into master (upcoming verison 10.0). We are currently using 9.2
 source-repository-package
   type: git
-  tag: b66e3a04c20f753213fe7e5115a95b3fe34109f9
+  tag: 3946a0e94470d7403a855dd60f8e54687ecc2b1d
   location: https://github.com/larskuhtz/sbv
-  --sha256: sha256-NQ00KGhu4IWeAry0r6m6FR/iCu/XboWtjOhbU+gtijU=
+  --sha256: 1msbz6525nmsywpm910jh23siil4qgn3rpsm52m8j6877r7v5zw3
 
 -- Servant is notoriously forcing outdated upper bounds onto its users.
 -- It is usually safe to just ignore those.
@@ -53,3 +53,6 @@ allow-newer: servant-server:*
 allow-newer: servant-client-core:*
 allow-newer: servant-client:*
 allow-newer: servant:*
+
+-- Required by trifecta (e.g. to allow mtl >=2.3)
+allow-newer: trifecta:*

--- a/pact.cabal
+++ b/pact.cabal
@@ -146,7 +146,7 @@ library
     Pact.Types.Typecheck
     Pact.Typechecker
     Pact.Utils.Servant
-  
+
   build-depends:
     , base >= 4.18.0.0
     , Decimal >=0.4.2
@@ -173,7 +173,7 @@ library
     , hashable >=1.4
     , lens >=4.14
     , megaparsec >=9
-    , mtl >=2.2.1
+    , mtl >=2.3
     , pact-json >=0.1
     , pact-time >=0.2
     , parsers >=0.12.4

--- a/src-ghc/Pact/ApiReq.hs
+++ b/src-ghc/Pact/ApiReq.hs
@@ -40,6 +40,7 @@ module Pact.ApiReq
 import Control.Applicative
 import Control.Error
 import Control.Lens hiding ((.=))
+import Control.Monad (foldM, forM, when)
 import Control.Monad.Catch
 import Control.Monad.State.Strict
 import Data.Aeson

--- a/src-ghc/Pact/Coverage.hs
+++ b/src-ghc/Pact/Coverage.hs
@@ -18,8 +18,8 @@ module Pact.Coverage
   , writeCovReport'
   ) where
 
+import Control.Monad (foldM, when)
 import Control.Monad.IO.Class
-import Control.Monad.State.Strict
 import Data.Foldable
 import Data.IORef
 import qualified Data.HashMap.Strict as HM

--- a/src-ghc/Pact/Main.hs
+++ b/src-ghc/Pact/Main.hs
@@ -31,6 +31,7 @@ import qualified Options.Applicative as O
 
 import Control.Applicative
 import Control.Lens
+import Control.Monad (forM, forM_)
 import Control.Monad.State.Strict
 
 import qualified Data.ByteString as BS

--- a/src-ghc/Pact/Server/ApiServer.hs
+++ b/src-ghc/Pact/Server/ApiServer.hs
@@ -29,6 +29,7 @@ import Prelude hiding (log)
 
 import Control.Concurrent
 import Control.Lens hiding ((<|))
+import Control.Monad (when)
 import Control.Monad.Reader
 import Control.Monad.Trans.Except
 

--- a/src-ghc/Pact/Server/PactService.hs
+++ b/src-ghc/Pact/Server/PactService.hs
@@ -15,7 +15,7 @@ module Pact.Server.PactService where
 
 import Prelude
 
-import Control.Monad.Except
+import Control.Monad (when)
 import Control.Monad.Reader
 import Data.Int (Int64)
 import Data.Maybe (fromMaybe)

--- a/src-tool/Pact/Analyze/Check.hs
+++ b/src-tool/Pact/Analyze/Check.hs
@@ -47,6 +47,7 @@ import           Control.Monad.Except
 import           Control.Monad.Morph        (generalize, hoist)
 import           Control.Monad.Reader       (runReaderT)
 import           Control.Monad.State.Strict (evalStateT)
+import           Control.Monad.Trans.Class  (lift)
 import           Data.Bifunctor             (first)
 import           Data.Either                (partitionEithers)
 import           Data.Foldable              (foldl')

--- a/src-tool/Pact/Analyze/Parse/Prop.hs
+++ b/src-tool/Pact/Analyze/Parse/Prop.hs
@@ -44,7 +44,7 @@ import           Control.Lens                 (at, toListOf, view, (%~), (&),
                                                (.~), (?~))
 import qualified Control.Lens                 as Lens
 import           Control.Monad                (unless, when)
-import           Control.Monad.Except         (MonadError (throwError))
+import           Control.Monad.Except         (runExcept, MonadError (throwError))
 import           Control.Monad.Reader         (asks, local, runReaderT)
 import           Control.Monad.State.Strict   (evalStateT)
 #if !MIN_VERSION_base(4,16,0)
@@ -875,7 +875,7 @@ expToProp tableEnv' genStart nameEnv idEnv consts propDefs ty body = do
     <- parseToPreProp genStart nameEnv propDefs body
   let env = PropCheckEnv (coerceQType <$> idEnv) tableEnv' Set.empty Set.empty
         preTypedPropDefs consts
-  _getEither $ runReaderT (checkPreProp ty preTypedBody) env
+  runExcept $ _getEither $ runReaderT (checkPreProp ty preTypedBody) env
 
 inferProp
   :: TableEnv
@@ -898,7 +898,7 @@ inferProp tableEnv' genStart nameEnv idEnv consts propDefs body = do
     <- parseToPreProp genStart nameEnv propDefs body
   let env = PropCheckEnv (coerceQType <$> idEnv) tableEnv' Set.empty Set.empty
         preTypedPropDefs consts
-  _getEither $ runReaderT (inferPreProp preTypedBody) env
+  runExcept $ _getEither $ runReaderT (inferPreProp preTypedBody) env
 
 -- | Parse both a property body and defined properties from `Exp` to `PreProp`.
 parseToPreProp

--- a/src-tool/Pact/Analyze/Parse/Types.hs
+++ b/src-tool/Pact/Analyze/Parse/Types.hs
@@ -12,7 +12,7 @@ module Pact.Analyze.Parse.Types where
 
 import           Control.Applicative        (Alternative)
 import           Control.Lens               (makeLenses, (<&>))
-import           Control.Monad.Except       (MonadError (throwError))
+import           Control.Monad.Except       (Except, MonadError (throwError))
 import           Control.Monad.Reader       (ReaderT)
 import           Control.Monad.State.Strict (StateT)
 import qualified Data.HashMap.Strict        as HM
@@ -154,7 +154,7 @@ data PropCheckEnv = PropCheckEnv
   , _localVars         :: HM.HashMap Text EProp
   }
 
-newtype EitherFail e a = EitherFail { _getEither :: Either e a }
+newtype EitherFail e a = EitherFail { _getEither :: Except e a }
     deriving (Show, Eq, Ord, Functor, Applicative, Alternative, Monad, MonadError e)
 
 type ParseEnv = Map Text VarId

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -59,6 +59,7 @@ import System.FilePath
 import Control.Concurrent
 import Control.Exception.Safe
 import Control.Lens hiding (op)
+import Control.Monad (foldM, forever, forM, forM_, when, void)
 import Control.Monad.State.Strict
 
 import qualified Data.Aeson as A

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -25,6 +25,7 @@ import Control.Arrow ((&&&))
 import Control.Concurrent.MVar
 import Control.Lens
 import Control.Exception.Safe
+import Control.Monad (foldM, forM, when)
 import Control.Monad.Reader
 import Control.Monad.State.Strict (get,put)
 

--- a/src/Pact/Types/Logger.hs
+++ b/src/Pact/Types/Logger.hs
@@ -15,6 +15,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as M
 import Data.Default
 import GHC.Generics
+import Control.Monad (forM_, when)
 import Control.Monad.IO.Class
 import Control.Monad.Reader
 import Prelude hiding (log)

--- a/src/Pact/Types/Purity.hs
+++ b/src/Pact/Types/Purity.hs
@@ -25,7 +25,6 @@ module Pact.Types.Purity
 
 import Control.Concurrent.MVar
 import Control.Monad.Catch
-import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
 import Data.Aeson hiding (Object)

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -66,7 +66,7 @@ module Pact.Types.Runtime
 import Control.Arrow ((&&&))
 import Control.Concurrent.MVar
 import Control.Lens hiding ((.=),DefName, elements)
-import Control.Monad.Except
+import Control.Monad (void)
 import Control.Exception.Safe
 import Control.Monad.Reader
 import Control.Monad.State.Strict

--- a/src/Pact/Types/SigData.hs
+++ b/src/Pact/Types/SigData.hs
@@ -22,7 +22,7 @@ module Pact.Types.SigData
   ) where
 
 import Control.Error
-import Control.Monad.State.Strict
+import Control.Monad (join)
 import Data.Aeson
 import Data.Bifunctor
 import qualified Data.HashMap.Strict as HM

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -8,6 +8,7 @@ module PactContinuationSpec (spec) where
 
 import qualified Control.Exception as Exception
 import Control.Lens hiding ((.=))
+import Control.Monad (forM_)
 import Control.Monad.Reader
 import Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL8

--- a/tests/PactTestsSpec.hs
+++ b/tests/PactTestsSpec.hs
@@ -5,6 +5,7 @@ module PactTestsSpec (spec) where
 import Test.Hspec
 
 import Control.Concurrent
+import Control.Monad (forM_)
 import Control.Monad.State.Strict
 import Control.Lens
 import Data.Text(Text)

--- a/tests/RemoteVerifySpec.hs
+++ b/tests/RemoteVerifySpec.hs
@@ -9,6 +9,7 @@ module RemoteVerifySpec (spec) where
 import Test.Hspec
 
 import Control.Lens
+import Control.Monad ((>=>))
 import Control.Monad.State.Strict
 import Control.Monad.Trans.Except
 


### PR DESCRIPTION
Switch to mtl >=2.3. This is a prerequisite for supporting sbv-10.

The code changes as well as the update of the sbv pin are due to the following changes:

* mtl modules do not re-export Control.Monad any more
* Either is not an instance of Alternative any more

[to the best of my knowledge nothing of the following applies to this PR]

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
