### PR TITLE
Tweak cost of running `concat`

### DIFF
--- a/src/Pact/Gas/Table.hs
+++ b/src/Pact/Gas/Table.hs
@@ -39,9 +39,9 @@ data GasCostConfig = GasCostConfig
   , _gasCostConfig_sortFactor :: Gas
   , _gasCostConfig_distinctFactor :: Gas
   , _gasCostConfig_concatenationFactor :: Gas
-  , _gasCostConfig_textConcatenationFactorOffset :: Gas -- up-front cost of text concatenation
-  , _gasCostConfig_textConcatenationFactorStringLen :: Gas -- additional cost of concatenation per 1K characters in the average string
-  , _gasCostConfig_textConcatenationFactorStrings :: Gas -- additional cost of concatenation per 1K strings
+  , _gasCostConfig_textConcatenationFactorOffset :: MilliGas -- up-front cost of text concatenation
+  , _gasCostConfig_textConcatenationFactorStringLen :: MilliGas -- additional cost of concatenation per character in the average string
+  , _gasCostConfig_textConcatenationFactorStrings :: MilliGas -- additional cost of concatenation per list item
   , _gasCostConfig_moduleCost :: Gas
   , _gasCostConfig_moduleMemberCost :: Gas
   , _gasCostConfig_useModuleCost :: Gas
@@ -61,9 +61,9 @@ defaultGasConfig = GasCostConfig
   , _gasCostConfig_sortFactor = 1
   , _gasCostConfig_distinctFactor = 1
   , _gasCostConfig_concatenationFactor = 1  -- TODO benchmark
-  , _gasCostConfig_textConcatenationFactorOffset = 50
-  , _gasCostConfig_textConcatenationFactorStringLen = 20
-  , _gasCostConfig_textConcatenationFactorStrings = 40
+  , _gasCostConfig_textConcatenationFactorOffset = MilliGas 50000
+  , _gasCostConfig_textConcatenationFactorStringLen = MilliGas 20
+  , _gasCostConfig_textConcatenationFactorStrings = MilliGas 40
   , _gasCostConfig_moduleCost = 1        -- TODO benchmark
   , _gasCostConfig_moduleMemberCost = 1
   , _gasCostConfig_useModuleCost = 1     -- TODO benchmark
@@ -256,10 +256,18 @@ tableGasModel gasConfig =
           gasToMilliGas $ fromIntegral n * _gasCostConfig_sortFactor gasConfig
         GConcatenation i j -> gasToMilliGas $
           fromIntegral (i + j) * _gasCostConfig_concatenationFactor gasConfig
-        GTextConcatenation nChars nStrings -> gasToMilliGas $
-          _gasCostConfig_textConcatenationFactorOffset gasConfig +
-          (fromIntegral nChars  * _gasCostConfig_textConcatenationFactorStringLen gasConfig) `div` 1000 `div` fromIntegral nStrings +
-          (fromIntegral nStrings * _gasCostConfig_textConcatenationFactorStrings gasConfig) `div` 1000
+        GTextConcatenation nChars nStrings ->
+          let
+            MilliGas offsetCost = _gasCostConfig_textConcatenationFactorOffset gasConfig
+            MilliGas charCost = _gasCostConfig_textConcatenationFactorStringLen gasConfig
+            MilliGas stringCost = _gasCostConfig_textConcatenationFactorStrings gasConfig
+
+            costForAverageStringLength =
+              (fromIntegral nChars  * charCost) `div` fromIntegral nStrings
+            costForNumberOfStrings =
+              fromIntegral nStrings * stringCost
+          in
+           MilliGas $ offsetCost + costForAverageStringLength + costForNumberOfStrings
         GFoldDB -> gasToMilliGas $ _gasCostConfig_foldDBCost gasConfig
         GPostRead r -> gasToMilliGas $ case r of
           ReadData cols -> _gasCostConfig_readColumnCost gasConfig * fromIntegral (Map.size (_objectMap $ _rdData cols))

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -1279,9 +1279,10 @@ concat' i [TList ls _ _] = do
               nStrings = V.length ls
           in
           GTextConcatenation nChars nStrings
-  computeGas' i concatGasCost $ let
-    ls' = V.toList ls
-    concatTextList = flip TLiteral def . LString . T.concat
+  computeGas' i concatGasCost $
+    let
+      ls' = V.toList ls
+      concatTextList = flip TLiteral def . LString . T.concat
     in fmap concatTextList $ forM ls' $ \case
       TLitString s -> return s
       t -> isOffChainForkedError >>= \case

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -1285,7 +1285,7 @@ concat' i [TList ls _ _] = do
       concatTextList = flip TLiteral def . LString . T.concat
     in fmap concatTextList $ forM ls' $ \case
       TLitString s -> return s
-      t -> isOffChainForkedError >>= \case
+      t -> isOffChainForkedError FlagDisablePact47 >>= \case
         OffChainError -> evalError' i $ "concat: expecting list of strings: " <> pretty t
         OnChainError -> evalError' i $ "concat: expected list of strings, received value of type: " <> pretty (typeof' t)
 concat' i as = argsError i as

--- a/src/Pact/Types/Gas.hs
+++ b/src/Pact/Types/Gas.hs
@@ -137,7 +137,10 @@ data GasArgs
   | GSortFieldLookup !Int
   -- ^ Cost of sorting by lookup fields
   | GConcatenation !Int !Int
-  -- ^ Cost of concatenating two strings, lists, and objects
+  -- ^ Cost of concatenating two strings before pact 4.8, lists, and objects
+  | GTextConcatenation !Int !Int
+  -- ^ Cost of concatenating a list of strings with the given total character
+  -- count and list length after pact 4.8
   | GUnreduced ![Term Ref]
   -- ^ Cost of using a native function
   | GPostRead !ReadValue
@@ -204,6 +207,7 @@ instance Pretty GasArgs where
     GSelect {} -> "GSelect"
     GSortFieldLookup i -> "GSortFieldLookup:" <> pretty i
     GConcatenation i j -> "GConcatenation:" <> pretty i <> colon <> pretty j
+    GTextConcatenation nChars nStrings -> "GTextConcatenation:" <> pretty nChars <> colon <> pretty nStrings
     GUnreduced {} -> "GUnreduced"
     GPostRead rv -> "GPostRead:" <> pretty rv
     GPreWrite wv szVer -> "GWrite:" <> pretty wv <> colon <> pretty szVer

--- a/tests/GasModelSpec.hs
+++ b/tests/GasModelSpec.hs
@@ -166,7 +166,7 @@ runTest t = runGasUnitTests t run run
       let
         flags = mkExecutionConfig
                [ FlagDisableInlineMemCheck, FlagDisablePactEvents
-               , FlagDisablePact43, FlagDisablePact44, FlagDisablePact45]
+               , FlagDisablePact43, FlagDisablePact44, FlagDisablePact45, FlagDisablePact48]
         r' = set eeExecutionConfig flags r
       pure (r', s)
 

--- a/tests/pact/gas.repl
+++ b/tests/pact/gas.repl
@@ -798,3 +798,34 @@ d.G3
 (str-to-list "0123456789")
 (expect "gas of str-to-list post-fork" 11 (env-gas))
 (commit-tx)
+
+
+; Test that `concat` is gassed by the number of characters
+; at pact-4.8.
+(begin-tx)
+(env-gaslimit 1000000)
+(module m G
+  (defcap G () true)
+  (defun ten_x_string (n)
+      (fold (lambda (acc unused) (+ acc "aaaaaaaaaa")) "" (enumerate 1 n)))
+  (defconst strings_1000_1000:[string] (make-list 1000 (ten_x_string 100)))
+  (defconst strings_1000_2000:[string] (make-list 2000 (ten_x_string 100)))
+  (defconst strings_2000_1000:[string] (make-list 1000 (ten_x_string 200)))
+  )
+
+; ============================================================ ;
+;; TEST: cost of running concat on large strings.
+;;
+(env-gas 0)
+(concat strings_1000_1000)
+(expect "calling (concat strings_1000_1000)" 111 (env-gas))
+
+(env-gas 0)
+(concat strings_2000_1000)
+(expect "calling (concat strings_2000_1000)" 131 (env-gas))
+
+(env-gas 0)
+(concat strings_1000_2000)
+(expect "calling (concat strings_1000_2000)" 151 (env-gas))
+
+(commit-tx)


### PR DESCRIPTION
Tweak the gas costing for the `concat` builtin to account for both the number of strings being concatenated, and the length of those strings.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] **N/A** Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] **N/A** In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [x] Confirm replay/back compat
* [x] Benchmark regressions
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
