### PR TITLE
Fix modref infos in capability guards

### DIFF
--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -43,7 +43,7 @@ module Pact.Eval
     ,computeUserAppGas,prepareUserAppArgs,evalUserAppBody
     ,evalByName
     ,resumePact
-    ,enforcePactValue,enforcePactValue'
+    ,enforcePactValue
     ,toPersistDirect
     ,reduceDynamic
     ,instantiate'
@@ -162,8 +162,7 @@ enforceGuard i g = case g of
     void $ runSysOnly $ evalByName _ugFun _ugArgs (getInfo i)
   GCapability CapabilityGuard{..} -> do
     traverse_ (enforcePactId True) _cgPactId
-    elide <- ifExecutionFlagSet' FlagDisablePact48 id elideModRefInfo
-    args <- traverse (fmap elide . enforcePactValue) _cgArgs
+    args <- traverse enforcePactValue _cgArgs
     acquired <- capabilityAcquired $ SigCapability _cgName args
     unless acquired $ failTx' i "Capability not acquired"
   where
@@ -1134,10 +1133,9 @@ appCall fa ai as = call (StackFrame (_faName fa) ai (Just (fa,map abbrev as)))
 enforcePactValue :: Pretty n => (Term n) -> Eval e PactValue
 enforcePactValue t = case toPactValue t of
   Left s -> evalError' t $ "Only value-level terms permitted: " <> pretty s
-  Right v -> return v
-
-enforcePactValue' :: (Pretty n, Traversable f) => f (Term n) -> Eval e (f PactValue)
-enforcePactValue' = traverse enforcePactValue
+  Right v -> do
+    elide <- ifExecutionFlagSet' FlagDisablePact48 id elideModRefInfo
+    return (elide v)
 
 reduceApp :: App (Term Ref) -> Eval e (Term Name)
 reduceApp (App (TVar (Direct t) _) as ai) = reduceDirect t as ai
@@ -1156,7 +1154,7 @@ reduceApp (App (TDef d@Def{..} _) as ai) = do
         continuation <-
           PactContinuation (QName (QualifiedName _dModule (asString _dDefName) def))
           . map elideModRefInfo
-          <$> enforcePactValue' (fst af)
+          <$> traverse enforcePactValue (fst af)
         initPact ai continuation bod'
     Defcap -> computeUserAppGas d ai *> evalError ai "Cannot directly evaluate defcap"
 reduceApp (App (TLam (Lam lamName funTy body _) _) as ai) =

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -162,7 +162,8 @@ enforceGuard i g = case g of
     void $ runSysOnly $ evalByName _ugFun _ugArgs (getInfo i)
   GCapability CapabilityGuard{..} -> do
     traverse_ (enforcePactId True) _cgPactId
-    args <- enforcePactValue' _cgArgs
+    elide <- ifExecutionFlagSet' FlagDisablePact48 id elideModRefInfo
+    args <- traverse (fmap elide . enforcePactValue) _cgArgs
     acquired <- capabilityAcquired $ SigCapability _cgName args
     unless acquired $ failTx' i "Capability not acquired"
   where

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -315,7 +315,10 @@ hashDef = defRNative "hash" hash' (funType tTyString [("value",a)])
     hash' :: RNativeFun e
     hash' i as = case as of
       [TLitString s] -> go $ T.encodeUtf8 s
-      [a'] -> enforcePactValue a' >>= \pv -> go $ J.encodeStrict pv
+      [a'] -> do
+        elide <- ifExecutionFlagSet' FlagDisablePact48 id elideModRefInfo
+        pv <- elide <$> enforcePactValue a'
+        go $ J.encodeStrict pv
       _ -> argsError i as
       where go = return . tStr . asString . pactHash
 

--- a/src/Pact/Native.hs
+++ b/src/Pact/Native.hs
@@ -315,10 +315,7 @@ hashDef = defRNative "hash" hash' (funType tTyString [("value",a)])
     hash' :: RNativeFun e
     hash' i as = case as of
       [TLitString s] -> go $ T.encodeUtf8 s
-      [a'] -> do
-        elide <- ifExecutionFlagSet' FlagDisablePact48 id elideModRefInfo
-        pv <- elide <$> enforcePactValue a'
-        go $ J.encodeStrict pv
+      [a'] -> enforcePactValue a' >>= go . J.encodeStrict
       _ -> argsError i as
       where go = return . tStr . asString . pactHash
 
@@ -1152,7 +1149,7 @@ yield i as = case as of
       case eym of
         Nothing -> evalError' i "Yield not in defpact context"
         Just pe -> do
-          o' <- fmap elideModRefInfo <$> enforcePactValue' o
+          o' <- fmap elideModRefInfo <$> traverse enforcePactValue o
           y <- case tid of
             Nothing -> return $ Yield o' Nothing Nothing
             Just t -> do
@@ -1422,7 +1419,7 @@ continueNested i as = gasUnreduced i as $ case as of
   [TApp (App t args _) _] -> lookup' t >>= \d ->
     (,) <$> view eePactStep <*> use evalPactExec >>= \case
       (Just ps, Just pe) -> do
-        contArgs <- traverse reduce args >>= enforcePactValue'
+        contArgs <- traverse reduce args >>= traverse enforcePactValue
         let childName = QName (QualifiedName (_dModule d) (asString (_dDefName d)) def)
             cont = PactContinuation childName (stripPactValueInfo <$> contArgs)
         newPactId <- createNestedPactId i cont (_psPactId ps)

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -355,7 +355,7 @@ withDefaultRead fi as@[table',key',defaultRow',b@(TBinding ps bd (BindSchema _) 
       guardTable fi table GtWithDefaultRead
       mrow <- readRow (_faInfo fi) (userTable table) (RowKey key)
       case mrow of
-        Nothing -> bindToRow ps bd b =<< enforcePactValue' defaultRow
+        Nothing -> bindToRow ps bd b =<< traverse enforcePactValue defaultRow
         (Just row) -> gasPostRead' fi row $ bindToRow ps bd b (rowDataToPactValue <$> _rdData row)
     _ -> argsError' fi as
 withDefaultRead fi as = argsError' fi as
@@ -439,7 +439,7 @@ write wt partial i as = do
   ts <- mapM reduce as
   case ts of
     [table@TTable {..},TLitString key, TObject (Object ps _ _ _) _] -> do
-      ps' <- enforcePactValue' ps
+      ps' <- traverse enforcePactValue ps
       computeGas (Right i) (GUnreduced [])
       szVer <- getSizeOfVersion
       computeGas (Right i) (GPreWrite (WriteData wt (asString key) ps') szVer)

--- a/src/Pact/Native/Guards.hs
+++ b/src/Pact/Native/Guards.hs
@@ -28,7 +28,6 @@ import Pact.Types.Capability
 import Pact.Types.KeySet
 import Pact.Types.Pretty
 import Pact.Types.Principal
-import Pact.Types.PactValue
 import Pact.Types.Runtime
 
 
@@ -180,8 +179,7 @@ createPrincipalDef =
 
 createPrincipal :: Info -> Guard (Term Name) -> Eval e Text
 createPrincipal i g = do
-  f <- ifExecutionFlagSet' FlagDisablePact48 id elideModRefInfo
-  g' <- traverse (fmap f . enforcePactValue) g
+  g' <- traverse enforcePactValue g
   mkPrincipalIdent <$> guardToPrincipal chargeGas g'
   where
     chargeGas amt =

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -448,7 +448,7 @@ mkSimpleYield
   -> ObjectMap (Term n)
   -> Eval e (Maybe Yield)
 mkSimpleYield p om =
-  Just . (\yieldData -> Yield yieldData p Nothing) <$> enforcePactValue' om
+  Just . (\yieldData -> Yield yieldData p Nothing) <$> traverse enforcePactValue om
 
 setentity :: RNativeFun LibState
 setentity i as = case as of

--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -850,3 +850,92 @@
  "cap pact guard fails on wrong pact id"
  "Invalid Pact ID"
  (continue-pact 1))
+
+(begin-tx)
+(env-exec-config ["DisablePact48"])
+
+ ; pact 48 caps
+ (interface ops
+  (defun op1:bool (a:string b:integer))
+  (defun op2:bool (c:string d:bool))
+  )
+
+
+(module caller G
+  (defcap G () true)
+  (defschema dep
+      callee:module{ops})
+  (deftable deps:{dep})
+  (defcap OP1 (a:string b:integer m:module{ops})
+    @managed
+    true)
+  (defcap OP2 (c:string d:bool m:module{ops})
+    @managed
+    true)
+  (defun op1-guard (a:string b:integer m:module{ops})
+    (create-capability-guard (OP1 a b m)))
+  (defun op2-guard (c:string d:bool m:module{ops})
+    (create-capability-guard (OP2 c d m)))
+  (defun callees:[module{ops}] ()
+     (map (compose (read deps) (at "callee")) (keys deps)))
+  (defun call-op1 (a:string b:integer)
+    (map (lambda (m:module{ops})
+           (install-capability (OP1 a b m))
+           (with-capability (OP1 a b m)
+             (m::op1 a b)))
+         (callees)))
+  (defun call-op2 (c:string d:bool)
+    (map (lambda (m:module{ops})
+           (install-capability (OP2 c d m))
+           (with-capability (OP2 c d m)
+             (m::op2 c d)))
+         (callees)))
+)
+(create-table deps)
+
+(module callee-A G
+  (defcap G () true)
+  (implements ops)
+  (defun op1:bool (a:string b:integer)
+    (enforce-guard (op1-guard a b callee-A))
+    true)
+  (defun op2:bool (c:string d:bool)
+    (enforce-guard (op2-guard c d callee-A))
+    false)
+
+  )
+
+(module callee-B G
+  (defcap G () true)
+  (implements ops)
+  (defun op1:bool (a:string b:integer)
+    ;; out-of-band call to callee-A
+    (callee-A.op1 a b)
+    false)
+  (defun op2:bool (c:string d:bool)
+    (enforce-guard (op2-guard c d callee-B))
+    true)
+  )
+
+(insert deps "callee-A" { 'callee: callee-A })
+(insert deps "callee-B" { 'callee: callee-B })
+(expect-failure
+   "out-of-band call fails pre-fork"
+   "Capability not acquired"
+   (call-op1 "hello" 2))
+(expect-failure
+   "normal case fails pre-fork"
+   (call-op2 "goodbye" false))
+
+(env-exec-config [])
+
+(expect-failure
+  "out-of-band call fails post-fork"
+  "Capability not acquired"
+  (call-op1 "hello" 2))
+(expect
+   "normal case succeeds for both callees post-fork"
+   [false true]
+   (call-op2 "goodbye" false))
+
+(commit-tx)

--- a/tests/pact/hash.repl
+++ b/tests/pact/hash.repl
@@ -29,6 +29,8 @@
   ( (h1 (get-hash "a"))
     (h2 (get-hash "b"))
   )
+  (enforce (= h1 "eU1QsrHzLyYN9620ongvIlpxzzX1KiVGbTDBT6zbh14") "h1 does not match expected value")
+  (enforce (= h2 "q9JZXDohMARxsVUtQWCiK7APdaiYpvqfJyq-aF3LhAA") "h2 does not match expected value")
   (expect-failure "hashes do not match pre-fork" (enforce (= h1 h2) "boom"))
   )
 
@@ -43,6 +45,7 @@
   ( (h1 (get-hash "a"))
     (h2 (get-hash "b"))
   )
+  (enforce (= h1 "0j95GFheG-uAWbGAjvTqV4QSGE74ZY38jxnNuHJ2p8A") "h1 does not match expected value")
   (expect "hashes match post-fork" true (enforce (= h1 h2) "boom"))
   )
 (commit-tx)

--- a/tests/pact/hash.repl
+++ b/tests/pact/hash.repl
@@ -1,3 +1,48 @@
 (expect "repl starts with empty hash" (hash "") (tx-hash))
 (env-hash (hash "hello"))
 (expect "hash roundtrip" (hash "hello") (tx-hash))
+
+(begin-tx)
+(env-exec-config ["DisablePact48"])
+
+(module my-mod G
+  (defcap G() true)
+
+  (defschema hashes h:string)
+  (deftable hashes-table:{hashes})
+
+  (defun get-hash (k:string)
+    (at "h" (read hashes-table k)))
+
+  (defun insert-hash (k:string h:string)
+    (write hashes-table k {"h":h})
+    (concat ["added hash ", h, " to table"])
+  )
+  )
+
+(create-table hashes-table)
+
+; pre fork module hashing
+(insert-hash "a" (hash my-mod))
+(insert-hash "b" (hash my-mod))
+(let*
+  ( (h1 (get-hash "a"))
+    (h2 (get-hash "b"))
+  )
+  (expect-failure "hashes do not match pre-fork" (enforce (= h1 h2) "boom"))
+  )
+
+
+(env-exec-config [])
+; post fork module hashing
+(insert-hash "a" (hash my-mod))
+(insert-hash "b" (hash my-mod))
+
+
+(let*
+  ( (h1 (get-hash "a"))
+    (h2 (get-hash "b"))
+  )
+  (expect "hashes match post-fork" true (enforce (= h1 h2) "boom"))
+  )
+(commit-tx)


### PR DESCRIPTION
Same issue as #1273 unfortunately, just in cap guards.

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
