### PR TITLE
fix fv str-to-int

### DIFF
--- a/src-tool/Pact/Analyze/Parse/Prop.hs
+++ b/src-tool/Pact/Analyze/Parse/Prop.hs
@@ -693,9 +693,6 @@ inferPreProp preProp = case preProp of
     Some ty a' <- inferPreProp a
     pure $ Some (SList ty) $ CoreProp $ MakeList ty i' a'
 
-  PreApp s [str] | s == SStringToInteger -> do
-    str' <- checkPreProp SStr str
-    pure $ Some SInteger $ CoreProp $ StrToInt str'
 
   PreApp s [str] | s == SStringHash -> do
     Some ty str' <- inferPreProp str
@@ -707,7 +704,11 @@ inferPreProp preProp = case preProp of
       SList ty' -> pure $ Some SStr $ CoreProp $ ListHash ty' str'
       _ -> throwErrorIn preProp "`hash` works only with integer, decimals, strings, bools, and list of those"
 
-  PreApp s [str, base] | s == SStringToInteger -> do
+  PreApp s [str] | s == SStringToInteger -> do
+    str' <- checkPreProp SStr str
+    pure $ Some SInteger $ CoreProp $ StrToInt str'
+
+  PreApp s [base, str] | s == SStringToInteger -> do
     str'  <- checkPreProp SStr str
     base' <- checkPreProp SInteger base
     pure $ Some SInteger $ CoreProp $ StrToIntBase base' str'

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -2412,6 +2412,15 @@ spec = describe "analyze" $ do
 
     describe "with specified base" $ do
       describe "concrete string and base" $ do
+        describe "as property" $
+          let code =
+                [text|
+                     (defun test:integer ()
+                     @model[(property (= result (str-to-int 10 "123")))]
+                     (str-to-int 10 "123"))
+                |]
+           in expectVerified code
+
         describe "valid inputs" $
           let code =
                 [text|

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -2372,6 +2372,14 @@ spec = describe "analyze" $ do
 
   describe "str-to-int" $ do
     describe "without specified base" $ do
+      describe "as property" $
+        let code =
+              [text|
+                (defun test:integer ()
+                  @model[(property (= result (str-to-int "123")))]
+                  (str-to-int "123"))
+              |]
+        in expectVerified code
       describe "concrete string" $ do
         describe "valid inputs" $
           let code =


### PR DESCRIPTION
This PR fixes the order of parameters (in case `base` is defined) to match documentation https://pact-language.readthedocs.io/en/latest/pact-properties-api.html?highlight=str-to-int#str-to-int. 
Additionally, we re-organize `str-to-int str` and `str-to-int base str` to be close to each other. 
I've added a property test case for both cases.

fixed #1303 

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
