### PR TITLE
Enable M1 runner nix caching

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -8,14 +8,15 @@ jobs:
   build-and-cache:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, mac-m1]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
 
     - name: Set up Nix with caching
-      uses: kadena-io/setup-nix-with-cache@v1
+      uses: kadena-io/setup-nix-with-cache@v2.1
       with:
         cache_url: s3://nixcache.chainweb.com?region=us-east-1
         signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,6 +3,9 @@ name: Build and cache with Nix
 on:
   workflow_dispatch:
   push:
+    paths-ignore:
+    - '.github/**'
+
 
 jobs:
   build-and-cache:
@@ -10,13 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, mac-m1]
+        os: [ubuntu-latest, mac-m1]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
 
     - name: Set up Nix with caching
-      uses: kadena-io/setup-nix-with-cache@v2.1
+      uses: kadena-io/setup-nix-with-cache@v2
       with:
         cache_url: s3://nixcache.chainweb.com?region=us-east-1
         signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
@@ -31,5 +34,5 @@ jobs:
     - name: Build and cache artifacts
       timeout-minutes: 740
       run: |
-        echo Building the default package and its devShell
-        nix build .#check
+        echo Building the project and its devShell
+        nix build .#check --log-lines 500 --show-trace


### PR DESCRIPTION
This PR enables the new M1 Mac runner for the nix build-and-cache job.  It removes the x86/64 Mac nix build-and-cache job as well, as that is supposedly depreciated/not in common use.

PR checklist not relevant.