### PR TITLE
Update nix.yml to fix Mac runner cache

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,9 +3,6 @@ name: Build and cache with Nix
 on:
   workflow_dispatch:
   push:
-    paths-ignore:
-    - '.github/**'
-
 
 jobs:
   build-and-cache:
@@ -19,7 +16,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Nix with caching
-      uses: kadena-io/setup-nix-with-cache@v2
+      uses: kadena-io/setup-nix-with-cache/by-root@v3
       with:
         cache_url: s3://nixcache.chainweb.com?region=us-east-1
         signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
@@ -31,6 +28,9 @@ jobs:
         aws-secret-access-key: ${{ secrets.NIX_CACHE_AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-1
 
+    - name: Give root user AWS credentials
+      uses: kadena-io/setup-nix-with-cache/copy-root-aws-credentials@v3
+      
     - name: Build and cache artifacts
       timeout-minutes: 740
       run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   build-and-cache:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 740
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, mac-m1]
+        os: [ubuntu-latest, macos-latest, mac-m1]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -32,7 +33,6 @@ jobs:
       uses: kadena-io/setup-nix-with-cache/copy-root-aws-credentials@v3
       
     - name: Build and cache artifacts
-      timeout-minutes: 740
       run: |
         echo Building the project and its devShell
         nix build .#check --log-lines 500 --show-trace


### PR DESCRIPTION
nix builds will behave correctly like this

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
