### PR TITLE
Magic caps for authorization natives

### DIFF
--- a/tests/pact/keysets.repl
+++ b/tests/pact/keysets.repl
@@ -467,3 +467,41 @@
   "Subsequent keyset rotations succeed without user guard - proof"
   "KeySet {keys: [rotated],pred: keys-all}"
   (format "{}" [(describe-keyset "ns.a")]))
+
+(commit-tx)
+
+;;
+;; ========= test define-keyset magic cap ===========
+;;
+
+(begin-tx)
+
+;; ugly: have to make fake root module to use repl tests for magic cap
+;; need additional coverage to prove we don't need this
+(module pact GOV
+  (defcap GOV () true)
+  (defcap DEFINE_KEYSET (name:string)
+    (enforce false "Must never be called")))
+
+(namespace 'ns)
+(env-data { "ks": ["signer"] })
+(env-keys ["u"])
+(define-keyset "ns.magic-1" (read-keyset 'ks))
+(define-keyset "ns.magic-2" (read-keyset 'ks))
+
+(commit-tx)
+
+(begin-tx)
+(env-sigs
+ [ { "key": "signer"
+   , "caps": [(pact.DEFINE_KEYSET "ns.magic-1")]
+   } ] )
+(expect
+ "success for rotate with ns.magic-1 scoped"
+ "Keyset defined"
+ (define-keyset "ns.magic-1" (read-keyset 'ks)))
+(expect-failure
+ "failure for rotate without ns.magic-2 scoped"
+ "Keyset failure"
+ (define-keyset "ns.magic-2" (read-keyset 'ks)))
+(commit-tx)


### PR DESCRIPTION
Provide magic signing capabilities for scoping native operations like `define-keyset`.


PR checklist:

* [x] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output 
* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [x] Benchmark regressions: minimal environment manipulation required
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
