### PR TITLE
Generalized parsing of conditional expressions

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1928,7 +1928,7 @@ Retreive any accumulated events and optionally clear event state. Object returne
  *&rarr;*&nbsp;`[string]`
 
 
-Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisableNewTrans","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePact45","DisablePact46","DisablePact47","DisablePact48","DisablePactEvents","DisableRuntimeReturnTypeChecking","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
+Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisableNewTrans","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePact45","DisablePact46","DisablePact47","DisablePact48","DisablePact49","DisablePactEvents","DisableRuntimeReturnTypeChecking","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
 ```lisp
 pact> (env-exec-config ['DisableHistoryInTransactionalMode]) (env-exec-config)
 ["DisableHistoryInTransactionalMode"]

--- a/pact.cabal
+++ b/pact.cabal
@@ -415,6 +415,7 @@ test-suite hspec
     , lens
     , mod
     , mtl
+    , neat-interpolation
     , pact
     , pact-json >= 0.1
     , semirings
@@ -476,7 +477,6 @@ test-suite hspec
       , hw-hspec-hedgehog >=0.1
       , intervals
       , mmorph
-      , neat-interpolation
       , sbv
       , servant-client >=0.16
       , temporary >=1.3

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -615,7 +615,7 @@ abstractBody' args body =
 -- | Parses a list of `p`s followed by a single `q`, allowing `p` ⊆ `q`.
 -- Hence the need for lookahead, as `some p >> q`-like parsing won't work.
 somePthenQ :: (String, Compile p) -> (String, Compile q) -> Compile ([p], q)
-somePthenQ (pName, p) (qName, q) = partitionPQ =<< some (Right <$> q `notFollowedBy'` p <|> Left <$> p)
+somePthenQ (pName, p) (qName, q) = partitionPQ =<< some (Right <$> q `notFollowedBy'` q <|> Left <$> p)
   where
   p1 `notFollowedBy'` p2 = try $ p1 <* notFollowedBy p2
   partitionPQ [Right q'] = pure ([], q')

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -620,7 +620,7 @@ somePthenQ (pName, p) (qName, q) = partitionPQ =<< some (Right <$> q `notFollowe
   p1 `notFollowedBy'` p2 = try $ p1 <* notFollowedBy p2
   partitionPQ [Right q'] = pure ([], q')
   partitionPQ (Left p' : rest@(_:_)) = first (p' :) <$> partitionPQ rest
-  partitionPQ [Left _] = error "somePthenQ: impossible: Left _ cannot be the last element"
+  partitionPQ [Left _] = expected $ qName <> " to be the last element"
   partitionPQ (Right _ : _ : _) = expected $ "a single " <> qName <> " clause"
   partitionPQ [] = expected $ "some " <> pName <> " clauses"
 

--- a/src/Pact/Compile.hs
+++ b/src/Pact/Compile.hs
@@ -619,9 +619,9 @@ somePthenQ (pName, p) (qName, q) = partitionPQ =<< some (Right <$> q `notFollowe
   where
   p1 `notFollowedBy'` p2 = try $ p1 <* notFollowedBy p2
   partitionPQ [Right q'] = pure ([], q')
-  partitionPQ (Left p' : rest@(_:_)) = first (p' :) <$> partitionPQ rest
+  partitionPQ (Right _ : _) = expected $ "a single " <> qName <> " clause"
   partitionPQ [Left _] = expected $ qName <> " to be the last element"
-  partitionPQ (Right _ : _ : _) = expected $ "a single " <> qName <> " clause"
+  partitionPQ (Left p' : rest) = first (p' :) <$> partitionPQ rest
   partitionPQ [] = expected $ "some " <> pName <> " clauses"
 
 condForm :: Compile (Term Name)

--- a/src/Pact/Interpreter.hs
+++ b/src/Pact/Interpreter.hs
@@ -148,10 +148,12 @@ data EvalResult = EvalResult
 -- | Execute pact statements.
 evalExec :: Interpreter e -> EvalEnv e -> ParsedCode -> IO EvalResult
 evalExec runner evalEnv ParsedCode {..} = do
-  terms <- throwEither $ compileExps (ParseEnv isNarrowTry) (mkTextInfo _pcCode) _pcExps
+  terms <- throwEither $ compileExps (ParseEnv isNarrowTry condGenParsing) (mkTextInfo _pcCode) _pcExps
   interpret runner evalEnv (Right terms)
   where
-    isNarrowTry = not $ S.member FlagDisablePact44 $ _ecFlags $ _eeExecutionConfig evalEnv
+    evalFlags = _ecFlags $ _eeExecutionConfig evalEnv
+    isNarrowTry = not $ S.member FlagDisablePact44 evalFlags
+    condGenParsing = not $ S.member FlagDisablePact49 evalFlags
 
 -- | For pre-installing modules into state.
 initStateModules :: HashMap ModuleName (ModuleData Ref) -> EvalState

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -905,7 +905,8 @@ hoistValueTerm t = die (getInfo t) $ "Unexpected term in value context: " <> sho
 -- | Build ASTs from terms.
 toAST :: Term (Either Ref (AST Node)) -> TC (AST Node)
 toAST TNative {..} = die _tInfo "Native in value position"
-toAST TDef {..} = die _tInfo "Def in value position"
+toAST t@TDef {} =
+  toAST $ TApp (Term.App t [] (getInfo t)) (getInfo t)
 toAST TSchema {..} = die _tInfo "User type in value position"
 toAST t@TLam{} =
   -- Lambda values are converted to Apps

--- a/src/Pact/Types/ExpParser.hs
+++ b/src/Pact/Types/ExpParser.hs
@@ -107,10 +107,13 @@ data ParseState a = ParseState
   }
 makeLenses ''ParseState
 
--- | Current env has flag for try-narrow fix.
-newtype ParseEnv = ParseEnv
-    { _peNarrowTry :: Bool }
-instance Default ParseEnv where def = ParseEnv True
+data ParseEnv = ParseEnv
+    { _peNarrowTry :: Bool
+    -- ^ Enable try-narrow fix.
+    , _peCondGenParsing :: Bool
+    -- ^ Enable more general `cond` parsing.
+    }
+instance Default ParseEnv where def = ParseEnv True True
 
 type MkInfo = Parsed -> Info
 

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -198,6 +198,8 @@ data ExecutionFlag
   | FlagDisableRuntimeReturnTypeChecking
   -- | Disable Pact 4.8 Features
   | FlagDisablePact48
+  -- | Disable Pact 4.9 Features
+  | FlagDisablePact49
   deriving (Eq,Ord,Show,Enum,Bounded)
 
 -- | Flag string representation

--- a/tests/ParserSpec.hs
+++ b/tests/ParserSpec.hs
@@ -133,6 +133,19 @@ condParsing = do
         )
       )
       |]
+  it "parses S-expr fallbacks of two terms" $
+    parses [text|
+      (module m g (defcap g() true)
+        (defun unknown:string (name:string) (format "I don't know {}" [name]))
+        (defun is-boy-or-girl:string (name:string)
+          (cond
+            ((= name "alice") "Girl")
+            ((= name "bob")   "Boy")
+            (unknown name)
+          )
+        )
+      )
+      |]
   it "doesn't parse single-token branches in the middle" $
     doesn'tParse [text|
       (module m g (defcap g() true)

--- a/tests/ParserSpec.hs
+++ b/tests/ParserSpec.hs
@@ -97,7 +97,7 @@ narrowTryBackCompat :: Spec
 narrowTryBackCompat = do
   -- code from bad-term-in-list.repl
   it "preserves old try bug" $
-    parseCompile (ParseEnv False) "[(module m g (defcap g () 1))]" `shouldSatisfy` rightRight
+    parseCompile (ParseEnv False False) "[(module m g (defcap g () 1))]" `shouldSatisfy` rightRight
   where
     rightRight (Right Right {}) = True
     rightRight _ = False

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -329,6 +329,37 @@
     "test anon lambdas"
     (map (lambda (i) (> i 1)) [1 2 3]))
 
+  (defun unknown-cond-helper:string (name:string) (format "I don't know {}" [name]))
+  (defun unknown-cond-helper2:string (name:string param:string) (format "I don't know {}" [name]))
+  (defun tc-cond-fallback-atom:string (name:string)
+    (cond
+      ((= name "alice") "Girl")
+      ((= name "bob")   "Boy")
+      name
+    )
+  )
+  (defun tc-cond-fallback-call:string (name:string)
+    (cond
+      ((= name "alice") "Girl")
+      ((= name "bob")   "Boy")
+      (unknown-cond-helper name)
+    )
+  )
+  (defun tc-cond-fallback-call-multiparam:string (name:string)
+    (cond
+      ((= name "alice") "Girl")
+      ((= name "bob")   "Boy")
+      (unknown-cond-helper2 name name)
+    )
+  )
+
+  (defun fails-cond-fallback-call-unsatisfied:string (name:string)
+    (cond
+      ((= name "alice") "Girl")
+      ((= name "bob")   "Boy")
+      unknown-cond-helper
+    )
+  )
 )
 
 (create-table persons)


### PR DESCRIPTION
This allows parsing some corner cases of the `cond` expression default values, in particular #1118.

The current `condForm` greedily parses the list of branches as, roughly speaking, `valueLevel >> valueLevel` (I'm omitting handling their results for brevity), and the default/fallback clause of the form `(a b)` gets consumed by this as well, so the final default clause parser doesn't see it and errors out.

To generalize, the problem is that we need to parse a list of `p`s followed by a single `q`, where `p` recognizes a (proper) subset of strings from `q`. The current parser effectively does `some p >> q`, which fails if that last element is in `p` (where, un-generalizing back to our problem, `p` is the branches parser, and `q` is the default clause parser).

Looks like the only solution (besides some post-processing and reshuffling of parsed terms, which is probably not something we'd like to do) is to do some lookahead. The way it's done here is as follows:

1. We first try to parse `q` ensuring it's not followed by another `q`. If it isn't followed, then it must be the final `q` and we're good.
2. If it is, then it must really be the (non-final) `p`, so we backtrack and parse with `p`.

As a side note, this parser now also accepts a `cond` with a single default clause and no branches — it makes the implementation a tad simpler and more readable in what's already a somewhat non-trivial code, without sacrificing correctness. If somebody wants an effectively no-op `cond`, shall we let them?

---

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
