### PR TITLE
add diff-time to FV

### DIFF
--- a/docs/en/pact-properties-api.md
+++ b/docs/en/pact-properties-api.md
@@ -944,6 +944,20 @@ Add seconds to a time
 
 Supported in either invariants or properties.
 
+### diff-time {#FTemporalDiff}
+
+```lisp
+(diff-time a b)
+```
+
+* takes `a`: `time`
+* takes `b`: `time`
+* produces `decimal`
+
+Time difference in seconds
+
+Supported in properties only.
+
 ## Quantification operators {#Quantification}
 
 ### forall {#FUniversalQuantification}

--- a/docs/en/pact-properties-api.md
+++ b/docs/en/pact-properties-api.md
@@ -954,7 +954,7 @@ Supported in either invariants or properties.
 * takes `b`: `time`
 * produces `decimal`
 
-Time difference in seconds
+Time difference in seconds of `a` - `b`
 
 Supported in properties only.
 

--- a/src-tool/Pact/Analyze/Eval/Core.hs
+++ b/src-tool/Pact/Analyze/Eval/Core.hs
@@ -103,6 +103,16 @@ evalDecAddTime timeT secsT = do
   else throwErrorNoLoc $ PossibleRoundoff
     "A time being added is not concrete, so we can't guarantee that roundoff won't happen when it's converted to an integer."
 
+evalDiffTime
+  :: Analyzer m
+  => TermOf m 'TyTime
+  -> TermOf m 'TyTime
+  -> m (S Decimal)
+evalDiffTime a b = do
+  a' <- eval a
+  b' <- eval b
+  pure $  (fromInteger' (fromIntegralS a' - fromIntegralS b')) / 1000000
+
 evalComparisonOp
   :: forall m a.
      Analyzer m
@@ -211,6 +221,7 @@ evalCore (StrDrop n s)                     = evalStrDrop n s
 evalCore (Numerical a)                     = evalNumerical a
 evalCore (IntAddTime time secs)            = evalIntAddTime time secs
 evalCore (DecAddTime time secs)            = evalDecAddTime time secs
+evalCore (DiffTime a b)                    = evalDiffTime a b
 evalCore (Comparison ty op x y)            = evalComparisonOp ty op x y
 evalCore (Logical op props)                = evalLogicalOp op props
 evalCore (ObjAt schema colNameT objT)

--- a/src-tool/Pact/Analyze/Feature.hs
+++ b/src-tool/Pact/Analyze/Feature.hs
@@ -1325,7 +1325,7 @@ doc FTemporalDiff = Doc
   "diff-time"
   CTemporal
   PropOnly
-  "Time difference in seconds"
+  "Time difference in seconds of `a` - `b`"
   [Usage
     "(diff-time a b)"
     Map.empty

--- a/src-tool/Pact/Analyze/Feature.hs
+++ b/src-tool/Pact/Analyze/Feature.hs
@@ -135,6 +135,7 @@ data Feature
   | FListHash
   -- Temporal operators
   | FTemporalAddition
+  | FTemporalDiff
   -- Quantification forms
   | FUniversalQuantification
   | FExistentialQuantification
@@ -1320,7 +1321,16 @@ doc FTemporalAddition = Doc
         ]
         (TyCon time)
   ]
-
+doc FTemporalDiff = Doc
+  "diff-time"
+  CTemporal
+  PropOnly
+  "Time difference in seconds"
+  [Usage
+    "(diff-time a b)"
+    Map.empty
+    $ Fun Nothing [("a", TyCon time), ("b", TyCon time)] (TyCon dec)
+  ]
 --
 -- Property-specific features
 --
@@ -1885,6 +1895,7 @@ PAT(SNumericalHash, FNumericalHash)
 PAT(SBoolHash, FBoolHash)
 PAT(SListHash, FListHash)
 PAT(STemporalAddition, FTemporalAddition)
+PAT(STemporalDiff, FTemporalDiff)
 PAT(SUniversalQuantification, FUniversalQuantification)
 PAT(SExistentialQuantification, FExistentialQuantification)
 PAT(SColumnOf, FColumnOf)

--- a/src-tool/Pact/Analyze/Patterns.hs
+++ b/src-tool/Pact/Analyze/Patterns.hs
@@ -192,6 +192,9 @@ pattern AST_Hash val <- App _node (NativeFunc "hash") [val]
 pattern AST_AddTime :: forall a. AST a -> AST a -> AST a
 pattern AST_AddTime time seconds <- App _ (NativeFunc STemporalAddition) [time, seconds]
 
+pattern AST_DiffTime :: forall a. AST a -> AST a -> AST a
+pattern AST_DiffTime a b <- App _ (NativeFunc STemporalDiff) [a, b]
+
 pattern AST_Days :: forall a. AST a -> AST a
 pattern AST_Days days <- App _ (NativeFunc "days") [days]
 

--- a/src-tool/Pact/Analyze/PrenexNormalize.hs
+++ b/src-tool/Pact/Analyze/PrenexNormalize.hs
@@ -112,6 +112,7 @@ singFloat ty p = case p of
   -- time
   CoreProp (IntAddTime time int) -> PIntAddTime <$> float time <*> float int
   CoreProp (DecAddTime time dec) -> PDecAddTime <$> float time <*> float dec
+  CoreProp (DiffTime a b) -> CoreProp ... DiffTime <$> float a <*> float b
 
   -- bool
   -- - quantification

--- a/src-tool/Pact/Analyze/Translate.hs
+++ b/src-tool/Pact/Analyze/Translate.hs
@@ -1433,6 +1433,12 @@ translateNode astNode = withAstContext astNode $ case astNode of
     tsStaticCapsInScope %= Set.insert capName
     return app
 
+  AST_DiffTime a b -> translateNode a >>= \case
+    Some STime a' -> translateNode b >>= \case
+      Some STime b' -> pure $ Some SDecimal $ CoreTerm $ DiffTime a' b'
+      _ -> unexpectedNode astNode
+    _ -> unexpectedNode astNode
+
   AST_AddTime time seconds
     | seconds ^. aNode . aTy == TyPrim Pact.TyInteger ||
       seconds ^. aNode . aTy == TyPrim Pact.TyDecimal -> translateNode time >>= \case

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -2333,6 +2333,24 @@ spec = describe "analyze" $ do
               ))
           |]
     in expectPass code $ Valid $ sNot Abort'
+
+  describe "diff-time implementation (#1291)" $
+    let code =
+          [text|
+            (defun test:decimal ()
+              @model[(property (= result -60.0))]
+              (diff-time (time "2021-01-01T00:00:00Z") (time "2021-01-01T00:01:00Z")))
+
+            (defun test1:decimal ()
+              @model[(property (= result -61.0))]
+              (diff-time (time "2021-01-01T00:00:00Z") (time "2021-01-01T00:01:01Z")))
+
+            (defun test2:decimal ()
+              @model[(property (= result 1.0))]
+              (diff-time (time "2021-01-01T00:00:01Z") (time "2021-01-01T00:00:00Z")))
+          |]
+    in expectVerified code
+
   describe "regression time representation (int64/integer)" $
     let code =
           [text|


### PR DESCRIPTION
closes #1291 

This PR adds the `diff-time` functionality to the FV system. So-far, the implementation was shimmed (returned 0).

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact

