### PR TITLE
Use Integers to represent Time in FV

### DIFF
--- a/src-tool/Pact/Analyze/Types/Shared.hs
+++ b/src-tool/Pact/Analyze/Types/Shared.hs
@@ -45,7 +45,7 @@ import           Data.Map.Strict              (Map)
 import qualified Data.Map.Strict              as Map
 import           Data.Maybe                   (isJust)
 import           Data.Monoid                  (First (..))
-import           Data.SBV                     (EqSymbolic, HasKind, Int64,
+import           Data.SBV                     (EqSymbolic, HasKind,
                                                Mergeable (symbolicMerge),
                                                OrdSymbolic, SBV,
                                                SDivisible (sDivMod, sQuotRem),
@@ -242,7 +242,7 @@ instance Pretty Str where
 
 type RowKey = Str
 
-type Time = Int64
+type Time = Integer
 
 -- | Convert between 'UTCTime' and 'Time'.
 --
@@ -254,10 +254,10 @@ timeIso :: PactIso UTCTime Time
 timeIso = PactIso $ iso mkTime unMkTime
   where
     mkTime :: UTCTime -> Time
-    mkTime utct = toMicroseconds (utct .-. mjdEpoch)
+    mkTime utct = fromIntegral $ toMicroseconds (utct .-. mjdEpoch)
 
     unMkTime :: Time -> UTCTime
-    unMkTime time = mjdEpoch .+^ fromMicroseconds time
+    unMkTime time = mjdEpoch .+^ fromMicroseconds (fromIntegral time)
 
 isGuardTy :: Pact.Type v -> Bool
 isGuardTy (Pact.TyPrim (Pact.TyGuard _)) = True

--- a/tests/Analyze/Gen.hs
+++ b/tests/Analyze/Gen.hs
@@ -306,7 +306,7 @@ genCore BoundedBool = Gen.recursive Gen.choice [
       mkBool $ Logical NotOp [extract x]
   ]
 genCore BoundedTime = Gen.recursive Gen.choice [
-    Some STime . Lit' <$> Gen.enumBounded -- Gen.int64
+    Some STime . Lit' <$> genInteger 1e9
   ] $ scale 4 <$>
     [ Gen.subtermM (genCore BoundedTime) $ \x -> do
         y <- genCore (BoundedInt 1e9)

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -2333,7 +2333,7 @@ spec = describe "analyze" $ do
               ))
           |]
     in expectPass code $ Valid $ sNot Abort'
-  describe "regression time representatin (int64/integer)" $
+  describe "regression time representation (int64/integer)" $
     let code =
           [text|
             (defun test: bool(a: time)

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -2333,6 +2333,14 @@ spec = describe "analyze" $ do
               ))
           |]
     in expectPass code $ Valid $ sNot Abort'
+  describe "regression time representatin (int64/integer)" $
+    let code =
+          [text|
+            (defun test: bool(a: time)
+              @model[ (property (= result true ))]
+              (<= a  (add-time a 100)))
+          |]
+    in expectPass code $ Valid Success'
 
   describe "str-to-int" $ do
     describe "without specified base" $ do


### PR DESCRIPTION
This PR changes the `Time` representation in FV. 
So-far, we represent time using microseconds as Int64, which exceeds (and does not align with) Z3s Integer representation.

PR checklist:

* [x] Test coverage for the proposed changes
* [] PR description contains example output from repl interaction or a snippet from unit test output
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
