### PR TITLE
Vendor sources of prettyprinter-1.6.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,28 +5,13 @@ constraints: sbv <10
 
 -- these upper bounds are required in order to not break payload validation in chainweb
 constraints: base16-bytestring <1
-constraints: prettyprinter <1.6.1
 constraints: base64-bytestring <1.1
 
 allow-newer: base64-bytestring:*
 allow-newer: base16-bytestring:*
-allow-newer: prettyprinter:*
 
 -- test upper bounds
 constraints: hspec-golden <0.2,
-
--- The following fork provides trifecta-2.`1.1.1 which is compatible with
--- hashable >=1.4 and prettyprinter <1.7
---
--- trifeta >=2.1.2 requires a prettyprinter >=1.7, which isn't supported by
--- pact (because it would break mainnet replays). trifecta ==2.1.1 does not
--- support hashable >=1.4.
---
-source-repository-package
-  type: git
-  tag: f991ffb74a1a1ab86f14e751d7c4f4ba549785b3
-  location: https://github.com/hackage-package-forks/trifecta
-  --sha256: sha256-m+IplwZ9DxJt6Mzkq961BzgiboHJul6w1uwDUqXnljo=
 
 source-repository-package
   type: git
@@ -34,10 +19,13 @@ source-repository-package
   location: https://github.com/kadena-io/pact-json
   --sha256: sha256-ZWbAId0JBaxDsYhwcYUyw04sjYstXyosSCenzOvUxsQ=
 
--- Required for GHC-9.6
-
+-- These packages are tightly bundled with GHC. The rules ensure that
+-- our builds use the version that ships with the GHC version that is
+-- used for the build.
+--
 allow-newer: *:template-haskell
 allow-newer: *:base
+allow-newer: *:ghc-prim
 
 -- Patch merged into master (upcoming verison 10.0). We are currently using 9.2
 source-repository-package
@@ -56,3 +44,7 @@ allow-newer: servant:*
 
 -- Required by trifecta (e.g. to allow mtl >=2.3)
 allow-newer: trifecta:*
+
+-- servant-0.20 does not yet support aeson-2.2
+--
+constraints: aeson <2.2

--- a/pact.cabal
+++ b/pact.cabal
@@ -47,6 +47,28 @@ flag tests-in-lib
   manual:      True
 
 -- -------------------------------------------------------------------------- --
+-- Internal: prettyprinter-1.6.0 and prettyprinter-ansi-terminal-1.1.2
+
+library pact-prettyprinter
+  hs-source-dirs: vendored/prettyprinter-1.6.0/src
+  default-language: Haskell2010
+  exposed-modules:
+    Data.Text.Prettyprint.Doc
+    Data.Text.Prettyprint.Doc.Internal
+    Data.Text.Prettyprint.Doc.Render.String
+    Data.Text.Prettyprint.Doc.Render.Terminal
+    Data.Text.Prettyprint.Doc.Render.Text
+    Data.Text.Prettyprint.Doc.Render.Util.Panic
+    Data.Text.Prettyprint.Doc.Render.Util.StackMachine
+    Data.Text.Prettyprint.Doc.Symbols.Ascii
+    Data.Text.Prettyprint.Doc.Compat
+  build-depends:
+    , base >= 4.5 && < 5
+    , text >= 1.2
+    , ansi-terminal >=0.4
+    , prettyprinter >= 1.7
+
+-- -------------------------------------------------------------------------- --
 -- Pact library
 
 library
@@ -148,6 +170,7 @@ library
     Pact.Utils.Servant
 
   build-depends:
+    , pact-prettyprinter
     , base >= 4.18.0.0
     , Decimal >=0.4.2
     , QuickCheck >=2.12.6.1
@@ -177,8 +200,6 @@ library
     , pact-json >=0.1
     , pact-time >=0.2
     , parsers >=0.12.4
-    , prettyprinter >=1.2
-    , prettyprinter-ansi-terminal >=1.1
     , quickcheck-instances >=0.3
     , reflection
     , scientific >= 0.3

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -48,6 +48,7 @@ import qualified Data.Set as S
 import Data.String
 import Data.Text (Text,unpack, pack)
 import Data.Text.Encoding (encodeUtf8, decodeUtf8)
+import Data.Text.Prettyprint.Doc.Compat (docToInternal)
 import qualified Data.Vector as V
 
 import Text.Megaparsec as MP
@@ -724,7 +725,7 @@ _compileF :: FilePath -> IO (Either PactError [Term Name])
 _compileF f = _parseF f >>= _compile id
 
 handleParseError :: TF.Result a -> IO a
-handleParseError (TF.Failure f) = putDoc (TF._errDoc f) >> error "parseFailed"
+handleParseError (TF.Failure f) = putDoc (docToInternal $ TF._errDoc f) >> error "parseFailed"
 handleParseError (TF.Success a) = return a
 
 _compileWith :: Compile a -> (ParseState CompileState -> ParseState CompileState) ->
@@ -768,7 +769,7 @@ _compileFile :: FilePath -> IO [Term Name]
 _compileFile f = do
     p <- _parseF f
     rs <- case p of
-            (TF.Failure e) -> putDoc (TF._errDoc e) >> error "Parse failed"
+            (TF.Failure e) -> putDoc (docToInternal $ TF._errDoc e) >> error "Parse failed"
             (TF.Success (es,s)) -> return $ map (compile def s) es
     case sequence rs of
       Left e -> throwIO $ userError (show e)

--- a/src/Pact/Repl.hs
+++ b/src/Pact/Repl.hs
@@ -73,6 +73,7 @@ import qualified Data.Map.Strict as M
 import Data.Monoid (appEndo)
 import Data.Text (Text, pack, unpack)
 import Data.Text.Encoding (encodeUtf8, decodeUtf8)
+import Data.Text.Prettyprint.Doc.Compat (docToInternal)
 import Data.Foldable(traverse_)
 
 import Text.Trifecta as TF hiding (line,err,try,newline)
@@ -201,7 +202,7 @@ getDelta = do
 handleParse :: TF.Result [Exp Parsed] -> ([Exp Parsed] -> Repl (Either String a)) -> Repl (Either String a)
 handleParse (TF.Failure e) _ = do
   mode <- use rMode
-  let errDoc = _errDoc e
+  let errDoc = docToInternal (_errDoc e)
   outStrLn HErr $ renderPrettyString' (colors mode) $ unAnnotate errDoc
   return $ Left $ renderCompactString' $ unAnnotate $ errDoc
 handleParse (TF.Success es) a = a es

--- a/src/Pact/Types/Pretty.hs
+++ b/src/Pact/Types/Pretty.hs
@@ -73,7 +73,7 @@ import           Data.Text.Prettyprint.Doc
   encloseSep, space, nest, align, hardline, tupled, indent, equals, reAnnotate,
   reAnnotateS, fillSep)
 import qualified Data.Text.Prettyprint.Doc as PP
-import qualified Data.Text.Prettyprint.Doc.Internal.Type as PP
+import qualified Data.Text.Prettyprint.Doc.Internal as PP
 import qualified Data.Text.Prettyprint.Doc.Render.String as PP
 import           Data.Text.Prettyprint.Doc.Render.Terminal
   (color, Color(..), AnsiStyle)

--- a/vendored/prettyprinter-1.6.0/LICENSE.md
+++ b/vendored/prettyprinter-1.6.0/LICENSE.md
@@ -1,0 +1,23 @@
+Copyright 2008, Daan Leijen and Max Bolingbroke, 2016 David Luposchainsky. All
+rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  - Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+  - Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+This software is provided by the copyright holders "as is" and any express or
+implied warranties, including, but not limited to, the implied warranties of
+merchantability and fitness for a particular purpose are disclaimed. In no event
+shall the copyright holders be liable for any direct, indirect, incidental,
+special, exemplary, or consequential damages (including, but not limited to,
+procurement of substitute goods or services; loss of use, data, or profits; or
+business interruption) however caused and on any theory of liability, whether in
+contract, strict liability, or tort (including negligence or otherwise) arising
+in any way out of the use of this software, even if advised of the possibility
+of such damage.

--- a/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc.hs
+++ b/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc.hs
@@ -1,0 +1,335 @@
+-- |
+-- Module      :  Data.Text.Prettyprint.Doc
+-- Copyright   :  Daan Leijen (c) 2000, http://www.cs.uu.nl/~daan
+--                Max Bolingbroke (c) 2008, http://blog.omega-prime.co.uk
+--                David Luposchainsky (c) 2016, http://github.com/quchen
+-- License     :  BSD-style (see the file LICENSE.md)
+-- Maintainer  :  David Luposchainsky <dluposchainsky (λ) google>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- = Overview
+--
+-- This module defines a prettyprinter to format text in a flexible and
+-- convenient way. The idea is to combine a 'Doc'ument out of many small
+-- components, then using a layouter to convert it to an easily renderable
+-- 'SimpleDocStream', which can then be rendered to a variety of formats, for
+-- example plain 'Text'.
+--
+-- The documentation consists of several parts:
+--
+--   1. Just below is some general information about the library.
+--   2. The actual library with extensive documentation and examples
+--   3. Migration guide for users familiar with (ansi-)wl-pprint
+--
+-- == Starting out
+--
+-- As a reading list for starters, some of the most commonly used functions in
+-- this module include '<>', 'hsep', '<+>', 'vsep', 'align', 'hang'. These cover
+-- many use cases already, and many other functions are variations or
+-- combinations of these.
+--
+-- = Simple example
+--
+-- Let’s prettyprint a simple Haskell type definition. First, intersperse @->@
+-- and add a leading @::@,
+--
+-- >>> let prettyType = align . sep . zipWith (<+>) ("::" : repeat "->")
+--
+-- The 'sep' function is one way of concatenating documents, there are multiple
+-- others, e.g. 'vsep', 'cat' and 'fillSep'. In our case, 'sep' space-separates
+-- all entries if there is space, and newlines if the remaining line is too
+-- short.
+--
+-- Second, prepend the name to the type,
+--
+-- >>> let prettyDecl n tys = pretty n <+> prettyType tys
+--
+-- Now we can define a document that contains some type signature:
+--
+-- >>> let doc = prettyDecl "example" ["Int", "Bool", "Char", "IO ()"]
+--
+-- This document can now be printed, and it automatically adapts to available
+-- space. If the page is wide enough (80 characters in this case), the
+-- definitions are space-separated,
+--
+-- >>> putDocW 80 doc
+-- example :: Int -> Bool -> Char -> IO ()
+--
+-- If we narrow the page width to only 20 characters, the /same document/
+-- renders vertically aligned:
+--
+-- >>> putDocW 20 doc
+-- example :: Int
+--         -> Bool
+--         -> Char
+--         -> IO ()
+--
+-- Speaking of alignment, had we not used 'align', the @->@ would be at the
+-- beginning of each line, and not beneath the @::@.
+--
+-- The 'Data.Text.Prettyprint.Doc.Util.putDocW' renderer used here is from
+-- "Data.Text.Prettyprint.Doc.Util".
+--
+-- = General workflow
+--
+-- @
+-- ╔══════════╗
+-- ║          ║                         ╭────────────────────╮
+-- ║          ║                         │ 'vsep', 'pretty', '<+>', │
+-- ║          ║                         │ 'nest', 'align', …     │
+-- ║          ║                         ╰─────────┬──────────╯
+-- ║          ║                                   │
+-- ║  Create  ║                                   │
+-- ║          ║                                   │
+-- ║          ║                                   ▽
+-- ║          ║                         ╭───────────────────╮
+-- ║          ║                         │        'Doc'        │
+-- ╠══════════╣                         │  (rich document)  │
+-- ║          ║                         ╰─────────┬─────────╯
+-- ║          ║                                   │
+-- ║          ║                                   │ Layout algorithms
+-- ║  Layout  ║                                   │ e.g. 'layoutPretty'
+-- ║          ║                                   ▽
+-- ║          ║                         ╭───────────────────╮
+-- ║          ║                         │  'SimpleDocStream'  │
+-- ╠══════════╣                         │ (simple document) │
+-- ║          ║                         ╰─────────┬─────────╯
+-- ║          ║                                   │
+-- ║          ║                                   ├─────────────────────────────╮
+-- ║          ║                                   │                             │ 'Data.Text.Prettyprint.Doc.Render.Util.SimpleDocTree.treeForm'
+-- ║          ║                                   │                             ▽
+-- ║          ║                                   │                     ╭───────────────╮
+-- ║          ║                                   │                     │ 'Data.Text.Prettyprint.Doc.Render.Util.SimpleDocTree.SimpleDocTree' │
+-- ║  Render  ║                                   │                     ╰───────┬───────╯
+-- ║          ║                                   │                             │
+-- ║          ║               ╭───────────────────┼─────────────────╮  ╭────────┴────────╮
+-- ║          ║               │                   │                 │  │                 │
+-- ║          ║               ▽                   ▽                 ▽  ▽                 ▽
+-- ║          ║       ╭───────────────╮   ╭───────────────╮   ╭───────────────╮   ╭───────────────╮
+-- ║          ║       │ ANSI terminal │   │  Plain 'Text'   │   │ other/custom  │   │     HTML      │
+-- ║          ║       ╰───────────────╯   ╰───────────────╯   ╰───────────────╯   ╰───────────────╯
+-- ║          ║
+-- ╚══════════╝
+-- @
+--
+-- = How the layout works
+--
+-- There are two key concepts to laying a document out: the available width, and
+-- 'group'ing.
+--
+-- == Available width
+--
+-- The page has a certain maximum width, which the layouter tries to not exceed,
+-- by inserting line breaks where possible. The functions given in this module
+-- make it fairly straightforward to specify where, and under what
+-- circumstances, such a line break may be inserted by the layouter, for example
+-- via the 'sep' function.
+--
+-- There is also the concept of /ribbon width/. The ribbon is the part of a line
+-- that is printed, i.e. the line length without the leading indentation. The
+-- layouters take a ribbon fraction argument, which specifies how much of a line
+-- should be filled before trying to break it up. A ribbon width of 0.5 in a
+-- document of width 80 will result in the layouter to try to not exceed @0.5*80 =
+-- 40@ (ignoring current indentation depth).
+--
+-- == Grouping
+--
+-- A document can be 'group'ed, which tells the layouter that it should attempt
+-- to collapse it to a single line. If the result does not fit within the
+-- constraints (given by page and ribbon widths), the document is rendered
+-- unaltered. This allows fallback definitions, so that we get nice results even
+-- when the original document would exceed the layout constraints.
+--
+-- = Things the prettyprinter /cannot/ do
+--
+-- Due to how the Wadler/Leijen algorithm is designed, a couple of things are
+-- unsupported right now, with a high possibility of having no sensible
+-- implementation without significantly changing the layout algorithm. In
+-- particular, this includes
+--
+--   * Leading symbols instead of just spaces for indentation, as used by the
+--     Linux @tree@ tool for example
+--   * Multi-column layouts, in particular tables with multiple cells of equal
+--     width adjacent to each other
+--
+-- = Some helpful tips
+--
+-- == Which kind of annotation should I use?
+--
+-- __Summary:__ Use semantic annotations for @'Doc'@, and after layouting map to
+-- backend-specific ones.
+--
+-- For example, suppose you want to prettyprint some programming language code.
+-- If you want keywords to be red, you should annotate the @'Doc'@ with a type
+-- that has a 'Keyword' field (without any notion of color), and then after
+-- layouting convert the annotations to map @'Keyword'@ to e.g. @'Red'@ (using
+-- @'reAnnotateS'@). The alternative that I /do not/ recommend is directly
+-- annotating the @'Doc'@ with 'Red'.
+--
+-- While both versions would superficially work equally well and would create
+-- identical output, the recommended way has two significant advantages:
+-- modularity and extensibility.
+--
+-- /Modularity:/ To change the color of keywords later, you have to touch one
+-- point, namely the mapping in @'reAnnotateS'@, where @'Keyword'@ is mapped to
+-- 'Red'. If you have @'annotate Red …'@ everywher, you’ll have to do a full
+-- text replacement, producing a large diff and touching lots of places for a
+-- very small change.
+--
+-- /Extensibility:/ Adding a different backend in the recommended version is
+-- simply adding another @'reAnnotateS'@ to convert the @'Doc'@ annotation to
+-- something else. On the other hand, if you have @'Red'@ as an annotation in
+-- the @'Doc'@ already and the other backend does not support anything red
+-- (think of plain text or a website where red doesn’t work well with the rest
+-- of the style), you’ll have to worry about what to map »redness« to, which has
+-- no canonical answer. Should it be omitted? What does »red« mean anyway –
+-- maybe keywords and variables are red, and you want to change only the color
+-- of variables?
+module Data.Text.Prettyprint.Doc (
+    -- * Documents
+    Doc,
+
+    -- * Basic functionality
+    Pretty(..),
+    viaShow, unsafeViaShow,
+    emptyDoc, nest, line, line', softline, softline', hardline, group, flatAlt,
+
+    -- * Alignment functions
+    --
+    -- | The functions in this section cannot be described by Wadler's original
+    -- functions. They align their output relative to the current output
+    -- position - in contrast to @'nest'@ which always aligns to the current
+    -- nesting level. This deprives these functions from being \'optimal\'. In
+    -- practice however they prove to be very useful. The functions in this
+    -- section should be used with care, since they are more expensive than the
+    -- other functions. For example, @'align'@ shouldn't be used to pretty print
+    -- all top-level declarations of a language, but using @'hang'@ for let
+    -- expressions is fine.
+    align, hang, indent, encloseSep, list, tupled,
+
+    -- * Binary functions
+    (<>), (<+>),
+
+    -- * List functions
+
+    -- | The 'sep' and 'cat' functions differ in one detail: when 'group'ed, the
+    -- 'sep's replace newlines wich 'space's, while the 'cat's simply remove
+    -- them. If you're not sure what you want, start with the 'sep's.
+
+    concatWith,
+
+    -- ** 'sep' family
+    --
+    -- | When 'group'ed, these will replace newlines with spaces.
+    hsep, vsep, fillSep, sep,
+    -- ** 'cat' family
+    --
+    -- | When 'group'ed, these will remove newlines.
+    hcat, vcat, fillCat, cat,
+    -- ** Others
+    punctuate,
+
+    -- * Reactive/conditional layouts
+    --
+    -- | Lay documents out differently based on current position and the page
+    -- layout.
+    column, nesting, width, pageWidth,
+
+    -- * Filler functions
+    --
+    -- | Fill up available space
+    fill, fillBreak,
+
+    -- * General convenience
+    --
+    -- | Useful helper functions.
+    plural, enclose, surround,
+
+    -- * Bracketing functions
+    --
+    -- | Enclose documents in common ways.
+    squotes, dquotes, parens, angles, brackets, braces,
+
+    -- * Named characters
+    --
+    -- | Convenience definitions for common characters
+    lparen, rparen, langle, rangle, lbrace, rbrace, lbracket, rbracket, squote,
+    dquote, semi, colon, comma, space, dot, slash, backslash, equals, pipe,
+
+    -- ** Annotations
+    annotate,
+    unAnnotate,
+    reAnnotate,
+    alterAnnotations,
+    unAnnotateS,
+    reAnnotateS,
+    alterAnnotationsS,
+
+    -- * Optimization
+    --
+    -- Render documents faster
+    fuse, FusionDepth(..),
+
+    -- * Layout
+    --
+    -- | Laying a 'Doc'ument out produces a straightforward 'SimpleDocStream'
+    -- based on parameters such as page width and ribbon size, by evaluating how
+    -- a 'Doc' fits these constraints the best. There are various ways to render
+    -- a 'SimpleDocStream'. For the common case of rendering a 'SimpleDocStream'
+    -- as plain 'Text' take a look at "Data.Text.Prettyprint.Doc.Render.Text".
+    SimpleDocStream(..),
+    PageWidth(..), LayoutOptions(..), defaultLayoutOptions,
+    layoutPretty, layoutCompact, layoutSmart,
+    removeTrailingWhitespace,
+
+    -- * Migration guide
+    --
+    -- $migration
+) where
+
+
+
+import Data.Text.Prettyprint.Doc.Internal
+import Data.Text.Prettyprint.Doc.Symbols.Ascii
+
+-- $setup
+--
+-- (Definitions for the doctests)
+--
+-- >>> :set -XOverloadedStrings
+-- >>> import Data.Text.Prettyprint.Doc.Render.Text
+-- >>> import Data.Text.Prettyprint.Doc.Util
+
+
+
+-- $migration
+--
+-- There are 3 main ways to migrate:
+--
+--   1. Direct: just replace the previous package and fix the errors
+--   2. Using a drop-in replacement mimicing the API of the former module, see
+--      the @prettyprinter-compat-<former package>@ packages
+--   3. Using a converter from the old @Doc@ type to the new one, see the
+--      @prettyprinter-convert-<former package>@ packages
+--
+-- If you're already familiar with (ansi-)wl-pprint, you'll recognize many
+-- functions in this module, and they work just the same way. However, a couple
+-- of definitions are missing:
+--
+--   - @char@, @string@, @double@, … – these are all special cases of the
+--     overloaded @'pretty'@ function.
+--   - @\<$>@, @\<$$>@, @\</>@, @\<//>@ are special cases of
+--     @'vsep'@, @'vcat'@, @'fillSep'@, @'fillCat'@ with only two documents.
+--   - If you need 'String' output, use the backends in the
+--     "Data.Text.Prettyprint.Doc.Render.String" module.
+--   - The /display/ functions are moved to the rendering submodules, for
+--     example conversion to plain 'Text' is in the
+--     "Data.Text.Prettyprint.Doc.Render.Text" module.
+--   - The /render/ functions are called /layout/ functions.
+--   - @SimpleDoc@ was renamed to @'SimpleDocStream'@, in order to make it
+--     clearer in the presence of @SimpleDocTree@.
+--   - Instead of providing an own colorization function for each
+--     color\/intensity\/layer combination, they have been combined in 'color',
+--     'colorDull', 'bgColor', and 'bgColorDull' functions, which can be found
+--     in the ANSI terminal specific @prettyprinter-ansi-terminal@ package.

--- a/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Compat.hs
+++ b/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Compat.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module: Data.Text.Prettyprint.Doc.Compat
+-- Copyright: Copyright © 2023 Kadena LLC.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lars@kadena.io>
+-- Stability: experimental
+--
+-- Translate between Doc values of the internal (vendored) prettyprinter
+-- implementation and of recent versions (>=1.7) of prettyprinter package on
+-- Hackage.
+--
+module Data.Text.Prettyprint.Doc.Compat
+( docToInternal
+, docFromInternal
+) where
+
+import "prettyprinter" Prettyprinter.Internal qualified as PP
+import Data.Text.Prettyprint.Doc.Internal
+
+pageWidthFromInternal :: PageWidth -> PP.PageWidth
+pageWidthFromInternal (AvailablePerLine a b) = PP.AvailablePerLine a b
+pageWidthFromInternal Unbounded = PP.Unbounded
+
+pageWidthToInternal :: PP.PageWidth -> PageWidth
+pageWidthToInternal (PP.AvailablePerLine a b) = AvailablePerLine a b
+pageWidthToInternal PP.Unbounded = Unbounded
+
+docFromInternal :: Doc a -> PP.Doc a
+docFromInternal Fail = PP.Fail
+docFromInternal Empty = PP.Empty
+docFromInternal (Char a) = PP.Char a
+docFromInternal (Text a b) = PP.Text a b
+docFromInternal Line = PP.Line
+docFromInternal (FlatAlt a b) = PP.FlatAlt (docFromInternal a) (docFromInternal b)
+docFromInternal (Cat a b) = PP.Cat (docFromInternal a) (docFromInternal b)
+docFromInternal (Nest a b) = PP.Nest a (docFromInternal b)
+docFromInternal (Union a b) = PP.Union (docFromInternal a) (docFromInternal b)
+docFromInternal (Column a) = PP.Column $ docFromInternal <$> a
+docFromInternal (WithPageWidth a) = PP.WithPageWidth (docFromInternal <$> a . pageWidthToInternal)
+docFromInternal (Nesting a) = PP.Nesting (docFromInternal <$> a)
+docFromInternal (Annotated a b) = PP.Annotated a (docFromInternal b)
+
+docToInternal :: PP.Doc a -> Doc a
+docToInternal PP.Fail = Fail
+docToInternal PP.Empty = Empty
+docToInternal (PP.Char a) = Char a
+docToInternal (PP.Text a b) = Text a b
+docToInternal PP.Line = Line
+docToInternal (PP.FlatAlt a b) = FlatAlt (docToInternal a) (docToInternal b)
+docToInternal (PP.Cat a b) = Cat (docToInternal a) (docToInternal b)
+docToInternal (PP.Nest a b) = Nest a (docToInternal b)
+docToInternal (PP.Union a b) = Union (docToInternal a) (docToInternal b)
+docToInternal (PP.Column a) = Column (docToInternal <$> a)
+docToInternal (PP.WithPageWidth a) = WithPageWidth (docToInternal <$> a . pageWidthFromInternal)
+docToInternal (PP.Nesting a) = Nesting (docToInternal <$> a)
+docToInternal (PP.Annotated a b) = Annotated a (docToInternal b)

--- a/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Internal.hs
+++ b/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Internal.hs
@@ -1,0 +1,1908 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DefaultSignatures   #-}
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | __Warning: internal module!__ This means that the API may change
+-- arbitrarily between versions without notice. Depending on this module may
+-- lead to unexpected breakages, so proceed with caution!
+--
+-- For a stable API, use the non-internal modules. For the special case of
+-- writing adaptors to this library’s @'Doc'@ type, see
+-- "Data.Text.Prettyprint.Doc.Internal.Type".
+module Data.Text.Prettyprint.Doc.Internal where
+
+
+
+import           Control.Applicative
+import           Data.Int
+import           Data.List.NonEmpty  (NonEmpty (..))
+import           Data.Maybe
+import           Data.String         (IsString (..))
+import           Data.Text           (Text)
+import qualified Data.Text           as T
+import qualified Data.Text.Lazy      as Lazy
+import           Data.Typeable       (Typeable)
+import           Data.Void
+import           Data.Word
+import           GHC.Generics        (Generic)
+
+-- Depending on the Cabal file, this might be from base, or for older builds,
+-- from the semigroups package.
+import Data.Semigroup
+
+import Numeric.Natural
+
+import Data.Functor.Identity
+
+import Data.Text.Prettyprint.Doc.Render.Util.Panic
+
+
+
+-- | The abstract data type @'Doc' ann@ represents pretty documents that have
+-- been annotated with data of type @ann@.
+--
+-- More specifically, a value of type @'Doc'@ represents a non-empty set of
+-- possible layouts of a document. The layout functions select one of these
+-- possibilities, taking into account things like the width of the output
+-- document.
+--
+-- The annotation is an arbitrary piece of data associated with (part of) a
+-- document. Annotations may be used by the rendering backends in order to
+-- display output differently, such as
+--
+--   - color information (e.g. when rendering to the terminal)
+--   - mouseover text (e.g. when rendering to rich HTML)
+--   - whether to show something or not (to allow simple or detailed versions)
+--
+-- The simplest way to display a 'Doc' is via the 'Show' class.
+--
+-- >>> putStrLn (show (vsep ["hello", "world"]))
+-- hello
+-- world
+data Doc ann =
+
+    -- | Occurs when flattening a line. The layouter will reject this document,
+    -- choosing a more suitable rendering.
+    Fail
+
+    -- | The empty document; conceptually the unit of 'Cat'
+    | Empty
+
+    -- | invariant: not '\n'
+    | Char !Char
+
+    -- | Invariants: at least two characters long, does not contain '\n'. For
+    -- empty documents, there is @Empty@; for singleton documents, there is
+    -- @Char@; newlines should be replaced by e.g. @Line@.
+    --
+    -- Since the frequently used 'T.length' of 'Text' is /O(length)/, we cache
+    -- it in this constructor.
+    | Text !Int !Text
+
+    -- | Hard line break
+    | Line
+
+    -- | Lay out the first 'Doc', but when flattened (via 'group'), fall back to
+    -- the second. The flattened version should in general be higher and
+    -- narrower than the fallback.
+    | FlatAlt (Doc ann) (Doc ann)
+
+    -- | Concatenation of two documents
+    | Cat (Doc ann) (Doc ann)
+
+    -- | Document indented by a number of columns
+    | Nest !Int (Doc ann)
+
+    -- | Invariant: The first lines of first document should be longer than the
+    -- first lines of the second one, so the layout algorithm can pick the one
+    -- that fits best. Used to implement layout alternatives for 'group'.
+    | Union (Doc ann) (Doc ann)
+
+    -- | React on the current cursor position, see 'column'
+    | Column (Int -> Doc ann)
+
+    -- | React on the document's width, see 'pageWidth'
+    | WithPageWidth (PageWidth -> Doc ann)
+
+    -- | React on the current nesting level, see 'nesting'
+    | Nesting (Int -> Doc ann)
+
+    -- | Add an annotation to the enclosed 'Doc'. Can be used for example to add
+    -- styling directives or alt texts that can then be used by the renderer.
+    | Annotated ann (Doc ann)
+    deriving (Generic, Typeable)
+
+-- |
+-- @
+-- x '<>' y = 'hcat' [x, y]
+-- @
+--
+-- >>> "hello" <> "world" :: Doc ann
+-- helloworld
+instance Semigroup (Doc ann) where
+    (<>) = Cat
+    sconcat (x :| xs) = hcat (x:xs)
+
+-- |
+-- @
+-- 'mempty' = 'emptyDoc'
+-- 'mconcat' = 'hcat'
+-- @
+--
+-- >>> mappend "hello" "world" :: Doc ann
+-- helloworld
+instance Monoid (Doc ann) where
+    mempty = emptyDoc
+    mappend = (<>)
+    mconcat = hcat
+
+-- | >>> pretty ("hello\nworld")
+-- hello
+-- world
+--
+-- This instance uses the 'Pretty' 'Text' instance, and uses the same newline to
+-- 'line' conversion.
+instance IsString (Doc ann) where
+    fromString = pretty . T.pack
+
+-- | Alter the document’s annotations.
+--
+-- This instance makes 'Doc' more flexible (because it can be used in
+-- 'Functor'-polymorphic values), but @'fmap'@ is much less readable compared to
+-- using @'reAnnotate'@ in code that only works for @'Doc'@ anyway. Consider
+-- using the latter when the type does not matter.
+instance Functor Doc where
+    fmap = reAnnotate
+
+-- | Overloaded conversion to 'Doc'.
+--
+-- Laws:
+--
+--   1. output should be pretty. :-)
+class Pretty a where
+
+    -- | >>> pretty 1 <+> pretty "hello" <+> pretty 1.234
+    -- 1 hello 1.234
+    pretty :: a -> Doc ann
+
+    default pretty :: Show a => a -> Doc ann
+    pretty = viaShow
+
+    -- | @'prettyList'@ is only used to define the @instance
+    -- 'Pretty' a => 'Pretty' [a]@. In normal circumstances only the @'pretty'@
+    -- function is used.
+    --
+    -- >>> prettyList [1, 23, 456]
+    -- [1, 23, 456]
+    prettyList :: [a] -> Doc ann
+    prettyList = align . list . map pretty
+
+    {-# MINIMAL pretty #-}
+
+-- $
+-- Issue #67: Nested lists were not aligned with »pretty«, leading to non-pretty
+-- output, violating the Pretty class law.
+--
+-- >>> pretty (replicate 2 (replicate 4 (1, replicate 8 2)))
+-- [ [ (1, [2, 2, 2, 2, 2, 2, 2, 2])
+--   , (1, [2, 2, 2, 2, 2, 2, 2, 2])
+--   , (1, [2, 2, 2, 2, 2, 2, 2, 2])
+--   , (1, [2, 2, 2, 2, 2, 2, 2, 2]) ]
+-- , [ (1, [2, 2, 2, 2, 2, 2, 2, 2])
+--   , (1, [2, 2, 2, 2, 2, 2, 2, 2])
+--   , (1, [2, 2, 2, 2, 2, 2, 2, 2])
+--   , (1, [2, 2, 2, 2, 2, 2, 2, 2]) ] ]
+
+instance Pretty a => Pretty (Const a b) where
+  pretty = pretty . getConst
+
+-- | >>> pretty (Identity 1)
+-- 1
+instance Pretty a => Pretty (Identity a) where
+  pretty = pretty . runIdentity
+
+-- | >>> pretty [1,2,3]
+-- [1, 2, 3]
+instance Pretty a => Pretty [a] where
+    pretty = prettyList
+
+instance Pretty a => Pretty (NonEmpty a) where
+    pretty (x:|xs) = prettyList (x:xs)
+
+-- | >>> pretty ()
+-- ()
+--
+-- The argument is not used,
+--
+-- >>> pretty (error "Strict?" :: ())
+-- ()
+instance Pretty () where
+    pretty _ = "()"
+
+-- | >>> pretty True
+-- True
+instance Pretty Bool where
+    pretty True  = "True"
+    pretty False = "False"
+
+-- | Instead of @('pretty' '\n')@, consider using @'line'@ as a more readable
+-- alternative.
+--
+-- >>> pretty 'f' <> pretty 'o' <> pretty 'o'
+-- foo
+-- >>> pretty ("string" :: String)
+-- string
+instance Pretty Char where
+    pretty '\n' = line
+    pretty c = Char c
+
+    prettyList = pretty . (id :: Text -> Text) . fromString
+
+-- | Convenience function to convert a 'Show'able value to a 'Doc'. If the
+-- 'String' does not contain newlines, consider using the more performant
+-- 'unsafeViaShow'.
+viaShow :: Show a => a -> Doc ann
+viaShow = pretty . T.pack . show
+
+-- | Convenience function to convert a 'Show'able value /that must not contain
+-- newlines/ to a 'Doc'. If there may be newlines, use 'viaShow' instead.
+unsafeViaShow :: Show a => a -> Doc ann
+unsafeViaShow = unsafeTextWithoutNewlines . T.pack . show
+
+-- | >>> pretty (123 :: Int)
+-- 123
+instance Pretty Int    where pretty = unsafeViaShow
+instance Pretty Int8   where pretty = unsafeViaShow
+instance Pretty Int16  where pretty = unsafeViaShow
+instance Pretty Int32  where pretty = unsafeViaShow
+instance Pretty Int64  where pretty = unsafeViaShow
+instance Pretty Word   where pretty = unsafeViaShow
+instance Pretty Word8  where pretty = unsafeViaShow
+instance Pretty Word16 where pretty = unsafeViaShow
+instance Pretty Word32 where pretty = unsafeViaShow
+instance Pretty Word64 where pretty = unsafeViaShow
+
+-- | >>> pretty (2^123 :: Integer)
+-- 10633823966279326983230456482242756608
+instance Pretty Integer where pretty = unsafeViaShow
+
+instance Pretty Natural where pretty = unsafeViaShow
+
+-- | >>> pretty (pi :: Float)
+-- 3.1415927
+instance Pretty Float where pretty = unsafeViaShow
+
+-- | >>> pretty (exp 1 :: Double)
+-- 2.71828182845904...
+instance Pretty Double where pretty = unsafeViaShow
+
+-- | >>> pretty (123, "hello")
+-- (123, hello)
+instance (Pretty a1, Pretty a2) => Pretty (a1,a2) where
+    pretty (x1,x2) = tupled [pretty x1, pretty x2]
+
+-- | >>> pretty (123, "hello", False)
+-- (123, hello, False)
+instance (Pretty a1, Pretty a2, Pretty a3) => Pretty (a1,a2,a3) where
+    pretty (x1,x2,x3) = tupled [pretty x1, pretty x2, pretty x3]
+
+--    -- | >>> pretty (123, "hello", False, ())
+--    -- (123, hello, False, ())
+--    instance (Pretty a1, Pretty a2, Pretty a3, Pretty a4) => Pretty (a1,a2,a3,a4) where
+--        pretty (x1,x2,x3,x4) = tupled [pretty x1, pretty x2, pretty x3, pretty x4]
+--
+--    -- | >>> pretty (123, "hello", False, (), 3.14)
+--    -- (123, hello, False, (), 3.14)
+--    instance (Pretty a1, Pretty a2, Pretty a3, Pretty a4, Pretty a5) => Pretty (a1,a2,a3,a4,a5) where
+--        pretty (x1,x2,x3,x4,x5) = tupled [pretty x1, pretty x2, pretty x3, pretty x4, pretty x5]
+--
+--    -- | >>> pretty (123, "hello", False, (), 3.14, Just 2.71)
+--    -- ( 123
+--    -- , hello
+--    -- , False
+--    -- , ()
+--    -- , 3.14
+--    -- , 2.71 )
+--    instance (Pretty a1, Pretty a2, Pretty a3, Pretty a4, Pretty a5, Pretty a6) => Pretty (a1,a2,a3,a4,a5,a6) where
+--        pretty (x1,x2,x3,x4,x5,x6) = tupled [pretty x1, pretty x2, pretty x3, pretty x4, pretty x5, pretty x6]
+--
+--    -- | >>> pretty (123, "hello", False, (), 3.14, Just 2.71, [1,2,3])
+--    -- ( 123
+--    -- , hello
+--    -- , False
+--    -- , ()
+--    -- , 3.14
+--    -- , 2.71
+--    -- , [1, 2, 3] )
+--    instance (Pretty a1, Pretty a2, Pretty a3, Pretty a4, Pretty a5, Pretty a6, Pretty a7) => Pretty (a1,a2,a3,a4,a5,a6,a7) where
+--        pretty (x1,x2,x3,x4,x5,x6,x7) = tupled [pretty x1, pretty x2, pretty x3, pretty x4, pretty x5, pretty x6, pretty x7]
+
+-- | Ignore 'Nothing's, print 'Just' contents.
+--
+-- >>> pretty (Just True)
+-- True
+-- >>> braces (pretty (Nothing :: Maybe Bool))
+-- {}
+--
+-- >>> pretty [Just 1, Nothing, Just 3, Nothing]
+-- [1, 3]
+instance Pretty a => Pretty (Maybe a) where
+    pretty = maybe mempty pretty
+    prettyList = prettyList . catMaybes
+
+-- | Automatically converts all newlines to @'line'@.
+--
+-- >>> pretty ("hello\nworld" :: Text)
+-- hello
+-- world
+--
+-- Note that  @'line'@ can be undone by @'group'@:
+--
+-- >>> group (pretty ("hello\nworld" :: Text))
+-- hello world
+--
+-- Manually use @'hardline'@ if you /definitely/ want newlines.
+instance Pretty Text where pretty = vsep . map unsafeTextWithoutNewlines . T.splitOn "\n"
+
+-- | (lazy 'Text' instance, identical to the strict version)
+instance Pretty Lazy.Text where pretty = pretty . Lazy.toStrict
+
+-- | Finding a good example for printing something that does not exist is hard,
+-- so here is an example of printing a list full of nothing.
+--
+-- >>> pretty ([] :: [Void])
+-- []
+instance Pretty Void where pretty = absurd
+
+
+
+-- | @(unsafeTextWithoutNewlines s)@ contains the literal string @s@.
+--
+-- The string must not contain any newline characters, since this is an
+-- invariant of the 'Text' constructor.
+unsafeTextWithoutNewlines :: Text -> Doc ann
+unsafeTextWithoutNewlines text = case T.uncons text of
+    Nothing -> Empty
+    Just (t,ext)
+        | T.null ext -> Char t
+        | otherwise -> Text (T.length text) text
+
+-- | The empty document behaves like @('pretty' "")@, so it has a height of 1.
+-- This may lead to surprising behaviour if we expect it to bear no weight
+-- inside e.g. 'vcat', where we get an empty line of output from it ('parens'
+-- for visibility only):
+--
+-- >>> vsep ["hello", parens emptyDoc, "world"]
+-- hello
+-- ()
+-- world
+--
+-- Together with '<>', 'emptyDoc' forms the 'Monoid' 'Doc'.
+emptyDoc :: Doc ann
+emptyDoc = Empty
+
+-- | @('nest' i x)@ lays out the document @x@ with the current nesting level
+-- (indentation of the following lines) increased by @i@. Negative values are
+-- allowed, and decrease the nesting level accordingly.
+--
+-- >>> vsep [nest 4 (vsep ["lorem", "ipsum", "dolor"]), "sit", "amet"]
+-- lorem
+--     ipsum
+--     dolor
+-- sit
+-- amet
+--
+-- See also
+--
+--   * 'hang' ('nest' relative to current cursor position instead of
+--      current nesting level)
+--   * 'align' (set nesting level to current cursor position)
+--   * 'indent' (increase indentation on the spot, padding with spaces).
+nest
+    :: Int -- ^ Change of nesting level
+    -> Doc ann
+    -> Doc ann
+nest 0 x = x -- Optimization
+nest i x = Nest i x
+
+-- | The @'line'@ document advances to the next line and indents to the current
+-- nesting level.
+--
+-- >>> let doc = "lorem ipsum" <> line <> "dolor sit amet"
+-- >>> doc
+-- lorem ipsum
+-- dolor sit amet
+--
+-- @'line'@ behaves like @'space'@ if the line break is undone by 'group':
+--
+-- >>> group doc
+-- lorem ipsum dolor sit amet
+line :: Doc ann
+line = FlatAlt Line (Char ' ')
+
+-- | @'line''@ is like @'line'@, but behaves like @'mempty'@ if the line break
+-- is undone by 'group' (instead of @'space'@).
+--
+-- >>> let doc = "lorem ipsum" <> line' <> "dolor sit amet"
+-- >>> doc
+-- lorem ipsum
+-- dolor sit amet
+-- >>> group doc
+-- lorem ipsumdolor sit amet
+line' :: Doc ann
+line' = FlatAlt Line mempty
+
+-- | @softline@ behaves like @'space'@ if the resulting output fits the page,
+-- otherwise like @'line'@.
+--
+-- Here, we have enough space to put everything in one line:
+--
+-- >>> let doc = "lorem ipsum" <> softline <> "dolor sit amet"
+-- >>> putDocW 80 doc
+-- lorem ipsum dolor sit amet
+--
+-- If we narrow the page to width 10, the layouter produces a line break:
+--
+-- >>> putDocW 10 doc
+-- lorem ipsum
+-- dolor sit amet
+--
+-- @
+-- 'softline' = 'group' 'line'
+-- @
+softline :: Doc ann
+softline = group line
+
+-- | @'softline''@ is like @'softline'@, but behaves like @'mempty'@ if the
+-- resulting output does not fit on the page (instead of @'space'@). In other
+-- words, @'line'@ is to @'line''@ how @'softline'@ is to @'softline''@.
+--
+-- With enough space, we get direct concatenation:
+--
+-- >>> let doc = "ThisWord" <> softline' <> "IsWayTooLong"
+-- >>> putDocW 80 doc
+-- ThisWordIsWayTooLong
+--
+-- If we narrow the page to width 10, the layouter produces a line break:
+--
+-- >>> putDocW 10 doc
+-- ThisWord
+-- IsWayTooLong
+--
+-- @
+-- 'softline'' = 'group' 'line''
+-- @
+softline' :: Doc ann
+softline' = group line'
+
+-- | A @'hardline'@ is /always/ laid out as a line break, even when 'group'ed or
+-- when there is plenty of space. Note that it might still be simply discarded
+-- if it is part of a 'flatAlt' inside a 'group'.
+--
+-- >>> let doc = "lorem ipsum" <> hardline <> "dolor sit amet"
+-- >>> putDocW 1000 doc
+-- lorem ipsum
+-- dolor sit amet
+--
+-- >>> group doc
+-- lorem ipsum
+-- dolor sit amet
+hardline :: Doc ann
+hardline = Line
+
+-- | @('group' x)@ tries laying out @x@ into a single line by removing the
+-- contained line breaks; if this does not fit the page, @x@ is laid out without
+-- any changes. The 'group' function is key to layouts that adapt to available
+-- space nicely.
+--
+-- See 'vcat', 'line', or 'flatAlt' for examples that are related, or make good
+-- use of it.
+group :: Doc ann -> Doc ann
+-- See note [Group: special flattening]
+group x = case changesUponFlattening x of
+    Flattened x' -> Union x' x
+    AlreadyFlat  -> x
+    NeverFlat    -> x
+
+-- Note [Group: special flattening]
+--
+-- Since certain documents do not change under removal of newlines etc, there is
+-- no point in creating a 'Union' of the flattened and unflattened version – all
+-- this does is introducing two branches for the layout algorithm to take,
+-- resulting in potentially exponential behavior on deeply nested examples, such
+-- as
+--
+--     pathological n = iterate (\x ->  hsep [x, sep []] ) "foobar" !! n
+--
+-- See https://github.com/quchen/prettyprinter/issues/22 for the  corresponding
+-- ticket.
+
+data FlattenResult a
+    = Flattened a
+    -- ^ @a@ is likely flatter than the input.
+    | AlreadyFlat
+    -- ^ The input was already flat, e.g. a 'Text'.
+    | NeverFlat
+    -- ^ The input couldn't be flattened: It contained a 'Line' or 'Fail'.
+
+instance Functor FlattenResult where
+    fmap f (Flattened a) = Flattened (f a)
+    fmap _ AlreadyFlat   = AlreadyFlat
+    fmap _ NeverFlat     = NeverFlat
+
+-- | Choose the first element of each @Union@, and discard the first field of
+-- all @FlatAlt@s.
+--
+-- The result is 'Flattened' if the element might change depending on the layout
+-- algorithm (i.e. contains differently renderable sub-documents), and 'AlreadyFlat'
+-- if the document is static (e.g. contains only a plain 'Empty' node).
+-- 'NeverFlat' is returned when the document cannot be flattened because it
+-- contains a hard 'Line' or 'Fail'.
+-- See [Group: special flattening] for further explanations.
+changesUponFlattening :: Doc ann -> FlattenResult (Doc ann)
+changesUponFlattening = \doc -> case doc of
+    FlatAlt _ y     -> Flattened (flatten y)
+    Line            -> NeverFlat
+    Union x _       -> Flattened x
+    Nest i x        -> fmap (Nest i) (changesUponFlattening x)
+    Annotated ann x -> fmap (Annotated ann) (changesUponFlattening x)
+
+    Column f        -> Flattened (Column (flatten . f))
+    Nesting f       -> Flattened (Nesting (flatten . f))
+    WithPageWidth f -> Flattened (WithPageWidth (flatten . f))
+
+    Cat x y -> case (changesUponFlattening x, changesUponFlattening y) of
+        (NeverFlat    ,  _          ) -> NeverFlat
+        (_            , NeverFlat   ) -> NeverFlat
+        (Flattened x' , Flattened y') -> Flattened (Cat x' y')
+        (Flattened x' , AlreadyFlat ) -> Flattened (Cat x' y)
+        (AlreadyFlat  , Flattened y') -> Flattened (Cat x y')
+        (AlreadyFlat  , AlreadyFlat ) -> AlreadyFlat
+
+    Empty  -> AlreadyFlat
+    Char{} -> AlreadyFlat
+    Text{} -> AlreadyFlat
+    Fail   -> NeverFlat
+  where
+    -- Flatten, but don’t report whether anything changes.
+    flatten :: Doc ann -> Doc ann
+    flatten = \doc -> case doc of
+        FlatAlt _ y     -> flatten y
+        Cat x y         -> Cat (flatten x) (flatten y)
+        Nest i x        -> Nest i (flatten x)
+        Line            -> Fail
+        Union x _       -> flatten x
+        Column f        -> Column (flatten . f)
+        WithPageWidth f -> WithPageWidth (flatten . f)
+        Nesting f       -> Nesting (flatten . f)
+        Annotated ann x -> Annotated ann (flatten x)
+
+        x@Fail   -> x
+        x@Empty  -> x
+        x@Char{} -> x
+        x@Text{} -> x
+
+
+
+-- | @('flatAlt' x fallback)@ renders as @x@ by default, but falls back to
+-- @fallback@ when 'group'ed. Since the layout algorithms rely on 'group' having
+-- an effect of shortening the width of the contained text, careless usage of
+-- 'flatAlt' with wide fallbacks might lead to unappealingly long lines.
+--
+-- 'flatAlt' is particularly useful for defining conditional separators such as
+--
+-- @
+-- softHyphen = 'flatAlt' 'mempty' "-"
+-- softline   = 'flatAlt' 'space' 'line'
+-- @
+--
+-- We can use this to render Haskell's do-notation nicely:
+--
+-- >>> let open        = flatAlt "" "{ "
+-- >>> let close       = flatAlt "" " }"
+-- >>> let separator   = flatAlt "" "; "
+-- >>> let prettyDo xs = group ("do" <+> align (encloseSep open close separator xs))
+-- >>> let statements  = ["name:_ <- getArgs", "let greet = \"Hello, \" <> name", "putStrLn greet"]
+--
+-- This is put into a single line with @{;}@ style if it fits,
+--
+-- >>> putDocW 80 (prettyDo statements)
+-- do { name:_ <- getArgs; let greet = "Hello, " <> name; putStrLn greet }
+--
+-- When there is not enough space the statements are broken up into lines
+-- nicely,
+--
+-- >>> putDocW 10 (prettyDo statements)
+-- do name:_ <- getArgs
+--    let greet = "Hello, " <> name
+--    putStrLn greet
+flatAlt
+    :: Doc ann -- ^ Default
+    -> Doc ann -- ^ Fallback when 'group'ed
+    -> Doc ann
+flatAlt = FlatAlt
+
+
+
+-- | @('align' x)@ lays out the document @x@ with the nesting level set to the
+-- current column. It is used for example to implement 'hang'.
+--
+-- As an example, we will put a document right above another one, regardless of
+-- the current nesting level. Without 'align'ment, the second line is put simply
+-- below everything we've had so far,
+--
+-- >>> "lorem" <+> vsep ["ipsum", "dolor"]
+-- lorem ipsum
+-- dolor
+--
+-- If we add an 'align' to the mix, the @'vsep'@'s contents all start in the
+-- same column,
+--
+-- >>> "lorem" <+> align (vsep ["ipsum", "dolor"])
+-- lorem ipsum
+--       dolor
+align :: Doc ann -> Doc ann
+align d = column (\k -> nesting (\i -> nest (k - i) d)) -- nesting might be negative!
+
+-- | @('hang' i x)@ lays out the document @x@ with a nesting level set to the
+-- /current column/ plus @i@. Negative values are allowed, and decrease the
+-- nesting level accordingly.
+--
+-- >>> let doc = reflow "Indenting these words with hang"
+-- >>> putDocW 24 ("prefix" <+> hang 4 doc)
+-- prefix Indenting these
+--            words with
+--            hang
+--
+-- This differs from 'nest', which is based on the /current nesting level/ plus
+-- @i@. When you're not sure, try the more efficient 'nest' first. In our
+-- example, this would yield
+--
+-- >>> let doc = reflow "Indenting these words with nest"
+-- >>> putDocW 24 ("prefix" <+> nest 4 doc)
+-- prefix Indenting these
+--     words with nest
+--
+-- @
+-- 'hang' i doc = 'align' ('nest' i doc)
+-- @
+hang
+    :: Int -- ^ Change of nesting level, relative to the start of the first line
+    -> Doc ann
+    -> Doc ann
+hang i d = align (nest i d)
+
+-- | @('indent' i x)@ indents document @x@ with @i@ spaces, starting from the
+-- current cursor position.
+--
+-- >>> let doc = reflow "The indent function indents these words!"
+-- >>> putDocW 24 ("prefix" <> indent 4 doc)
+-- prefix    The indent
+--           function
+--           indents these
+--           words!
+--
+-- @
+-- 'indent' i d = 'hang' i ({i spaces} <> d)
+-- @
+indent
+    :: Int -- ^ Number of spaces to increase indentation by
+    -> Doc ann
+    -> Doc ann
+indent i d = hang i (spaces i <> d)
+
+-- | @('encloseSep' l r sep xs)@ concatenates the documents @xs@ separated by
+-- @sep@, and encloses the resulting document by @l@ and @r@.
+--
+-- The documents are laid out horizontally if that fits the page,
+--
+-- >>> let doc = "list" <+> align (encloseSep lbracket rbracket comma (map pretty [1,20,300,4000]))
+-- >>> putDocW 80 doc
+-- list [1,20,300,4000]
+--
+-- If there is not enough space, then the input is split into lines entry-wise
+-- therwise they are laid out vertically, with separators put in the front:
+--
+-- >>> putDocW 10 doc
+-- list [1
+--      ,20
+--      ,300
+--      ,4000]
+--
+-- Note that @doc@ contains an explicit call to 'align' so that the list items
+-- are aligned vertically.
+--
+-- For putting separators at the end of entries instead, have a look at
+-- 'punctuate'.
+encloseSep
+    :: Doc ann   -- ^ left delimiter
+    -> Doc ann   -- ^ right delimiter
+    -> Doc ann   -- ^ separator
+    -> [Doc ann] -- ^ input documents
+    -> Doc ann
+encloseSep l r s ds = case ds of
+    []  -> l <> r
+    [d] -> l <> d <> r
+    _   -> cat (zipWith (<>) (l : repeat s) ds) <> r
+
+-- | Haskell-inspired variant of 'encloseSep' with braces and comma as
+-- separator.
+--
+-- >>> let doc = list (map pretty [1,20,300,4000])
+--
+-- >>> putDocW 80 doc
+-- [1, 20, 300, 4000]
+--
+-- >>> putDocW 10 doc
+-- [ 1
+-- , 20
+-- , 300
+-- , 4000 ]
+list :: [Doc ann] -> Doc ann
+list = group . encloseSep (flatAlt "[ " "[")
+                          (flatAlt " ]" "]")
+                          ", "
+
+-- | Haskell-inspired variant of 'encloseSep' with parentheses and comma as
+-- separator.
+--
+-- >>> let doc = tupled (map pretty [1,20,300,4000])
+--
+-- >>> putDocW 80 doc
+-- (1, 20, 300, 4000)
+--
+-- >>> putDocW 10 doc
+-- ( 1
+-- , 20
+-- , 300
+-- , 4000 )
+tupled :: [Doc ann] -> Doc ann
+tupled = group . encloseSep (flatAlt "( " "(")
+                            (flatAlt " )" ")")
+                            ", "
+
+
+
+-- | @(x '<+>' y)@ concatenates document @x@ and @y@ with a @'space'@ in
+-- between.
+--
+-- >>> "hello" <+> "world"
+-- hello world
+--
+-- @
+-- x '<+>' y = x '<>' 'space' '<>' y
+-- @
+(<+>) :: Doc ann -> Doc ann -> Doc ann
+x <+> y = x <> Char ' ' <> y
+infixr 6 <+> -- like <>
+
+
+
+-- | Concatenate all documents element-wise with a binary function.
+--
+-- @
+-- 'concatWith' _ [] = 'mempty'
+-- 'concatWith' (**) [x,y,z] = x ** y ** z
+-- @
+--
+-- Multiple convenience definitions based on 'concatWith' are alredy predefined,
+-- for example
+--
+-- @
+-- 'hsep'    = 'concatWith' ('<+>')
+-- 'fillSep' = 'concatWith' (\\x y -> x '<>' 'softline' '<>' y)
+-- @
+--
+-- This is also useful to define customized joiners,
+--
+-- >>> concatWith (surround dot) ["Data", "Text", "Prettyprint", "Doc"]
+-- Data.Text.Prettyprint.Doc
+concatWith :: Foldable t => (Doc ann -> Doc ann -> Doc ann) -> t (Doc ann) -> Doc ann
+concatWith f ds
+    | null ds = mempty
+    | otherwise = foldr1 f ds
+{-# INLINE concatWith #-}
+{-# SPECIALIZE concatWith :: (Doc ann -> Doc ann -> Doc ann) -> [Doc ann] -> Doc ann #-}
+
+-- | @('hsep' xs)@ concatenates all documents @xs@ horizontally with @'<+>'@,
+-- i.e. it puts a space between all entries.
+--
+-- >>> let docs = Util.words "lorem ipsum dolor sit amet"
+--
+-- >>> hsep docs
+-- lorem ipsum dolor sit amet
+--
+-- @'hsep'@ does not introduce line breaks on its own, even when the page is too
+-- narrow:
+--
+-- >>> putDocW 5 (hsep docs)
+-- lorem ipsum dolor sit amet
+--
+-- For automatic line breaks, consider using 'fillSep' instead.
+hsep :: [Doc ann] -> Doc ann
+hsep = concatWith (<+>)
+
+-- | @('vsep' xs)@ concatenates all documents @xs@ above each other. If a
+-- 'group' undoes the line breaks inserted by @vsep@, the documents are
+-- separated with a 'space' instead.
+--
+-- Using 'vsep' alone yields
+--
+-- >>> "prefix" <+> vsep ["text", "to", "lay", "out"]
+-- prefix text
+-- to
+-- lay
+-- out
+--
+-- 'group'ing a 'vsep' separates the documents with a 'space' if it fits the
+-- page (and does nothing otherwise). See the @'sep'@ convenience function for
+-- this use case.
+--
+-- The 'align' function can be used to align the documents under their first
+-- element:
+--
+-- >>> "prefix" <+> align (vsep ["text", "to", "lay", "out"])
+-- prefix text
+--        to
+--        lay
+--        out
+--
+-- Since 'group'ing a 'vsep' is rather common, 'sep' is a built-in for doing
+-- that.
+vsep :: [Doc ann] -> Doc ann
+vsep = concatWith (\x y -> x <> line <> y)
+
+-- | @('fillSep' xs)@ concatenates the documents @xs@ horizontally with @'<+>'@
+-- as long as it fits the page, then inserts a @'line'@ and continues doing that
+-- for all documents in @xs@. (@'line'@ means that if 'group'ed, the documents
+-- are separated with a 'space' instead of newlines. Use 'fillCat' if you do not
+-- want a 'space'.)
+--
+-- Let's print some words to fill the line:
+--
+-- >>> let docs = take 20 (cycle ["lorem", "ipsum", "dolor", "sit", "amet"])
+-- >>> putDocW 80 ("Docs:" <+> fillSep docs)
+-- Docs: lorem ipsum dolor sit amet lorem ipsum dolor sit amet lorem ipsum dolor
+-- sit amet lorem ipsum dolor sit amet
+--
+-- The same document, printed at a width of only 40, yields
+--
+-- >>> putDocW 40 ("Docs:" <+> fillSep docs)
+-- Docs: lorem ipsum dolor sit amet lorem
+-- ipsum dolor sit amet lorem ipsum dolor
+-- sit amet lorem ipsum dolor sit amet
+fillSep :: [Doc ann] -> Doc ann
+fillSep = concatWith (\x y -> x <> softline <> y)
+
+-- | @('sep' xs)@ tries laying out the documents @xs@ separated with 'space's,
+-- and if this does not fit the page, separates them with newlines. This is what
+-- differentiates it from 'vsep', which always lays out its contents beneath
+-- each other.
+--
+-- >>> let doc = "prefix" <+> sep ["text", "to", "lay", "out"]
+-- >>> putDocW 80 doc
+-- prefix text to lay out
+--
+-- With a narrower layout, the entries are separated by newlines:
+--
+-- >>> putDocW 20 doc
+-- prefix text
+-- to
+-- lay
+-- out
+--
+-- @
+-- 'sep' = 'group' . 'vsep'
+-- @
+sep :: [Doc ann] -> Doc ann
+sep = group . vsep
+
+
+
+-- | @('hcat' xs)@ concatenates all documents @xs@ horizontally with @'<>'@
+-- (i.e. without any spacing).
+--
+-- It is provided only for consistency, since it is identical to 'mconcat'.
+--
+-- >>> let docs = Util.words "lorem ipsum dolor"
+-- >>> hcat docs
+-- loremipsumdolor
+hcat :: [Doc ann] -> Doc ann
+hcat = concatWith (<>)
+
+-- | @('vcat' xs)@ vertically concatenates the documents @xs@. If it is
+-- 'group'ed, the line breaks are removed.
+--
+-- In other words @'vcat'@ is like @'vsep'@, with newlines removed instead of
+-- replaced by 'space's.
+--
+-- >>> let docs = Util.words "lorem ipsum dolor"
+-- >>> vcat docs
+-- lorem
+-- ipsum
+-- dolor
+-- >>> group (vcat docs)
+-- loremipsumdolor
+--
+-- Since 'group'ing a 'vcat' is rather common, 'cat' is a built-in shortcut for
+-- it.
+vcat :: [Doc ann] -> Doc ann
+vcat = concatWith (\x y -> x <> line' <> y)
+
+-- | @('fillCat' xs)@ concatenates documents @xs@ horizontally with @'<>'@ as
+-- long as it fits the page, then inserts a @'line''@ and continues doing that
+-- for all documents in @xs@. This is similar to how an ordinary word processor
+-- lays out the text if you just keep typing after you hit the maximum line
+-- length.
+--
+-- (@'line''@ means that if 'group'ed, the documents are separated with nothing
+-- instead of newlines. See 'fillSep' if you want a 'space' instead.)
+--
+-- Observe the difference between 'fillSep' and 'fillCat'. 'fillSep'
+-- concatenates the entries 'space'd when 'group'ed,
+--
+-- >>> let docs = take 20 (cycle (["lorem", "ipsum", "dolor", "sit", "amet"]))
+-- >>> putDocW 40 ("Grouped:" <+> group (fillSep docs))
+-- Grouped: lorem ipsum dolor sit amet
+-- lorem ipsum dolor sit amet lorem ipsum
+-- dolor sit amet lorem ipsum dolor sit
+-- amet
+--
+-- On the other hand, 'fillCat' concatenates the entries directly when
+-- 'group'ed,
+--
+-- >>> putDocW 40 ("Grouped:" <+> group (fillCat docs))
+-- Grouped: loremipsumdolorsitametlorem
+-- ipsumdolorsitametloremipsumdolorsitamet
+-- loremipsumdolorsitamet
+fillCat :: [Doc ann] -> Doc ann
+fillCat = concatWith (\x y -> x <> softline' <> y)
+
+-- | @('cat' xs)@ tries laying out the documents @xs@ separated with nothing,
+-- and if this does not fit the page, separates them with newlines. This is what
+-- differentiates it from 'vcat', which always lays out its contents beneath
+-- each other.
+--
+-- >>> let docs = Util.words "lorem ipsum dolor"
+-- >>> putDocW 80 ("Docs:" <+> cat docs)
+-- Docs: loremipsumdolor
+--
+-- When there is enough space, the documents are put above one another,
+--
+-- >>> putDocW 10 ("Docs:" <+> cat docs)
+-- Docs: lorem
+-- ipsum
+-- dolor
+--
+-- @
+-- 'cat' = 'group' . 'vcat'
+-- @
+cat :: [Doc ann] -> Doc ann
+cat = group . vcat
+
+
+
+-- | @('punctuate' p xs)@ appends @p@ to all but the last document in @xs@.
+--
+-- >>> let docs = punctuate comma (Util.words "lorem ipsum dolor sit amet")
+-- >>> putDocW 80 (hsep docs)
+-- lorem, ipsum, dolor, sit, amet
+--
+-- The separators are put at the end of the entries, which we can see if we
+-- position the result vertically:
+--
+-- >>> putDocW 20 (vsep docs)
+-- lorem,
+-- ipsum,
+-- dolor,
+-- sit,
+-- amet
+--
+-- If you want put the commas in front of their elements instead of at the end,
+-- you should use 'tupled' or, in general, 'encloseSep'.
+punctuate
+    :: Doc ann -- ^ Punctuation, e.g. 'comma'
+    -> [Doc ann]
+    -> [Doc ann]
+punctuate p = go
+  where
+    go []     = []
+    go [d]    = [d]
+    go (d:ds) = (d <> p) : go ds
+
+
+
+-- | Layout a document depending on which column it starts at. 'align' is
+-- implemented in terms of 'column'.
+--
+-- >>> column (\l -> "Columns are" <+> pretty l <> "-based.")
+-- Columns are 0-based.
+--
+-- >>> let doc = "prefix" <+> column (\l -> "| <- column" <+> pretty l)
+-- >>> vsep [indent n doc | n <- [0,4,8]]
+-- prefix | <- column 7
+--     prefix | <- column 11
+--         prefix | <- column 15
+column :: (Int -> Doc ann) -> Doc ann
+column = Column
+
+-- | Layout a document depending on the current 'nest'ing level. 'align' is
+-- implemented in terms of 'nesting'.
+--
+-- >>> let doc = "prefix" <+> nesting (\l -> brackets ("Nested:" <+> pretty l))
+-- >>> vsep [indent n doc | n <- [0,4,8]]
+-- prefix [Nested: 0]
+--     prefix [Nested: 4]
+--         prefix [Nested: 8]
+nesting :: (Int -> Doc ann) -> Doc ann
+nesting = Nesting
+
+-- | @('width' doc f)@ lays out the document 'doc', and makes the column width
+-- of it available to a function.
+--
+-- >>> let annotate doc = width (brackets doc) (\w -> " <- width:" <+> pretty w)
+-- >>> align (vsep (map annotate ["---", "------", indent 3 "---", vsep ["---", indent 4 "---"]]))
+-- [---] <- width: 5
+-- [------] <- width: 8
+-- [   ---] <- width: 8
+-- [---
+--     ---] <- width: 8
+width :: Doc ann -> (Int -> Doc ann) -> Doc ann
+width doc f
+  = column (\colStart ->
+        doc <> column (\colEnd ->
+            f (colEnd - colStart)))
+
+-- | Layout a document depending on the page width, if one has been specified.
+--
+-- >>> let prettyPageWidth (AvailablePerLine l r) = "Width:" <+> pretty l <> ", ribbon fraction:" <+> pretty r
+-- >>> let doc = "prefix" <+> pageWidth (brackets . prettyPageWidth)
+-- >>> putDocW 32 (vsep [indent n doc | n <- [0,4,8]])
+-- prefix [Width: 32, ribbon fraction: 1.0]
+--     prefix [Width: 32, ribbon fraction: 1.0]
+--         prefix [Width: 32, ribbon fraction: 1.0]
+pageWidth :: (PageWidth -> Doc ann) -> Doc ann
+pageWidth = WithPageWidth
+
+
+
+-- | @('fill' i x)@ lays out the document @x@. It then appends @space@s until
+-- the width is equal to @i@. If the width of @x@ is already larger, nothing is
+-- appended.
+--
+-- This function is quite useful in practice to output a list of bindings:
+--
+-- >>> let types = [("empty","Doc"), ("nest","Int -> Doc -> Doc"), ("fillSep","[Doc] -> Doc")]
+-- >>> let ptype (name, tp) = fill 5 (pretty name) <+> "::" <+> pretty tp
+-- >>> "let" <+> align (vcat (map ptype types))
+-- let empty :: Doc
+--     nest  :: Int -> Doc -> Doc
+--     fillSep :: [Doc] -> Doc
+fill
+    :: Int -- ^ Append spaces until the document is at least this wide
+    -> Doc ann
+    -> Doc ann
+fill n doc = width doc (\w -> spaces (n - w))
+
+-- | @('fillBreak' i x)@ first lays out the document @x@. It then appends @space@s
+-- until the width is equal to @i@. If the width of @x@ is already larger than
+-- @i@, the nesting level is increased by @i@ and a @line@ is appended. When we
+-- redefine @ptype@ in the example given in 'fill' to use @'fillBreak'@, we get
+-- a useful variation of the output:
+--
+-- >>> let types = [("empty","Doc"), ("nest","Int -> Doc -> Doc"), ("fillSep","[Doc] -> Doc")]
+-- >>> let ptype (name, tp) = fillBreak 5 (pretty name) <+> "::" <+> pretty tp
+-- >>> "let" <+> align (vcat (map ptype types))
+-- let empty :: Doc
+--     nest  :: Int -> Doc -> Doc
+--     fillSep
+--           :: [Doc] -> Doc
+fillBreak
+    :: Int -- ^ Append spaces until the document is at least this wide
+    -> Doc ann
+    -> Doc ann
+fillBreak f x = width x (\w ->
+    if w > f
+        then nest f line'
+        else spaces (f - w))
+
+-- | Insert a number of spaces. Negative values count as 0.
+spaces :: Int -> Doc ann
+spaces n = unsafeTextWithoutNewlines (T.replicate n " ")
+
+-- $
+-- prop> \(NonNegative n) -> length (show (spaces n)) == n
+--
+-- >>> case spaces 1 of Char ' ' -> True; _ -> False
+-- True
+--
+-- >>> case spaces 0 of Empty -> True; _ -> False
+-- True
+--
+-- prop> \(Positive n) -> case (spaces (-n)) of Empty -> True; _ -> False
+
+
+
+-- | @('plural' n one many)@ is @one@ if @n@ is @1@, and @many@ otherwise. A
+-- typical use case is  adding a plural "s".
+--
+-- >>> let things = [True]
+-- >>> let amount = length things
+-- >>> pretty things <+> "has" <+> pretty amount <+> plural "entry" "entries" amount
+-- [True] has 1 entry
+plural
+    :: (Num amount, Eq amount)
+    => doc -- ^ @1@ case
+    -> doc -- ^ other cases
+    -> amount
+    -> doc
+plural one multiple n
+    | n == 1    = one
+    | otherwise = multiple
+
+-- | @('enclose' l r x)@ encloses document @x@ between documents @l@ and @r@
+-- using @'<>'@.
+--
+-- >>> enclose "A" "Z" "·"
+-- A·Z
+--
+-- @
+-- 'enclose' l r x = l '<>' x '<>' r
+-- @
+enclose
+    :: Doc ann -- ^ L
+    -> Doc ann -- ^ R
+    -> Doc ann -- ^ x
+    -> Doc ann -- ^ LxR
+enclose l r x = l <> x <> r
+
+-- | @('surround' x l r)@ surrounds document @x@ with @l@ and @r@.
+--
+-- >>> surround "·" "A" "Z"
+-- A·Z
+--
+-- This is merely an argument reordering of @'enclose'@, but allows for
+-- definitions like
+--
+-- >>> concatWith (surround ".") ["Data", "Text", "Prettyprint", "Doc"]
+-- Data.Text.Prettyprint.Doc
+surround
+    :: Doc ann
+    -> Doc ann
+    -> Doc ann
+    -> Doc ann
+surround x l r = l <> x <> r
+
+
+
+
+
+
+-- | Add an annotation to a @'Doc'@. This annotation can then be used by the
+-- renderer to e.g. add color to certain parts of the output. For a full
+-- tutorial example on how to use it, see the
+-- "Data.Text.Prettyprint.Doc.Render.Tutorials.StackMachineTutorial" or
+-- "Data.Text.Prettyprint.Doc.Render.Tutorials.TreeRenderingTutorial" modules.
+--
+-- This function is only relevant for custom formats with their own annotations,
+-- and not relevant for basic prettyprinting. The predefined renderers, e.g.
+-- "Data.Text.Prettyprint.Doc.Render.Text", should be enough for the most common
+-- needs.
+annotate :: ann -> Doc ann -> Doc ann
+annotate = Annotated
+
+-- | Remove all annotations.
+--
+-- Although 'unAnnotate' is idempotent with respect to rendering,
+--
+-- @
+-- 'unAnnotate' . 'unAnnotate' = 'unAnnotate'
+-- @
+--
+-- it should not be used without caution, for each invocation traverses the
+-- entire contained document. If possible, it is preferrable to unannotate after
+-- producing the layout by using 'unAnnotateS'.
+unAnnotate :: Doc ann -> Doc xxx
+unAnnotate = alterAnnotations (const [])
+
+-- | Change the annotation of a 'Doc'ument.
+--
+-- Useful in particular to embed documents with one form of annotation in a more
+-- generlly annotated document.
+--
+-- Since this traverses the entire @'Doc'@ tree, including parts that are not
+-- rendered due to other layouts fitting better, it is preferrable to reannotate
+-- after producing the layout by using @'reAnnotateS'@.
+--
+-- Since @'reAnnotate'@ has the right type and satisfies @'reAnnotate id = id'@,
+-- it is used to define the @'Functor'@ instance of @'Doc'@.
+reAnnotate :: (ann -> ann') -> Doc ann -> Doc ann'
+reAnnotate re = alterAnnotations (pure . re)
+
+-- | Change the annotations of a 'Doc'ument. Individual annotations can be
+-- removed, changed, or replaced by multiple ones.
+--
+-- This is a general function that combines 'unAnnotate' and 'reAnnotate', and
+-- it is useful for mapping semantic annotations (such as »this is a keyword«)
+-- to display annotations (such as »this is red and underlined«), because some
+-- backends may not care about certain annotations, while others may.
+--
+-- Annotations earlier in the new list will be applied earlier, i.e. returning
+-- @[Bold, Green]@ will result in a bold document that contains green text, and
+-- not vice-versa.
+--
+-- Since this traverses the entire @'Doc'@ tree, including parts that are not
+-- rendered due to other layouts fitting better, it is preferrable to reannotate
+-- after producing the layout by using @'alterAnnotationsS'@.
+alterAnnotations :: (ann -> [ann']) -> Doc ann -> Doc ann'
+alterAnnotations re = go
+  where
+    go = \doc -> case doc of
+        Fail     -> Fail
+        Empty    -> Empty
+        Char c   -> Char c
+        Text l t -> Text l t
+        Line     -> Line
+
+        FlatAlt x y     -> FlatAlt (go x) (go y)
+        Cat x y         -> Cat (go x) (go y)
+        Nest i x        -> Nest i (go x)
+        Union x y       -> Union (go x) (go y)
+        Column f        -> Column (go . f)
+        WithPageWidth f -> WithPageWidth (go . f)
+        Nesting f       -> Nesting (go . f)
+        Annotated ann x -> foldr Annotated (go x) (re ann)
+
+-- $
+-- >>> let doc = "lorem" <+> annotate () "ipsum" <+> "dolor"
+-- >>> let re () = ["FOO", "BAR"]
+-- >>> layoutPretty defaultLayoutOptions (alterAnnotations re doc)
+-- SText 5 "lorem" (SChar ' ' (SAnnPush "FOO" (SAnnPush "BAR" (SText 5 "ipsum" (SAnnPop (SAnnPop (SChar ' ' (SText 5 "dolor" SEmpty))))))))
+
+-- | Remove all annotations. 'unAnnotate' for 'SimpleDocStream'.
+unAnnotateS :: SimpleDocStream ann -> SimpleDocStream xxx
+unAnnotateS = go
+  where
+    go = \doc -> case doc of
+        SFail              -> SFail
+        SEmpty             -> SEmpty
+        SChar c rest       -> SChar c (go rest)
+        SText l t rest     -> SText l t (go rest)
+        SLine l rest       -> SLine l (go rest)
+        SAnnPop rest       -> go rest
+        SAnnPush _ann rest -> go rest
+
+-- | Change the annotation of a document. 'reAnnotate' for 'SimpleDocStream'.
+reAnnotateS :: (ann -> ann') -> SimpleDocStream ann -> SimpleDocStream ann'
+reAnnotateS re = go
+  where
+    go = \doc -> case doc of
+        SFail             -> SFail
+        SEmpty            -> SEmpty
+        SChar c rest      -> SChar c (go rest)
+        SText l t rest    -> SText l t (go rest)
+        SLine l rest      -> SLine l (go rest)
+        SAnnPop rest      -> SAnnPop (go rest)
+        SAnnPush ann rest -> SAnnPush (re ann) (go rest)
+
+data AnnotationRemoval = Remove | DontRemove
+  deriving Typeable
+
+-- | Change the annotation of a document to a different annotation, or none at
+-- all. 'alterAnnotations' for 'SimpleDocStream'.
+--
+-- Note that the 'Doc' version is more flexible, since it allows changing a
+-- single annotation to multiple ones.
+-- ('Data.Text.Prettyprint.Doc.Render.Util.SimpleDocTree.SimpleDocTree' restores
+-- this flexibility again.)
+alterAnnotationsS :: (ann -> Maybe ann') -> SimpleDocStream ann -> SimpleDocStream ann'
+alterAnnotationsS re = go []
+  where
+    -- We keep a stack of whether to remove a pop so that we can remove exactly
+    -- the pops corresponding to annotations that mapped to Nothing.
+    go stack = \sds -> case sds of
+        SFail             -> SFail
+        SEmpty            -> SEmpty
+        SChar c rest      -> SChar c (go stack rest)
+        SText l t rest    -> SText l t (go stack rest)
+        SLine l rest      -> SLine l (go stack rest)
+        SAnnPush ann rest -> case re ann of
+            Nothing   -> go (Remove:stack) rest
+            Just ann' -> SAnnPush ann' (go (DontRemove:stack) rest)
+        SAnnPop rest      -> case stack of
+            []                -> panicPeekedEmpty
+            DontRemove:stack' -> SAnnPop (go stack' rest)
+            Remove:stack'     -> go stack' rest
+
+-- | Fusion depth parameter, used by 'fuse'.
+data FusionDepth =
+
+    -- | Do not dive deep into nested documents, fusing mostly concatenations of
+    -- text nodes together.
+    Shallow
+
+    -- | Recurse into all parts of the 'Doc', including different layout
+    -- alternatives, and location-sensitive values such as created by 'nesting'
+    -- which cannot be fused before, but only during, the layout process. As a
+    -- result, the performance cost of using deep fusion is often hard to
+    -- predict, and depends on the interplay between page layout and document to
+    -- prettyprint.
+    --
+    -- This value should only be used if profiling shows it is significantly
+    -- faster than using 'Shallow'.
+    | Deep
+    deriving (Eq, Ord, Show, Typeable)
+
+-- | @('fuse' depth doc)@ combines text nodes so they can be rendered more
+-- efficiently. A fused document is always laid out identical to its unfused
+-- version.
+--
+-- When laying a 'Doc'ument out to a 'SimpleDocStream', every component of the
+-- input is translated directly to the simpler output format. This sometimes
+-- yields undesirable chunking when many pieces have been concatenated together.
+--
+-- For example
+--
+-- >>> "a" <> "b" <> pretty 'c' <> "d"
+-- abcd
+--
+-- results in a chain of four entries in a 'SimpleDocStream', although this is fully
+-- equivalent to the tightly packed
+--
+-- >>> "abcd" :: Doc ann
+-- abcd
+--
+-- which is only a single 'SimpleDocStream' entry, and can be processed faster.
+--
+-- It is therefore a good idea to run 'fuse' on concatenations of lots of small
+-- strings that are used many times,
+--
+-- >>> let oftenUsed = fuse Shallow ("a" <> "b" <> pretty 'c' <> "d")
+-- >>> hsep (replicate 5 oftenUsed)
+-- abcd abcd abcd abcd abcd
+fuse :: FusionDepth -> Doc ann -> Doc ann
+fuse depth = go
+  where
+    go = \doc -> case doc of
+        Cat Empty x                   -> go x
+        Cat x Empty                   -> go x
+        Cat (Char c1) (Char c2)       -> Text 2 (T.singleton c1 <> T.singleton c2)
+        Cat (Text lt t) (Char c)      -> Text (lt+1) (T.snoc t c)
+        Cat (Char c) (Text lt t)      -> Text (1+lt) (T.cons c t)
+        Cat (Text l1 t1) (Text l2 t2) -> Text (l1+l2) (t1 <> t2)
+
+        Cat x@Char{} (Cat y@Char{} z) -> go (Cat (go (Cat x y)) z)
+        Cat x@Text{} (Cat y@Char{} z) -> go (Cat (go (Cat x y)) z)
+        Cat x@Char{} (Cat y@Text{} z) -> go (Cat (go (Cat x y)) z)
+        Cat x@Text{} (Cat y@Text{} z) -> go (Cat (go (Cat x y)) z)
+
+        Cat (Cat x y@Char{}) z -> go (Cat x (go (Cat y z)))
+        Cat (Cat x y@Text{}) z -> go (Cat x (go (Cat y z)))
+
+        Cat x y -> Cat (go x) (go y)
+
+        Nest i (Nest j x) -> let !fused = Nest (i+j) x
+                             in go fused
+        Nest _ x@Empty{} -> x
+        Nest _ x@Text{}  -> x
+        Nest _ x@Char{}  -> x
+        Nest 0 x         -> go x
+        Nest i x         -> Nest i (go x)
+
+        Annotated ann x -> Annotated ann (go x)
+
+        FlatAlt x1 x2 -> FlatAlt (go x1) (go x2)
+        Union x1 x2   -> Union (go x1) (go x2)
+
+        other | depth == Shallow -> other
+
+        Column f        -> Column (go . f)
+        WithPageWidth f -> WithPageWidth (go . f)
+        Nesting f       -> Nesting (go . f)
+
+        other -> other
+
+
+
+-- | The data type @SimpleDocStream@ represents laid out documents and is used
+-- by the display functions.
+--
+-- A simplified view is that @'Doc' = ['SimpleDocStream']@, and the layout
+-- functions pick one of the 'SimpleDocStream's based on which one fits the
+-- layout constraints best. This means that 'SimpleDocStream' has all complexity
+-- contained in 'Doc' resolved, making it very easy to convert it to other
+-- formats, such as plain text or terminal output.
+--
+-- To write your own @'Doc'@ to X converter, it is therefore sufficient to
+-- convert from @'SimpleDocStream'@. The »Render« submodules provide some
+-- built-in converters to do so, and helpers to create own ones.
+data SimpleDocStream ann =
+      SFail
+    | SEmpty
+    | SChar Char (SimpleDocStream ann)
+
+    -- | Some layout algorithms use the Since the frequently used 'T.length' of
+    -- the 'Text', which scales linearly with its length, we cache it in this
+    -- constructor.
+    | SText !Int Text (SimpleDocStream ann)
+
+    -- | @Int@ = indentation level for the (next) line
+    | SLine !Int (SimpleDocStream ann)
+
+    -- | Add an annotation to the remaining document.
+    | SAnnPush ann (SimpleDocStream ann)
+
+    -- | Remove a previously pushed annotation.
+    | SAnnPop (SimpleDocStream ann)
+    deriving (Eq, Ord, Show, Generic, Typeable)
+
+-- | Remove all trailing space characters.
+--
+-- This has some performance impact, because it does an entire additional pass
+-- over the 'SimpleDocStream'.
+--
+-- No trimming will be done inside annotations, which are considered to contain
+-- no (trimmable) whitespace, since the annotation might actually be /about/ the
+-- whitespace, for example a renderer that colors the background of trailing
+-- whitespace, as e.g. @git diff@ can be configured to do.
+removeTrailingWhitespace :: SimpleDocStream ann -> SimpleDocStream ann
+removeTrailingWhitespace = go (RecordedWhitespace [] 0)
+  where
+    commitWhitespace
+        :: [Int] -- Withheld lines
+        -> Int -- Withheld spaces
+        -> SimpleDocStream ann
+        -> SimpleDocStream ann
+    commitWhitespace is0 n0 = commitLines is0 . commitSpaces n0
+      where
+        commitLines [] = id
+        commitLines (i:is) = foldr (\_ f -> SLine 0 . f) (SLine i) is
+
+        commitSpaces 0 = id
+        commitSpaces 1 = SChar ' '
+        commitSpaces n = SText n (T.replicate n " ")
+
+    go :: WhitespaceStrippingState -> SimpleDocStream ann -> SimpleDocStream ann
+    -- We do not strip whitespace inside annotated documents, since it might
+    -- actually be relevant there.
+    go annLevel@(AnnotationLevel annLvl) = \sds -> case sds of
+        SFail             -> SFail
+        SEmpty            -> SEmpty
+        SChar c rest      -> SChar c (go annLevel rest)
+        SText l text rest -> SText l text (go annLevel rest)
+        SLine i rest      -> SLine i (go annLevel rest)
+        SAnnPush ann rest -> let !annLvl' = annLvl+1
+                             in SAnnPush ann (go (AnnotationLevel annLvl') rest)
+        SAnnPop rest
+            | annLvl > 1  -> let !annLvl' = annLvl-1
+                             in SAnnPop (go (AnnotationLevel annLvl') rest)
+            | otherwise   -> SAnnPop (go (RecordedWhitespace [] 0) rest)
+    -- Record all spaces/lines encountered, and once proper text starts again,
+    -- release only the necessary ones.
+    go (RecordedWhitespace withheldLines withheldSpaces) = \sds -> case sds of
+        SFail -> SFail
+        SEmpty -> foldr (\_i sds' -> SLine 0 sds') SEmpty withheldLines
+        SChar c rest
+            | c == ' ' -> go (RecordedWhitespace withheldLines (withheldSpaces+1)) rest
+            | otherwise -> commitWhitespace
+                               withheldLines
+                               withheldSpaces
+                               (SChar c (go (RecordedWhitespace [] 0) rest))
+        SText textLength text rest ->
+            let stripped = T.dropWhileEnd (== ' ') text
+                strippedLength = T.length stripped
+                trailingLength = textLength - strippedLength
+                isOnlySpace = strippedLength == 0
+            in if isOnlySpace
+                then go (RecordedWhitespace withheldLines (withheldSpaces + textLength)) rest
+                else commitWhitespace
+                        withheldLines
+                        withheldSpaces
+                        (SText strippedLength
+                               stripped
+                               (go (RecordedWhitespace [] trailingLength) rest))
+        SLine i rest -> go (RecordedWhitespace (i:withheldLines) 0) rest
+        SAnnPush ann rest -> commitWhitespace
+                                 withheldLines
+                                 withheldSpaces
+                                 (SAnnPush ann (go (AnnotationLevel 1) rest))
+        SAnnPop _ -> error "Tried skipping spaces in unannotated data! Please report this as a bug in 'prettyprinter'."
+
+data WhitespaceStrippingState
+    = AnnotationLevel !Int
+    | RecordedWhitespace [Int] !Int
+      -- ^ [Newline with indentation i] Spaces
+  deriving Typeable
+
+
+-- | Test whether a docstream starts with a linebreak, ignoring any annotations.
+startsWithLine :: SimpleDocStream ann -> Bool
+startsWithLine sds = case sds of
+    SLine{}      -> True
+    SAnnPush _ s -> startsWithLine s
+    SAnnPop s    -> startsWithLine s
+    _            -> False
+
+
+-- $
+-- >>> import qualified Data.Text.IO as T
+-- >>> doc = "lorem" <> hardline <> hardline <> pretty "ipsum"
+-- >>> go = T.putStrLn . renderStrict . removeTrailingWhitespace . layoutPretty defaultLayoutOptions
+-- >>> go doc
+-- lorem
+-- <BLANKLINE>
+-- ipsum
+
+
+
+-- | Alter the document’s annotations.
+--
+-- This instance makes 'SimpleDocStream' more flexible (because it can be used in
+-- 'Functor'-polymorphic values), but @'fmap'@ is much less readable compared to
+-- using @'reAnnotateST'@ in code that only works for @'SimpleDocStream'@ anyway.
+-- Consider using the latter when the type does not matter.
+instance Functor SimpleDocStream where
+    fmap = reAnnotateS
+
+-- | Collect all annotations from a document.
+instance Foldable SimpleDocStream where
+    foldMap f = go
+      where
+        go = \sds -> case sds of
+            SFail             -> mempty
+            SEmpty            -> mempty
+            SChar _ rest      -> go rest
+            SText _ _ rest    -> go rest
+            SLine _ rest      -> go rest
+            SAnnPush ann rest -> f ann `mappend` go rest
+            SAnnPop rest      -> go rest
+
+-- | Transform a document based on its annotations, possibly leveraging
+-- 'Applicative' effects.
+instance Traversable SimpleDocStream where
+    traverse f = go
+      where
+        go = \sds -> case sds of
+            SFail             -> pure SFail
+            SEmpty            -> pure SEmpty
+            SChar c rest      -> SChar c   <$> go rest
+            SText l t rest    -> SText l t <$> go rest
+            SLine i rest      -> SLine i   <$> go rest
+            SAnnPush ann rest -> SAnnPush  <$> f ann <*> go rest
+            SAnnPop rest      -> SAnnPop   <$> go rest
+
+-- | Decide whether a 'SimpleDocStream' fits the constraints given, namely
+--
+--   - page width
+--   - minimum nesting level to fit in
+--   - width in which to fit the first line
+newtype FittingPredicate ann
+  = FittingPredicate (PageWidth
+                   -> Int
+                   -> Int
+                   -> SimpleDocStream ann
+                   -> Bool)
+  deriving Typeable
+
+-- | List of nesting level/document pairs yet to be laid out.
+data LayoutPipeline ann =
+      Nil
+    | Cons !Int (Doc ann) (LayoutPipeline ann)
+    | UndoAnn (LayoutPipeline ann)
+  deriving Typeable
+
+-- | Maximum number of characters that fit in one line. The layout algorithms
+-- will try not to exceed the set limit by inserting line breaks when applicable
+-- (e.g. via 'softline'').
+data PageWidth
+
+    = AvailablePerLine Int Double
+    -- ^ Layouters should not exceed the specified space per line.
+    --
+    --   - The 'Int' is the number of characters, including whitespace, that
+    --     fit in a line. A typical value is 80.
+    --
+    --   - The 'Double' is the ribbon with, i.e. the fraction of the total
+    --     page width that can be printed on. This allows limiting the length
+    --     of printable text per line. Values must be between 0 and 1, and
+    --     0.4 to 1 is typical.
+
+    | Unbounded
+    -- ^ Layouters should not introduce line breaks on their own.
+
+    deriving (Eq, Ord, Show, Typeable)
+
+defaultPageWidth :: PageWidth
+defaultPageWidth = AvailablePerLine 80 1
+
+-- $ Test to avoid surprising behaviour
+-- >>> Unbounded > AvailablePerLine maxBound 1
+-- True
+
+-- | Options to influence the layout algorithms.
+newtype LayoutOptions = LayoutOptions { layoutPageWidth :: PageWidth }
+    deriving (Eq, Ord, Show, Typeable)
+
+-- | The default layout options, suitable when you just want some output, and
+-- don’t particularly care about the details. Used by the 'Show' instance, for
+-- example.
+--
+-- >>> defaultLayoutOptions
+-- LayoutOptions {layoutPageWidth = AvailablePerLine 80 1.0}
+defaultLayoutOptions :: LayoutOptions
+defaultLayoutOptions = LayoutOptions { layoutPageWidth = defaultPageWidth }
+
+-- | This is the default layout algorithm, and it is used by 'show', 'putDoc'
+-- and 'hPutDoc'.
+--
+-- @'layoutPretty'@ commits to rendering something in a certain way if the next
+-- element fits the layout constraints; in other words, it has one
+-- 'SimpleDocStream' element lookahead when rendering. Consider using the
+-- smarter, but a bit less performant, @'layoutSmart'@ algorithm if the results
+-- seem to run off to the right before having lots of line breaks.
+layoutPretty
+    :: LayoutOptions
+    -> Doc ann
+    -> SimpleDocStream ann
+layoutPretty = layoutWadlerLeijen
+    (FittingPredicate (\_pWidth _minNestingLevel maxWidth sdoc -> fits maxWidth sdoc))
+  where
+    fits :: Int -- ^ Width in which to fit the first line
+         -> SimpleDocStream ann
+         -> Bool
+    fits w _ | w < 0      = False
+    fits _ SFail          = False
+    fits _ SEmpty         = True
+    fits w (SChar _ x)    = fits (w - 1) x
+    fits w (SText l _t x) = fits (w - l) x
+    fits _ SLine{}        = True
+    fits w (SAnnPush _ x) = fits w x
+    fits w (SAnnPop x)    = fits w x
+
+-- | A layout algorithm with more lookahead than 'layoutPretty', that introduces
+-- line breaks earlier if the content does not (or will not, rather) fit into
+-- one line.
+--
+-- Consider the following python-ish document,
+--
+-- >>> let fun x = hang 2 ("fun(" <> softline' <> x) <> ")"
+-- >>> let doc = (fun . fun . fun . fun . fun) (align (list ["abcdef", "ghijklm"]))
+--
+-- which we’ll be rendering using the following pipeline (where the layout
+-- algorithm has been left open),
+--
+-- >>> import Data.Text.IO as T
+-- >>> import Data.Text.Prettyprint.Doc.Render.Text
+-- >>> let hr = pipe <> pretty (replicate (26-2) '-') <> pipe
+-- >>> let go layouter x = (T.putStrLn . renderStrict . layouter (LayoutOptions (AvailablePerLine 26 1))) (vsep [hr, x, hr])
+--
+-- If we render this using @'layoutPretty'@ with a page width of 26 characters
+-- per line, all the @fun@ calls fit into the first line so they will be put
+-- there,
+--
+-- >>> go layoutPretty doc
+-- |------------------------|
+-- fun(fun(fun(fun(fun(
+--                   [ abcdef
+--                   , ghijklm ])))))
+-- |------------------------|
+--
+-- Note that this exceeds the desired 26 character page width. The same
+-- document, rendered with @'layoutSmart'@, fits the layout contstraints:
+--
+-- >>> go layoutSmart doc
+-- |------------------------|
+-- fun(
+--   fun(
+--     fun(
+--       fun(
+--         fun(
+--           [ abcdef
+--           , ghijklm ])))))
+-- |------------------------|
+--
+-- The key difference between @'layoutPretty'@ and @'layoutSmart'@ is that the
+-- latter will check the potential document up to the end of the current
+-- indentation level, instead of just having one element lookahead.
+layoutSmart
+    :: LayoutOptions
+    -> Doc ann
+    -> SimpleDocStream ann
+layoutSmart = layoutWadlerLeijen (FittingPredicate fits)
+  where
+    -- Search with more lookahead: assuming that nesting roughly corresponds to
+    -- syntactic depth, @fits@ checks that not only the current line fits, but
+    -- the entire syntactic structure being formatted at this level of
+    -- indentation fits. If we were to remove the second case for @SLine@, we
+    -- would check that not only the current structure fits, but also the rest
+    -- of the document, which would be slightly more intelligent but would have
+    -- exponential runtime (and is prohibitively expensive in practice).
+    fits :: PageWidth
+         -> Int -- ^ Minimum nesting level to fit in
+         -> Int -- ^ Width in which to fit the first line
+         -> SimpleDocStream ann
+         -> Bool
+    fits _ _ w _ | w < 0                    = False
+    fits _ _ _ SFail                        = False
+    fits _ _ _ SEmpty                       = True
+    fits pw m w (SChar _ x)                 = fits pw m (w - 1) x
+    fits pw m w (SText l _t x)              = fits pw m (w - l) x
+    fits pw m _ (SLine i x)
+      | m < i, AvailablePerLine cpl _ <- pw = fits pw m (cpl - i) x
+      | otherwise                           = True
+    fits pw m w (SAnnPush _ x)              = fits pw m w x
+    fits pw m w (SAnnPop x)                 = fits pw m w x
+
+-- | The Wadler/Leijen layout algorithm
+layoutWadlerLeijen
+    :: forall ann. FittingPredicate ann
+    -> LayoutOptions
+    -> Doc ann
+    -> SimpleDocStream ann
+layoutWadlerLeijen
+    (FittingPredicate fits)
+    LayoutOptions { layoutPageWidth = pWidth }
+    doc
+  = best 0 0 (Cons 0 doc Nil)
+  where
+
+    -- * current column >= current nesting level
+    -- * current column - current indentaion = number of chars inserted in line
+    best
+        :: Int -- Current nesting level
+        -> Int -- Current column, i.e. "where the cursor is"
+        -> LayoutPipeline ann -- Documents remaining to be handled (in order)
+        -> SimpleDocStream ann
+    best !_ !_ Nil           = SEmpty
+    best nl cc (UndoAnn ds)  = SAnnPop (best nl cc ds)
+    best nl cc (Cons i d ds) = case d of
+        Fail            -> SFail
+        Empty           -> best nl cc ds
+        Char c          -> let !cc' = cc+1 in SChar c (best nl cc' ds)
+        Text l t        -> let !cc' = cc+l in SText l t (best nl cc' ds)
+        Line            -> SLine i (best i i ds)
+        FlatAlt x _     -> best nl cc (Cons i x ds)
+        Cat x y         -> best nl cc (Cons i x (Cons i y ds))
+        Nest j x        -> let !ij = i+j in best nl cc (Cons ij x ds)
+        Union x y       -> let x' = best nl cc (Cons i x ds)
+                               y' = best nl cc (Cons i y ds)
+                           in selectNicer nl cc x' y'
+        Column f        -> best nl cc (Cons i (f cc) ds)
+        WithPageWidth f -> best nl cc (Cons i (f pWidth) ds)
+        Nesting f       -> best nl cc (Cons i (f i) ds)
+        Annotated ann x -> SAnnPush ann (best nl cc (Cons i x (UndoAnn ds)))
+
+    selectNicer
+        :: Int           -- ^ Current nesting level
+        -> Int           -- ^ Current column
+        -> SimpleDocStream ann -- ^ Choice A. Invariant: first lines should not be longer than B's.
+        -> SimpleDocStream ann -- ^ Choice B.
+        -> SimpleDocStream ann -- ^ Choice A if it fits, otherwise B.
+    selectNicer lineIndent currentColumn x y = case pWidth of
+        AvailablePerLine lineLength ribbonFraction
+          | fits pWidth minNestingLevel availableWidth x -> x
+          where
+            minNestingLevel =
+                -- See https://github.com/quchen/prettyprinter/issues/83.
+                if startsWithLine y
+                    -- y might be a (more compact) hanging layout. Let's check x
+                    -- thoroughly with the smaller lineIndent.
+                    then lineIndent
+                    -- y definitely isn't a hanging layout. Let's allow the first
+                    -- line of x to be checked on its own and format it consistently
+                    -- with subsequent lines with the same indentation.
+                    else currentColumn
+            availableWidth = min columnsLeftInLine columnsLeftInRibbon
+              where
+                columnsLeftInLine = lineLength - currentColumn
+                columnsLeftInRibbon = lineIndent + ribbonWidth - currentColumn
+                ribbonWidth =
+                    (max 0 . min lineLength . round)
+                        (fromIntegral lineLength * ribbonFraction)
+        Unbounded
+          -- See the Note [Detecting failure with Unbounded page width].
+          | not (failsOnFirstLine x) -> x
+        _ -> y
+
+    failsOnFirstLine :: SimpleDocStream ann -> Bool
+    failsOnFirstLine = go
+      where
+        go sds = case sds of
+            SFail        -> True
+            SEmpty       -> False
+            SChar _ s    -> go s
+            SText _ _ s  -> go s
+            SLine _ _    -> False
+            SAnnPush _ s -> go s
+            SAnnPop s    -> go s
+
+
+-- Note [Detecting failure with Unbounded page width]
+--
+-- To understand why it is sufficient to check the first line of the
+-- SimpleDocStream, trace how an SFail ends up there:
+--
+-- 1. We group a Doc containing a Line, producing a (Union x y) where
+--    x contains Fail.
+--
+-- 2. In best, any Unions are handled recursively, rejecting any
+--    alternatives that would result in SFail.
+--
+-- So once a SimpleDocStream reaches selectNicer, any SFail in it must
+-- appear before the first linebreak – any other SFail would have been
+-- detected and rejected in a previous iteration.
+
+
+
+-- | @(layoutCompact x)@ lays out the document @x@ without adding any
+-- indentation. Since no \'pretty\' printing is involved, this layouter is very
+-- fast. The resulting output contains fewer characters than a prettyprinted
+-- version and can be used for output that is read by other programs.
+--
+-- >>> let doc = hang 4 (vsep ["lorem", "ipsum", hang 4 (vsep ["dolor", "sit"])])
+-- >>> doc
+-- lorem
+--     ipsum
+--     dolor
+--         sit
+--
+-- >>> let putDocCompact = renderIO System.IO.stdout . layoutCompact
+-- >>> putDocCompact doc
+-- lorem
+-- ipsum
+-- dolor
+-- sit
+layoutCompact :: Doc ann -> SimpleDocStream ann
+layoutCompact doc = scan 0 [doc]
+  where
+    scan _ [] = SEmpty
+    scan !col (d:ds) = case d of
+        Fail            -> SFail
+        Empty           -> scan col ds
+        Char c          -> SChar c (scan (col+1) ds)
+        Text l t        -> let !col' = col+l in SText l t (scan col' ds)
+        FlatAlt x _     -> scan col (x:ds)
+        Line            -> SLine 0 (scan 0 ds)
+        Cat x y         -> scan col (x:y:ds)
+        Nest _ x        -> scan col (x:ds)
+        Union _ y       -> scan col (y:ds)
+        Column f        -> scan col (f col:ds)
+        WithPageWidth f -> scan col (f Unbounded : ds)
+        Nesting f       -> scan col (f 0 : ds)
+        Annotated _ x   -> scan col (x:ds)
+
+-- | @('show' doc)@ prettyprints document @doc@ with 'defaultLayoutOptions',
+-- ignoring all annotations.
+instance Show (Doc ann) where
+    showsPrec _ doc = renderShowS (layoutPretty defaultLayoutOptions doc)
+
+-- | Render a 'SimpleDocStream' to a 'ShowS', useful to write 'Show' instances
+-- based on the prettyprinter.
+--
+-- @
+-- instance 'Show' MyType where
+--     'showsPrec' _ = 'renderShowS' . 'layoutPretty' 'defaultLayoutOptions' . 'pretty'
+-- @
+renderShowS :: SimpleDocStream ann -> ShowS
+renderShowS = \sds -> case sds of
+    SFail        -> panicUncaughtFail
+    SEmpty       -> id
+    SChar c x    -> showChar c . renderShowS x
+    SText _l t x -> showString (T.unpack t) . renderShowS x
+    SLine i x    -> showString ('\n' : replicate i ' ') . renderShowS x
+    SAnnPush _ x -> renderShowS x
+    SAnnPop x    -> renderShowS x
+
+
+-- $setup
+--
+-- (Definitions for the doctests)
+--
+-- >>> :set -XOverloadedStrings
+-- >>> import Data.Text.Prettyprint.Doc.Render.Text
+-- >>> import Data.Text.Prettyprint.Doc.Symbols.Ascii
+-- >>> import Data.Text.Prettyprint.Doc.Util as Util
+-- >>> import Test.QuickCheck.Modifiers

--- a/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Render/String.hs
+++ b/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Render/String.hs
@@ -1,0 +1,10 @@
+module Data.Text.Prettyprint.Doc.Render.String (
+    renderString,
+    renderShowS,
+) where
+
+import Data.Text.Prettyprint.Doc.Internal (SimpleDocStream, renderShowS)
+
+-- | Render a 'SimpleDocStream' to a 'String'.
+renderString :: SimpleDocStream ann -> String
+renderString s = renderShowS s ""

--- a/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Render/Terminal.hs
+++ b/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Render/Terminal.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | This module is adapted from the package prettyprinter-ansi-terminal-1.1.2
--- to work with prettyprinter-1.6.1 in the context of Pact.
+-- to work with prettyprinter-1.6.0 in the context of Pact.
 --
 -- prettyprinter-ansi-terminal-1.1.2 is Copyright 2008, Daan Leijen and Max
 -- Bolingbroke, 2016 David Luposchainsky.

--- a/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Render/Terminal.hs
+++ b/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Render/Terminal.hs
@@ -1,0 +1,333 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | This module is adapted from the package prettyprinter-ansi-terminal-1.1.2
+-- to work with prettyprinter-1.6.1 in the context of Pact.
+--
+-- prettyprinter-ansi-terminal-1.1.2 is Copyright 2008, Daan Leijen and Max
+-- Bolingbroke, 2016 David Luposchainsky.
+--
+module Data.Text.Prettyprint.Doc.Render.Terminal (
+    -- * Styling
+    AnsiStyle(..),
+    Color(..),
+
+    -- ** Font color
+    color, colorDull,
+
+    -- ** Background color
+    bgColor, bgColorDull,
+
+    -- ** Font style
+    bold, italicized, underlined,
+
+    -- ** Internal markers
+    Intensity(..),
+    Bold(..),
+    Underlined(..),
+    Italicized(..),
+
+    -- * Conversion to ANSI-infused 'Text'
+    renderLazy, renderStrict,
+
+    -- * Render directly to 'stdout'
+    renderIO,
+
+    -- ** Convenience functions
+    putDoc, hPutDoc,
+) where
+
+
+
+import           Control.Applicative
+import           Data.IORef
+import           Data.Maybe
+import           Data.Text              (Text)
+import qualified Data.Text              as T
+import qualified Data.Text.IO           as T
+import qualified Data.Text.Lazy         as TL
+import qualified Data.Text.Lazy.Builder as TLB
+import qualified System.Console.ANSI    as ANSI
+import           System.IO              (Handle, hPutChar, stdout)
+
+import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc.Render.Util.Panic
+
+-- | The 8 ANSI terminal colors.
+data Color = Black | Red | Green | Yellow | Blue | Magenta | Cyan | White
+    deriving (Eq, Ord, Show)
+
+-- | Dull or vivid coloring, as supported by ANSI terminals.
+data Intensity = Vivid | Dull
+    deriving (Eq, Ord, Show)
+
+-- | Foreground (text) or background (paper) color
+data Layer = Foreground | Background
+    deriving (Eq, Ord, Show)
+
+data Bold       = Bold       deriving (Eq, Ord, Show)
+data Underlined = Underlined deriving (Eq, Ord, Show)
+data Italicized = Italicized deriving (Eq, Ord, Show)
+
+-- | Style the foreground with a vivid color.
+color :: Color -> AnsiStyle
+color c = mempty { ansiForeground = Just (Vivid, c) }
+
+-- | Style the background with a vivid color.
+bgColor :: Color -> AnsiStyle
+bgColor c =  mempty { ansiBackground = Just (Vivid, c) }
+
+-- | Style the foreground with a dull color.
+colorDull :: Color -> AnsiStyle
+colorDull c =  mempty { ansiForeground = Just (Dull, c) }
+
+-- | Style the background with a dull color.
+bgColorDull :: Color -> AnsiStyle
+bgColorDull c =  mempty { ansiBackground = Just (Dull, c) }
+
+-- | Render in __bold__.
+bold :: AnsiStyle
+bold = mempty { ansiBold = Just Bold }
+
+-- | Render in /italics/.
+italicized :: AnsiStyle
+italicized = mempty { ansiItalics = Just Italicized }
+
+-- | Render underlined.
+underlined :: AnsiStyle
+underlined = mempty { ansiUnderlining = Just Underlined }
+
+-- | @('renderLazy' doc)@ takes the output @doc@ from a rendering function
+-- and transforms it to lazy text, including ANSI styling directives for things
+-- like colorization.
+--
+-- ANSI color information will be discarded by this function unless you are
+-- running on a Unix-like operating system. This is due to a technical
+-- limitation in Windows ANSI support.
+--
+-- With a bit of trickery to make the ANSI codes printable, here is an example
+-- that would render colored in an ANSI terminal:
+--
+-- >>> let render = TL.putStrLn . TL.replace "\ESC" "\\e" . renderLazy . layoutPretty defaultLayoutOptions
+-- >>> let doc = annotate (color Red) ("red" <+> align (vsep [annotate (color Blue <> underlined) ("blue+u" <+> annotate bold "bold" <+> "blue+u"), "red"]))
+-- >>> render (unAnnotate doc)
+-- red blue+u bold blue+u
+--     red
+-- >>> render doc
+-- \e[0;91mred \e[0;94;4mblue+u \e[0;94;1;4mbold\e[0;94;4m blue+u\e[0;91m
+--     red\e[0m
+--
+-- Run the above via @echo -e '...'@ in your terminal to see the coloring.
+renderLazy :: SimpleDocStream AnsiStyle -> TL.Text
+renderLazy =
+    let push x = (x :)
+
+        unsafePeek []    = panicPeekedEmpty
+        unsafePeek (x:_) = x
+
+        unsafePop []     = panicPoppedEmpty
+        unsafePop (x:xs) = (x, xs)
+
+        go :: [AnsiStyle] -> SimpleDocStream AnsiStyle -> TLB.Builder
+        go s sds = case sds of
+            SFail -> panicUncaughtFail
+            SEmpty -> mempty
+            SChar c rest -> TLB.singleton c <> go s rest
+            SText _ t rest -> TLB.fromText t <> go s rest
+            SLine i rest -> TLB.singleton '\n' <> TLB.fromText (T.replicate i " ") <> go s rest
+            SAnnPush style rest ->
+                let currentStyle = unsafePeek s
+                    newStyle = style <> currentStyle
+                in  TLB.fromText (styleToRawText newStyle) <> go (push style s) rest
+            SAnnPop rest ->
+                let (_currentStyle, s') = unsafePop s
+                    newStyle = unsafePeek s'
+                in  TLB.fromText (styleToRawText newStyle) <> go s' rest
+
+    in  TLB.toLazyText . go [mempty]
+
+
+-- | @('renderIO' h sdoc)@ writes @sdoc@ to the handle @h@.
+--
+-- >>> let render = renderIO System.IO.stdout . layoutPretty defaultLayoutOptions
+-- >>> let doc = annotate (color Red) ("red" <+> align (vsep [annotate (color Blue <> underlined) ("blue+u" <+> annotate bold "bold" <+> "blue+u"), "red"]))
+--
+-- We render the 'unAnnotate'd version here, since the ANSI codes don’t display
+-- well in Haddock,
+--
+-- >>> render (unAnnotate doc)
+-- red blue+u bold blue+u
+--     red
+--
+-- This function behaves just like
+--
+-- @
+-- 'renderIO' h sdoc = 'TL.hPutStr' h ('renderLazy' sdoc)
+-- @
+--
+-- but will not generate any intermediate text, rendering directly to the
+-- handle.
+renderIO :: Handle -> SimpleDocStream AnsiStyle -> IO ()
+renderIO h sdoc = do
+    styleStackRef <- newIORef [mempty]
+
+    let push x = modifyIORef' styleStackRef (x :)
+        unsafePeek = readIORef styleStackRef >>= \tok -> case tok of
+            [] -> panicPeekedEmpty
+            x:_ -> pure x
+        unsafePop = readIORef styleStackRef >>= \tok -> case tok of
+            [] -> panicPoppedEmpty
+            x:xs -> writeIORef styleStackRef xs >> pure x
+
+    let go = \sds -> case sds of
+            SFail -> panicUncaughtFail
+            SEmpty -> pure ()
+            SChar c rest -> do
+                hPutChar h c
+                go rest
+            SText _ t rest -> do
+                T.hPutStr h t
+                go rest
+            SLine i rest -> do
+                hPutChar h '\n'
+                T.hPutStr h (T.replicate i (T.singleton ' '))
+                go rest
+            SAnnPush style rest -> do
+                currentStyle <- unsafePeek
+                let newStyle = style <> currentStyle
+                push newStyle
+                T.hPutStr h (styleToRawText newStyle)
+                go rest
+            SAnnPop rest -> do
+                _currentStyle <- unsafePop
+                newStyle <- unsafePeek
+                T.hPutStr h (styleToRawText newStyle)
+                go rest
+    go sdoc
+    readIORef styleStackRef >>= \stack -> case stack of
+        []  -> panicStyleStackFullyConsumed
+        [_] -> pure ()
+        xs  -> panicStyleStackNotFullyConsumed (length xs)
+
+panicStyleStackFullyConsumed :: void
+panicStyleStackFullyConsumed
+  = error ("There is no empty style left at the end of rendering" ++
+           " (but there should be). Please report this as a bug.")
+
+panicStyleStackNotFullyConsumed :: Int -> void
+panicStyleStackNotFullyConsumed len
+  = error ("There are " <> show len <> " styles left at the" ++
+           "end of rendering (there should be only 1). Please report" ++
+           " this as a bug.")
+
+-- $
+-- >>> let render = renderIO System.IO.stdout . layoutPretty defaultLayoutOptions
+-- >>> let doc = annotate (color Red) ("red" <+> align (vsep [annotate (color Blue <> underlined) ("blue+u" <+> annotate bold "bold" <+> "blue+u"), "red"]))
+-- >>> render (unAnnotate doc)
+-- red blue+u bold blue+u
+--     red
+--
+-- This test won’t work since I don’t know how to type \ESC for doctest :-/
+-- -- >>> render doc
+-- -- \ESC[0;91mred \ESC[0;94;4mblue+u \ESC[0;94;1;4mbold\ESC[0;94;4m blue+u\ESC[0;91m
+-- --     red\ESC[0m
+
+-- | Render the annotated document in a certain style. Styles not set in the
+-- annotation will use the style of the surrounding document, or the terminal’s
+-- default if none has been set yet.
+--
+-- @
+-- style = 'color' 'Green' '<>' 'bold'
+-- styledDoc = 'annotate' style "hello world"
+-- @
+data AnsiStyle = SetAnsiStyle
+    { ansiForeground  :: Maybe (Intensity, Color) -- ^ Set the foreground color, or keep the old one.
+    , ansiBackground  :: Maybe (Intensity, Color) -- ^ Set the background color, or keep the old one.
+    , ansiBold        :: Maybe Bold               -- ^ Switch on boldness, or don’t do anything.
+    , ansiItalics     :: Maybe Italicized         -- ^ Switch on italics, or don’t do anything.
+    , ansiUnderlining :: Maybe Underlined         -- ^ Switch on underlining, or don’t do anything.
+    } deriving (Eq, Ord, Show)
+
+-- | Keep the first decision for each of foreground color, background color,
+-- boldness, italication, and underlining. If a certain style is not set, the
+-- terminal’s default will be used.
+--
+-- Example:
+--
+-- @
+-- 'color' 'Red' '<>' 'color' 'Green'
+-- @
+--
+-- is red because the first color wins, and not bold because (or if) that’s the
+-- terminal’s default.
+instance Semigroup AnsiStyle where
+    cs1 <> cs2 = SetAnsiStyle
+        { ansiForeground  = ansiForeground  cs1 <|> ansiForeground  cs2
+        , ansiBackground  = ansiBackground  cs1 <|> ansiBackground  cs2
+        , ansiBold        = ansiBold        cs1 <|> ansiBold        cs2
+        , ansiItalics     = ansiItalics     cs1 <|> ansiItalics     cs2
+        , ansiUnderlining = ansiUnderlining cs1 <|> ansiUnderlining cs2 }
+
+-- | 'mempty' does nothing, which is equivalent to inheriting the style of the
+-- surrounding doc, or the terminal’s default if no style has been set yet.
+instance Monoid AnsiStyle where
+    mempty = SetAnsiStyle Nothing Nothing Nothing Nothing Nothing
+    mappend = (<>)
+
+styleToRawText :: AnsiStyle -> Text
+styleToRawText = T.pack . ANSI.setSGRCode . stylesToSgrs
+  where
+    stylesToSgrs :: AnsiStyle -> [ANSI.SGR]
+    stylesToSgrs (SetAnsiStyle fg bg b i u) = catMaybes
+        [ Just ANSI.Reset
+        , fmap (\(intensity, c) -> ANSI.SetColor ANSI.Foreground (convertIntensity intensity) (convertColor c)) fg
+        , fmap (\(intensity, c) -> ANSI.SetColor ANSI.Background (convertIntensity intensity) (convertColor c)) bg
+        , fmap (\_              -> ANSI.SetConsoleIntensity ANSI.BoldIntensity) b
+        , fmap (\_              -> ANSI.SetItalicized True) i
+        , fmap (\_              -> ANSI.SetUnderlining ANSI.SingleUnderline) u
+        ]
+
+    convertIntensity :: Intensity -> ANSI.ColorIntensity
+    convertIntensity = \i -> case i of
+        Vivid -> ANSI.Vivid
+        Dull  -> ANSI.Dull
+
+    convertColor :: Color -> ANSI.Color
+    convertColor = \c -> case c of
+        Black   -> ANSI.Black
+        Red     -> ANSI.Red
+        Green   -> ANSI.Green
+        Yellow  -> ANSI.Yellow
+        Blue    -> ANSI.Blue
+        Magenta -> ANSI.Magenta
+        Cyan    -> ANSI.Cyan
+        White   -> ANSI.White
+
+
+
+-- | @('renderStrict' sdoc)@ takes the output @sdoc@ from a rendering and
+-- transforms it to strict text.
+renderStrict :: SimpleDocStream AnsiStyle -> Text
+renderStrict = TL.toStrict . renderLazy
+
+-- | @('putDoc' doc)@ prettyprints document @doc@ to standard output using
+-- 'defaultLayoutOptions'.
+--
+-- >>> putDoc ("hello" <+> "world")
+-- hello world
+--
+-- @
+-- 'putDoc' = 'hPutDoc' 'stdout'
+-- @
+putDoc :: Doc AnsiStyle -> IO ()
+putDoc = hPutDoc stdout
+
+-- | Like 'putDoc', but instead of using 'stdout', print to a user-provided
+-- handle, e.g. a file or a socket using 'defaultLayoutOptions'.
+--
+-- > main = withFile "someFile.txt" (\h -> hPutDoc h (vcat ["vertical", "text"]))
+--
+-- @
+-- 'hPutDoc' h doc = 'renderIO' h ('layoutPretty' 'defaultLayoutOptions' doc)
+-- @
+hPutDoc :: Handle -> Doc AnsiStyle -> IO ()
+hPutDoc h doc = renderIO h (layoutPretty defaultLayoutOptions doc)

--- a/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Render/Text.hs
+++ b/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Render/Text.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Render an unannotated 'SimpleDocStream' as plain 'Text'.
+module Data.Text.Prettyprint.Doc.Render.Text (
+    -- * Conversion to plain 'Text'
+    renderLazy, renderStrict,
+
+    -- * Render to a 'Handle'
+    renderIO,
+
+    -- ** Convenience functions
+    putDoc, hPutDoc
+) where
+
+
+
+import           Data.Text              (Text)
+import qualified Data.Text              as T
+import qualified Data.Text.IO           as T
+import qualified Data.Text.Lazy         as TL
+import qualified Data.Text.Lazy.Builder as TLB
+import           System.IO
+
+import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc.Render.Util.Panic
+import Data.Text.Prettyprint.Doc.Render.Util.StackMachine
+
+-- $setup
+--
+-- (Definitions for the doctests)
+--
+-- >>> :set -XOverloadedStrings
+-- >>> import qualified Data.Text.IO as T
+-- >>> import qualified Data.Text.Lazy.IO as TL
+
+
+
+-- | @('renderLazy' sdoc)@ takes the output @sdoc@ from a rendering function
+-- and transforms it to lazy text.
+--
+-- >>> let render = TL.putStrLn . renderLazy . layoutPretty defaultLayoutOptions
+-- >>> let doc = "lorem" <+> align (vsep ["ipsum dolor", parens "foo bar", "sit amet"])
+-- >>> render doc
+-- lorem ipsum dolor
+--       (foo bar)
+--       sit amet
+renderLazy :: SimpleDocStream ann -> TL.Text
+renderLazy = TLB.toLazyText . renderSimplyDecorated TLB.fromText (pure mempty) (pure mempty)
+
+-- | @('renderStrict' sdoc)@ takes the output @sdoc@ from a rendering function
+-- and transforms it to strict text.
+renderStrict :: SimpleDocStream ann -> Text
+renderStrict = TL.toStrict . renderLazy
+
+
+
+-- | @('renderIO' h sdoc)@ writes @sdoc@ to the file @h@.
+--
+-- >>> renderIO System.IO.stdout (layoutPretty defaultLayoutOptions "hello\nworld")
+-- hello
+-- world
+--
+-- This function is more efficient than @'T.hPutStr' h ('renderStrict' sdoc)@,
+-- since it writes to the handle directly, skipping the intermediate 'Text'
+-- representation.
+renderIO :: Handle -> SimpleDocStream ann -> IO ()
+renderIO h = go
+  where
+    go :: SimpleDocStream ann -> IO ()
+    go = \sds -> case sds of
+        SFail              -> panicUncaughtFail
+        SEmpty             -> pure ()
+        SChar c rest       -> do hPutChar h c
+                                 go rest
+        SText _ t rest     -> do T.hPutStr h t
+                                 go rest
+        SLine n rest       -> do hPutChar h '\n'
+                                 T.hPutStr h (T.replicate n " ")
+                                 go rest
+        SAnnPush _ann rest -> go rest
+        SAnnPop rest       -> go rest
+
+-- | @('putDoc' doc)@ prettyprints document @doc@ to standard output. Uses the
+-- 'defaultLayoutOptions'.
+--
+-- >>> putDoc ("hello" <+> "world")
+-- hello world
+--
+-- @
+-- 'putDoc' = 'hPutDoc' 'stdout'
+-- @
+putDoc :: Doc ann -> IO ()
+putDoc = hPutDoc stdout
+
+-- | Like 'putDoc', but instead of using 'stdout', print to a user-provided
+-- handle, e.g. a file or a socket. Uses the 'defaultLayoutOptions'.
+--
+-- @
+-- main = 'withFile' filename (\h -> 'hPutDoc' h doc)
+--   where
+--     doc = 'vcat' ["vertical", "text"]
+--     filename = "someFile.txt"
+-- @
+--
+-- @
+-- 'hPutDoc' h doc = 'renderIO' h ('layoutPretty' 'defaultLayoutOptions' doc)
+-- @
+hPutDoc :: Handle -> Doc ann -> IO ()
+hPutDoc h doc = renderIO h (layoutPretty defaultLayoutOptions doc)

--- a/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Render/Util/Panic.hs
+++ b/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Render/Util/Panic.hs
@@ -1,0 +1,38 @@
+module Data.Text.Prettyprint.Doc.Render.Util.Panic (
+    panicUncaughtFail,
+    panicUnpairedPop,
+    panicSimpleDocTreeConversionFailed,
+    panicInputNotFullyConsumed,
+    panicPeekedEmpty,
+    panicPoppedEmpty,
+) where
+
+-- | Raise a hard 'error' if there is a 'Data.Text.Prettyprint.Doc.SFail' in a
+-- 'Data.Text.Prettyprint.Doc.SimpleDocStream'.
+panicUncaughtFail :: void
+panicUncaughtFail = error ("»SFail« must not appear in a rendered »SimpleDocStream«. This is a bug in the layout algorithm! " ++ report)
+
+-- | Raise a hard 'error' when an annotation terminator is encountered in an
+-- unannotated region.
+panicUnpairedPop :: void
+panicUnpairedPop = error ("An unpaired style terminator was encountered. This is a bug in the layout algorithm! " ++ report)
+
+-- | Raise a hard generic 'error' when the
+-- 'Data.Text.Prettyprint.Doc.SimpleDocStream' to
+-- 'Data.Text.Prettyprint.Doc.Render.Util.SimpleDocTree.SimpleDocTree' conversion fails.
+panicSimpleDocTreeConversionFailed :: void
+panicSimpleDocTreeConversionFailed = error ("Conversion from SimpleDocStream to SimpleDocTree failed! " ++ report)
+
+-- | Raise a hard 'error' when the »to
+-- 'Data.Text.Prettyprint.Doc.Render.Util.SimpleDocTree.SimpleDocTree'« parser finishes
+-- without consuming the full input.
+panicInputNotFullyConsumed :: void
+panicInputNotFullyConsumed = error ("Conversion from SimpleDocStream to SimpleDocTree left unconsumed input! " ++ report)
+
+report :: String
+report = "Please report this as a bug"
+
+panicPeekedEmpty, panicPoppedEmpty :: void
+(panicPeekedEmpty, panicPoppedEmpty) = (mkErr "Peeked", mkErr "Popped")
+  where
+    mkErr x = error (x ++ " an empty style stack! Please report this as a bug.")

--- a/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Render/Util/StackMachine.hs
+++ b/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Render/Util/StackMachine.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Definitions to write renderers based on looking at a 'SimpleDocStream' as
+-- an instruction tape for a stack machine: text is written, annotations are
+-- added (pushed) and later removed (popped).
+module Data.Text.Prettyprint.Doc.Render.Util.StackMachine (
+
+    -- * Simple, pre-defined stack machines
+    --
+    -- | These cover most basic use cases where there is not too much special
+    -- logic, and all that’s important is how to render text, and how to
+    -- add/remove an annotation.
+    renderSimplyDecorated,
+    renderSimplyDecoratedA,
+
+    -- * General stack machine
+    --
+    -- | These definitions allow defining a full-blown stack machine renderer,
+    -- allowing for arbitrary peeking, popping and what not.
+    StackMachine,
+    execStackMachine,
+
+    pushStyle,
+    unsafePopStyle,
+    unsafePeekStyle,
+    writeOutput,
+) where
+
+
+
+import           Control.Applicative
+import           Data.Text           (Text)
+import qualified Data.Text           as T
+
+import Data.Text.Prettyprint.Doc                   (SimpleDocStream (..))
+import Data.Text.Prettyprint.Doc.Render.Util.Panic
+
+
+-- $setup
+--
+-- (Definitions for the doctests)
+--
+-- >>> import Data.Text.Prettyprint.Doc hiding ((<>))
+-- >>> import qualified Data.Text.IO as T
+
+
+
+-- | Simplest possible stack-based renderer.
+--
+-- For example, here is a document annotated with @()@, and the behaviour is to
+-- write »>>>« at the beginning, and »<<<« at the end of the annotated region:
+--
+-- >>> let doc = "hello" <+> annotate () "world" <> "!"
+-- >>> let sdoc = layoutPretty defaultLayoutOptions doc
+-- >>> T.putStrLn (renderSimplyDecorated id (\() -> ">>>") (\() -> "<<<") sdoc)
+-- hello >>>world<<<!
+--
+-- The monoid will be concatenated in a /right associative/ fashion.
+renderSimplyDecorated
+    :: Monoid out
+    => (Text -> out) -- ^ Render plain 'Text'
+    -> (ann -> out)  -- ^ How to render an annotation
+    -> (ann -> out)  -- ^ How to render the removed annotation
+    -> SimpleDocStream ann
+    -> out
+renderSimplyDecorated text push pop = go []
+  where
+    go _           SFail               = panicUncaughtFail
+    go []          SEmpty              = mempty
+    go (_:_)       SEmpty              = panicInputNotFullyConsumed
+    go stack       (SChar c rest)      = text (T.singleton c) <> go stack rest
+    go stack       (SText _l t rest)   = text t <> go stack rest
+    go stack       (SLine i rest)      = text (T.singleton '\n') <> text (T.replicate i " ") <> go stack rest
+    go stack       (SAnnPush ann rest) = push ann <> go (ann : stack) rest
+    go (ann:stack) (SAnnPop rest)      = pop ann <> go stack rest
+    go []          SAnnPop{}           = panicUnpairedPop
+{-# INLINE renderSimplyDecorated #-}
+
+-- | Version of 'renderSimplyDecoratedA' that allows for 'Applicative' effects.
+renderSimplyDecoratedA
+    :: (Applicative f, Monoid out)
+    => (Text -> f out) -- ^ Render plain 'Text'
+    -> (ann -> f out)  -- ^ How to render an annotation
+    -> (ann -> f out)  -- ^ How to render the removed annotation
+    -> SimpleDocStream ann
+    -> f out
+renderSimplyDecoratedA text push pop = go []
+  where
+    go _           SFail               = panicUncaughtFail
+    go []          SEmpty              = pure mempty
+    go (_:_)       SEmpty              = panicInputNotFullyConsumed
+    go stack       (SChar c rest)      = text (T.singleton c) <++> go stack rest
+    go stack       (SText _l t rest)   = text t <++> go stack rest
+    go stack       (SLine i rest)      = text (T.singleton '\n') <++> text (T.replicate i " ") <++> go stack rest
+    go stack       (SAnnPush ann rest) = push ann <++> go (ann : stack) rest
+    go (ann:stack) (SAnnPop rest)      = pop ann <++> go stack rest
+    go []          SAnnPop{}           = panicUnpairedPop
+
+    (<++>) = liftA2 mappend
+{-# INLINE renderSimplyDecoratedA #-}
+
+
+
+-- | @WriterT output StateT [style] a@, but with a strict Writer value.
+--
+-- The @output@ type is used to append data chunks to, the @style@ is the member
+-- of a stack of styles to model nested styles with.
+newtype StackMachine output style a = StackMachine ([style] -> (a, output, [style]))
+{-# DEPRECATED StackMachine "Writing your own stack machine is probably more efficient and customizable; also consider using »renderSimplyDecorated(A)« instead" #-}
+
+instance Functor (StackMachine output style) where
+    fmap f (StackMachine r) = StackMachine (\s ->
+        let (x1, w1, s1) = r s
+        in (f x1, w1, s1))
+
+instance Monoid output => Applicative (StackMachine output style) where
+    pure x = StackMachine (\s -> (x, mempty, s))
+    StackMachine f <*> StackMachine x = StackMachine (\s ->
+        let (f1, w1, s1) = f s
+            (x2, w2, s2) = x s1
+            !w12 = w1 <> w2
+        in (f1 x2, w12, s2))
+
+instance Monoid output => Monad (StackMachine output style) where
+    StackMachine r >>= f = StackMachine (\s ->
+        let (x1, w1, s1) = r s
+            StackMachine r1 = f x1
+            (x2, w2, s2) = r1 s1
+            !w12 = w1 <> w2
+        in (x2, w12, s2))
+
+-- | Add a new style to the style stack.
+pushStyle :: Monoid output => style -> StackMachine output style ()
+pushStyle style = StackMachine (\styles -> ((), mempty, style : styles))
+
+-- | Get the topmost style.
+--
+-- If the stack is empty, this raises an 'error'.
+unsafePopStyle :: Monoid output => StackMachine output style style
+unsafePopStyle = StackMachine (\stack -> case stack of
+    x:xs -> (x, mempty, xs)
+    [] -> panicPoppedEmpty )
+
+-- | View the topmost style, but do not modify the stack.
+--
+-- If the stack is empty, this raises an 'error'.
+unsafePeekStyle :: Monoid output => StackMachine output style style
+unsafePeekStyle = StackMachine (\styles -> case styles of
+    x:_ -> (x, mempty, styles)
+    [] -> panicPeekedEmpty )
+
+-- | Append a value to the output end.
+writeOutput :: output -> StackMachine output style ()
+writeOutput w = StackMachine (\styles -> ((), w, styles))
+
+-- | Run the renderer and retrive the writing end
+execStackMachine :: [styles] -> StackMachine output styles a -> (output, [styles])
+execStackMachine styles (StackMachine r) = let (_, w, s) = r styles in (w, s)

--- a/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Symbols/Ascii.hs
+++ b/vendored/prettyprinter-1.6.0/src/Data/Text/Prettyprint/Doc/Symbols/Ascii.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Common symbols composed out of the ASCII subset of Unicode. For non-ASCII
+-- symbols, see "Data.Text.Prettyprint.Doc.Symbols.Unicode".
+module Data.Text.Prettyprint.Doc.Symbols.Ascii where
+
+
+
+import Data.Text.Prettyprint.Doc.Internal
+
+
+
+-- | >>> squotes "·"
+-- '·'
+squotes :: Doc ann -> Doc ann
+squotes = enclose squote squote
+
+-- | >>> dquotes "·"
+-- "·"
+dquotes :: Doc ann -> Doc ann
+dquotes = enclose dquote dquote
+
+-- | >>> parens "·"
+-- (·)
+parens :: Doc ann -> Doc ann
+parens = enclose lparen rparen
+
+-- | >>> angles "·"
+-- <·>
+angles :: Doc ann -> Doc ann
+angles = enclose langle rangle
+
+-- | >>> brackets "·"
+-- [·]
+brackets :: Doc ann -> Doc ann
+brackets = enclose lbracket rbracket
+
+-- | >>> braces "·"
+-- {·}
+braces :: Doc ann -> Doc ann
+braces = enclose lbrace rbrace
+
+-- | >>> squote
+-- '
+squote :: Doc ann
+squote = "'"
+
+-- | >>> dquote
+-- "
+dquote :: Doc ann
+dquote = "\""
+
+-- | >>> lparen
+-- (
+lparen :: Doc ann
+lparen = "("
+
+-- | >>> rparen
+-- )
+rparen :: Doc ann
+rparen = ")"
+
+-- | >>> langle
+-- <
+langle :: Doc ann
+langle = "<"
+
+-- | >>> rangle
+-- >
+rangle :: Doc ann
+rangle = ">"
+
+-- | >>> lbracket
+-- [
+lbracket :: Doc ann
+lbracket = "["
+-- | >>> rbracket
+-- ]
+rbracket :: Doc ann
+rbracket = "]"
+
+-- | >>> lbrace
+-- {
+lbrace :: Doc ann
+lbrace = "{"
+-- | >>> rbrace
+-- }
+rbrace :: Doc ann
+rbrace = "}"
+
+-- | >>> semi
+-- ;
+semi :: Doc ann
+semi = ";"
+
+-- | >>> colon
+-- :
+colon :: Doc ann
+colon = ":"
+
+-- | >>> comma
+-- ,
+comma :: Doc ann
+comma = ","
+
+-- | >>> "a" <> space <> "b"
+-- a b
+--
+-- This is mostly used via @'<+>'@,
+--
+-- >>> "a" <+> "b"
+-- a b
+space :: Doc ann
+space = " "
+
+-- | >>> dot
+-- .
+dot :: Doc ann
+dot = "."
+
+-- | >>> slash
+-- /
+slash :: Doc ann
+slash = "/"
+
+-- | >>> backslash
+-- \\
+
+backslash :: Doc ann
+backslash = "\\"
+
+-- | >>> equals
+-- =
+equals :: Doc ann
+equals = "="
+
+-- | >>> pipe
+-- |
+pipe :: Doc ann
+pipe = "|"
+
+
+
+-- $setup
+--
+-- (Definitions for the doctests)
+--
+-- >>> :set -XOverloadedStrings
+-- >>> import Data.Semigroup
+-- >>> import Data.Text.Prettyprint.Doc.Render.Text
+-- >>> import Data.Text.Prettyprint.Doc.Util


### PR DESCRIPTION
Vendor relevant files from prettyerinter-1.6.0. This is a prerequisite for the of mtl-2.3 and latest pact master in chainweb.

As a side effect of the PR, the source-repository-package pin on trifecta can be dropped. It also removes implicit upper bounds on a number of other dependencies like optparse-applicative and configuration tools.

PR checklist:

There are no actual code changes (the code from prettyerinter is copy and pasted without changes, only outdated CPP guarded code is removed) and no behavior changes.

However, due to the implied upgrade of the trifecta version, we have to double check that main net history replay still is not broken, which will be done for the corresponding chainweb-node PR.

* [x] Confirm replay/back compat 
    
    Mainnet replay succeeded on https://github.com/kadena-io/chainweb-node/pull/1709
