### PR TITLE
FV: inline authorized-by parameters

### DIFF
--- a/src-tool/Pact/Analyze/Parse/Prop.hs
+++ b/src-tool/Pact/Analyze/Parse/Prop.hs
@@ -600,8 +600,11 @@ inferPreProp preProp = case preProp of
     (Some SBool . PropSpecific) ... RowExists tn'
       <$> checkPreProp SStr rk
       <*> parseBeforeAfter beforeAfter
-  PreApp s [PreStringLit rn] | s == SAuthorizedBy ->
-    pure $ Some SBool (PropSpecific (GuardPassed (RegistryName rn)))
+  PreApp s [rn] | s == SAuthorizedBy -> do
+    rn' <- inferPreProp rn
+    case rn' of
+      Some SStr (TextLit str) -> pure $ Some SBool (PropSpecific (GuardPassed (RegistryName str)))
+      _ -> throwErrorIn preProp "expected string literal"
   PreApp s [tn, cn, rk] | s == SRowEnforced -> do
     tn' <- parseTableName tn
     cn' <- parseColumnName cn

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -1385,6 +1385,16 @@ spec = describe "analyze" $ do
 
     expectVerified code
 
+  describe "authorized-by inlines definitions (regression #1294)" $ do
+    let code =
+          [text|
+               (defconst testname: string 'ks)
+               (defun test:bool ()
+                 @model[(property (authorized-by testname))]
+                 (enforce-guard (create-module-guard "governance")))
+          |]
+    expectVerified code
+
   describe "enforce-one.1" $ do
     let code =
           [text|


### PR DESCRIPTION
Before this PR, the `authorized-by` built-in did not inline the properties. In case, a user specified a `defconst` it failed.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact

The rest is not applicable.