### PR TITLE
Fix incorrect examples in docs

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -750,7 +750,7 @@ Top level only: this function will fail if used in module code.
 *table*&nbsp;`table:<{row}>` *&rarr;*&nbsp;`object:*`
 
 
-Get metadata for TABLE. Returns an object with 'name', 'hash', 'blessed', 'code', and 'keyset' fields.
+Get metadata for TABLE. Returns an object with 'name', 'module', and 'type' fields.
 ```lisp
 (describe-table accounts)
 ```
@@ -1719,7 +1719,7 @@ Defines a custom guard CLOSURE whose arguments are strictly evaluated at definit
 
 Tell whether PRINCIPAL string conforms to the principal format without proving validity.
 ```lisp
-(enforce   (is-principal 'k:462e97a099987f55f6a2b52e7bfd52a36b4b5b470fed0816a3d9b26f9450ba69)   "Invalid account structure: non-principal account")
+(enforce   (is-principal "k:462e97a099987f55f6a2b52e7bfd52a36b4b5b470fed0816a3d9b26f9450ba69")   "Invalid account structure: non-principal account")
 ```
 
 
@@ -1738,7 +1738,7 @@ Creates a guard for the keyset registered as KEYSET-REF with 'define-keyset'. Co
 
 Return the protocol type of a given PRINCIPAL value. If input value is not a principal type, then the empty string is returned.
 ```lisp
-(typeof-principal 'k:462e97a099987f55f6a2b52e7bfd52a36b4b5b470fed0816a3d9b26f9450ba69)
+(typeof-principal "k:462e97a099987f55f6a2b52e7bfd52a36b4b5b470fed0816a3d9b26f9450ba69")
 ```
 
 

--- a/src/Pact/Native/Db.hs
+++ b/src/Pact/Native/Db.hs
@@ -161,7 +161,7 @@ dbDefs =
     ,setTopLevelOnly $ defRNative "describe-table" descTable
      (funType tTyObjectAny [("table",tableTy)])
      [LitExample "(describe-table accounts)"]
-     "Get metadata for TABLE. Returns an object with 'name', 'hash', 'blessed', 'code', and 'keyset' fields."
+     "Get metadata for TABLE. Returns an object with 'name', 'module', and 'type' fields."
     ,setTopLevelOnly $ defGasRNative "describe-keyset" descKeySet
      (funType tTyObjectAny [("keyset",tTyString)]) [] "Get metadata for KEYSET."
     ,setTopLevelOnly $ defRNative "describe-module" descModule

--- a/src/Pact/Native/Guards.hs
+++ b/src/Pact/Native/Guards.hs
@@ -207,7 +207,7 @@ isPrincipleDef = defRNative "is-principal" isPrincipal
   (funType tTyBool [("principal", tTyString)])
   [LitExample
    "(enforce \
-   \  (is-principal 'k:462e97a099987f55f6a2b52e7bfd52a36b4b5b470fed0816a3d9b26f9450ba69) \
+   \  (is-principal \"k:462e97a099987f55f6a2b52e7bfd52a36b4b5b470fed0816a3d9b26f9450ba69\") \
    \  \"Invalid account structure: non-principal account\")"]
   "Tell whether PRINCIPAL string conforms to the principal format without proving validity."
   where
@@ -222,7 +222,7 @@ typeOfPrincipalDef :: NativeDef
 typeOfPrincipalDef = defRNative "typeof-principal" typeOfPrincipal
   (funType tTyString [("principal", tTyString)])
     [LitExample
-     "(typeof-principal 'k:462e97a099987f55f6a2b52e7bfd52a36b4b5b470fed0816a3d9b26f9450ba69)"]
+     "(typeof-principal \"k:462e97a099987f55f6a2b52e7bfd52a36b4b5b470fed0816a3d9b26f9450ba69\")"]
   "Return the protocol type of a given PRINCIPAL value. If input value is not a principal type, \
   \then the empty string is returned."
   where


### PR DESCRIPTION
Originally noticed by @CryptoPascal31, there are several incorrect examples and descriptions in the natives docs. These are a couple of them. Namely:

* describe-table was a copy-paste of describe-module and incorrectly listed the field names in the object it returns
* the principal examples use 'k:12345 but the symbol syntax is incompatible with the use of a colon

For the latter, you can trivially verify the error with:

```sh
➜ nix run github:thomashoneyman/pact-nix#pact
pact> (is-principal 'k:12345)
(interactive):1:17: error: Expected: atom, Expected: list, Expected: literal, Unexpected end of input
pact> (is-principal "k:12345")
false 
```

For maintainers: for documentation PRs in which I'm updating the Haskell code, should I be committing the updated .md files as well? Or just the Haskell? It's not clear to me what is generated in the release process.

--------

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
