### PR TITLE
Disable key formats enforcing in Pact 4.10

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -1928,7 +1928,7 @@ Retreive any accumulated events and optionally clear event state. Object returne
  *&rarr;*&nbsp;`[string]`
 
 
-Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisableNewTrans","DisablePact40","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePact45","DisablePact46","DisablePact47","DisablePact48","DisablePact49","DisablePactEvents","DisableRuntimeReturnTypeChecking","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
+Queries, or with arguments, sets execution config flags. Valid flags: ["AllowReadInLocal","DisableHistoryInTransactionalMode","DisableInlineMemCheck","DisableModuleInstall","DisableNewTrans","DisablePact40","DisablePact410","DisablePact420","DisablePact43","DisablePact431","DisablePact44","DisablePact45","DisablePact46","DisablePact47","DisablePact48","DisablePact49","DisablePactEvents","DisableRuntimeReturnTypeChecking","EnforceKeyFormats","OldReadOnlyBehavior","PreserveModuleIfacesBug","PreserveModuleNameBug","PreserveNsModuleInstallBug","PreserveShowDefs"]
 ```lisp
 pact> (env-exec-config ['DisableHistoryInTransactionalMode]) (env-exec-config)
 ["DisableHistoryInTransactionalMode"]

--- a/src/Pact/Native/Keysets.hs
+++ b/src/Pact/Native/Keysets.hs
@@ -69,6 +69,7 @@ readKeySet' :: FunApp -> Text -> Eval e KeySet
 readKeySet' i key = do
   ks <- parseMsgKey i "read-keyset" key
   whenExecutionFlagSet FlagEnforceKeyFormats $
+    whenExecutionFlagSet FlagDisablePact410 $
       enforceKeyFormats (const $ evalError' i "Invalid keyset") ks
   pure ks
 

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -200,6 +200,8 @@ data ExecutionFlag
   | FlagDisablePact48
   -- | Disable Pact 4.9 Features
   | FlagDisablePact49
+  -- | Disable Pact 4.10 Features
+  | FlagDisablePact410
   deriving (Eq,Ord,Show,Enum,Bounded)
 
 -- | Flag string representation

--- a/tests/pact/keysets.repl
+++ b/tests/pact/keysets.repl
@@ -208,7 +208,7 @@
 ;; keyset formats
 ;;
 
-(env-exec-config ["EnforceKeyFormats"])
+(env-exec-config ["EnforceKeyFormats", "DisablePact410"])
 (env-data
  { 'bad: ['foo]
  , 'short: ["12440d374865bdf0a3349634a70d1317fc279e7e13db98f2199ac5e7378975"]
@@ -245,6 +245,42 @@
 (expect-failure
  "enforce kadena key format with flag: fail one bad one good"
  "Invalid keyset"
+ (read-keyset 'mixed))
+(expect-that
+ "enforce kadena key format with flag: success single"
+ (constantly true)
+ (read-keyset 'good))
+(expect-that
+ "enforce kadena key format with flag: success 2"
+ (constantly true)
+ (read-keyset 'good2))
+
+(env-exec-config ["EnforceKeyFormats"])
+
+(expect-that
+ "does not enforce kadena key format with flag in Pact 4.10 which'd otherwise fail single"
+ (constantly true)
+ (read-keyset 'bad))
+(expect-that
+ "does not enforce kadena key format with flag in Pact 4.10 which'd otherwise fail short"
+ (constantly true)
+ (read-keyset 'short))
+(expect-that
+ "does not enforce kadena key format with flag in Pact 4.10 which'd otherwise fail long"
+ (constantly true)
+ (read-keyset 'long))
+(expect-that
+ "does not enforce kadena key format with flag in Pact 4.10 which'd otherwise fail badchars"
+ (constantly true)
+ (read-keyset 'badchars))
+(expect-that
+ "does not enforce kadena key format with flag in Pact 4.10 which'd otherwise fail uppercase"
+ (constantly true)
+ (read-keyset 'ucase))
+
+(expect-that
+ "does not enforce kadena key format with flag in Pact 4.10 which'd otherwise fail one bad one good"
+ (constantly true)
  (read-keyset 'mixed))
 (expect-that
  "enforce kadena key format with flag: success single"


### PR DESCRIPTION
PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
