### PR TITLE
Migrate to hs-nix-infra for the Nix setup

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         cache_url: s3://nixcache.chainweb.com?region=us-east-1
         signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
+        additional_experimental_features: recursive-nix
 
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Nix with caching
-      uses: kadena-io/setup-nix-with-cache/by-root@v3
+      uses: kadena-io/setup-nix-with-cache/by-root@v3.1
       with:
         cache_url: s3://nixcache.chainweb.com?region=us-east-1
         signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
@@ -34,7 +34,7 @@ jobs:
         aws-region: us-east-1
 
     - name: Give root user AWS credentials
-      uses: kadena-io/setup-nix-with-cache/copy-root-aws-credentials@v3
+      uses: kadena-io/setup-nix-with-cache/copy-root-aws-credentials@v3.1
 
     - name: Build and cache artifacts
       run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -35,8 +35,11 @@ jobs:
 
     - name: Give root user AWS credentials
       uses: kadena-io/setup-nix-with-cache/copy-root-aws-credentials@v3
-      
+
     - name: Build and cache artifacts
       run: |
         echo Building the project and its devShell
         nix build .#check --log-lines 500 --show-trace
+
+        echo Build the recursive output
+        nix build .#recursive.allDerivations --log-lines 500 --show-trace

--- a/flake.lock
+++ b/flake.lock
@@ -226,11 +226,11 @@
         "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1699959816,
-        "narHash": "sha256-OurMcrf07sCDHBumWm8lorsA9hhiKX5KnVogsxx7bJs=",
+        "lastModified": 1699970998,
+        "narHash": "sha256-NgvBCRIB+lvcxJWMpU8Mulx8PG8s5jtqSR8K/natoTA=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "a38e0b9c37cc67ef27241d33fcc30d01125f12b5",
+        "rev": "a69071dafa3f0d12edf30ecc5a562aee1f7d138d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -226,16 +226,15 @@
         "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1699956738,
+        "lastModified": 1699959816,
         "narHash": "sha256-OurMcrf07sCDHBumWm8lorsA9hhiKX5KnVogsxx7bJs=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "8c1053765b265a8f13885687f00e094a7a5b76e5",
+        "rev": "a38e0b9c37cc67ef27241d33fcc30d01125f12b5",
         "type": "github"
       },
       "original": {
         "owner": "kadena-io",
-        "ref": "enis/metadata-experiments",
         "repo": "hs-nix-infra",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -17,6 +17,21 @@
       }
     },
     "flake-compat": {
+      "locked": {
+        "lastModified": 1699384378,
+        "narHash": "sha256-jI0nYllONVrNnyOYrvQMIEJQJuNeKnfJo5keRxWMcWs=",
+        "owner": "kadena-io",
+        "repo": "flake-compat",
+        "rev": "6ef9397736efb0f6075188aa3488022d1b85c11d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kadena-io",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1672831974,
@@ -89,7 +104,7 @@
           "hs-nix-infra",
           "empty"
         ],
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "ghc-8.6.5-iohk": [
           "hs-nix-infra",
           "empty"
@@ -204,25 +219,44 @@
     "hs-nix-infra": {
       "inputs": {
         "empty": "empty",
+        "flake-compat": "flake-compat",
         "hackage": "hackage",
         "haskellNix": "haskellNix",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1699283242,
-        "narHash": "sha256-weg0rDYjM93IxaRwcfNlnT6lVJ/f6dtfyF6ngF/6dlw=",
+        "lastModified": 1699956738,
+        "narHash": "sha256-OurMcrf07sCDHBumWm8lorsA9hhiKX5KnVogsxx7bJs=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "1410c0de36aa60fee36d65da22fb944ac87dee21",
+        "rev": "8c1053765b265a8f13885687f00e094a7a5b76e5",
         "type": "github"
       },
       "original": {
         "owner": "kadena-io",
+        "ref": "enis/metadata-experiments",
         "repo": "hs-nix-infra",
         "type": "github"
       }
     },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1669833724,
+        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "type": "github"
+      }
+    },
+    "nixpkgs-rec": {
       "locked": {
         "lastModified": 1669833724,
         "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",

--- a/flake.lock
+++ b/flake.lock
@@ -1,85 +1,18 @@
 {
   "nodes": {
-    "HTTP": {
+    "empty": {
       "flake": false,
       "locked": {
-        "lastModified": 1451647621,
-        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
-        "owner": "phadej",
-        "repo": "HTTP",
-        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "lastModified": 1683033565,
+        "narHash": "sha256-UZ2dz7/RzJKTw/8uqLu6biAbb3xNk23xUHb5/oAYWsw=",
+        "owner": "kadena-io",
+        "repo": "empty",
+        "rev": "c30c041f692678788a294069c95677774be2dff3",
         "type": "github"
       },
       "original": {
-        "owner": "phadej",
-        "repo": "HTTP",
-        "type": "github"
-      }
-    },
-    "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-34": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645834128,
-        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.4",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-36": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1669081697,
-        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.6",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cardano-shell": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1608537748,
-        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
+        "owner": "kadena-io",
+        "repo": "empty",
         "type": "github"
       }
     },
@@ -101,61 +34,31 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1679360468,
-        "narHash": "sha256-LGnza3cfXF10Biw3ZTg0u9o9t7s680Ww200t5KkHTh8=",
-        "owner": "hamishmack",
-        "repo": "flake-utils",
-        "rev": "e1ea268ff47ad475443dbabcd54744b4e5b9d4f5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hamishmack",
-        "ref": "hkm/nested-hydraJobs",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "ghc-8.6.5-iohk": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
         "type": "github"
       }
     },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1690331094,
-        "narHash": "sha256-xGJlmbRruW61N0rEcFn2pRlpLnE1TCKvvyz2nytYzE4=",
+        "lastModified": 1696379114,
+        "narHash": "sha256-dtax/ci3JfYvR2lLsvpvC6b3NCoEGZLrDH21/2svTps=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "efc8a53a648a6a3b0973aaefc93ace7d0ddf198d",
+        "rev": "21eae6f46c91831741496101e541e628aadecd98",
         "type": "github"
       },
       "original": {
@@ -166,320 +69,160 @@
     },
     "haskellNix": {
       "inputs": {
-        "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
-        "cabal-34": "cabal-34",
-        "cabal-36": "cabal-36",
-        "cardano-shell": "cardano-shell",
+        "HTTP": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cabal-32": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cabal-34": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cabal-36": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cardano-shell": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_2",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "hackage": "hackage",
-        "hls-1.10": "hls-1.10",
-        "hls-2.0": "hls-2.0",
-        "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
-        "iserv-proxy": "iserv-proxy",
+        "ghc-8.6.5-iohk": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "ghc980": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "ghc99": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hackage": [
+          "hs-nix-infra",
+          "hackage"
+        ],
+        "hls-1.10": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.0": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.2": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.3": "hls-2.3",
+        "hpc-coveralls": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hydra": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "iserv-proxy": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "nixpkgs": [
+          "hs-nix-infra",
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-2111": "nixpkgs-2111",
-        "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-2211": "nixpkgs-2211",
-        "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2003": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2105": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2111": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2205": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2211": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2305": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "old-ghc-nix": "old-ghc-nix",
-        "stackage": "stackage"
-      },
-      "locked": {
-        "lastModified": 1690332668,
-        "narHash": "sha256-GtrWrvYe5GlUH6adZjcs4Z0yEY+JrGBS2uentXjVNyI=",
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "d9c1f82b37b4226eb22718b657bb80fe961f1cdf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "type": "github"
-      }
-    },
-    "hls-1.10": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1680000865,
-        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "1.10.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.0": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1687698105,
-        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "783905f211ac63edf982dd1889c671653327e441",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.0.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hpc-coveralls": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1607498076,
-        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "type": "github"
-      }
-    },
-    "hydra": {
-      "inputs": {
-        "nix": "nix",
-        "nixpkgs": [
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
+        "old-ghc-nix": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "stackage": [
+          "hs-nix-infra",
+          "empty"
         ]
       },
       "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
+        "lastModified": 1697195891,
+        "narHash": "sha256-0L803S/wcHmVebEwFxObYCYOaB14ZtBAFCdg0aRgH70=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "c6cb3ff56b001b211690da35f70827fab5bf3272",
         "type": "github"
       },
       "original": {
-        "id": "hydra",
-        "type": "indirect"
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
       }
     },
-    "iserv-proxy": {
+    "hls-2.3": {
       "flake": false,
       "locked": {
-        "lastModified": 1688517130,
-        "narHash": "sha256-hUqfxSlo+ffqVdkSZ1EDoB7/ILCL25eYkcCXW9/P3Wc=",
-        "ref": "hkm/remote-iserv",
-        "rev": "9151db2a9a61d7f5fe52ff8836f18bbd0fd8933c",
-        "revCount": 13,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
-      },
-      "original": {
-        "ref": "hkm/remote-iserv",
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
-      }
-    },
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
         "type": "github"
       },
       "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
         "type": "github"
       }
     },
-    "nix": {
+    "hs-nix-infra": {
       "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-regression": "nixpkgs-regression"
+        "empty": "empty",
+        "hackage": "hackage",
+        "haskellNix": "haskellNix",
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
+        "lastModified": 1699283242,
+        "narHash": "sha256-weg0rDYjM93IxaRwcfNlnT6lVJ/f6dtfyF6ngF/6dlw=",
+        "owner": "kadena-io",
+        "repo": "hs-nix-infra",
+        "rev": "1410c0de36aa60fee36d65da22fb944ac87dee21",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
+        "owner": "kadena-io",
+        "repo": "hs-nix-infra",
         "type": "github"
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1682600000,
-        "narHash": "sha256-ha4BehR1dh8EnXSoE1m/wyyYVvHI9txjW4w5/oxsW5Y=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "50fc86b75d2744e1ab3837ef74b53f103a9b55a0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1685314633,
-        "narHash": "sha256-8LXBPqTQXl5ofkjpJ18JcbmLJ/lWDoMxtUwiDYv0wro=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c8a17ce7abc03c50cd072e9e6c9b389c5f61836b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2305": {
-      "locked": {
-        "lastModified": 1685338297,
-        "narHash": "sha256-+Aq4O0Jn1W1q927ZHc3Zn6RO7bwQGmb6O8xYoGy0KrM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "6287b47dbfabbb8bfbb9b1b53d198ad58a774de4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1685347552,
-        "narHash": "sha256-9woSppRyUFo26yUffORTzttJ+apOt8MmCv6RxpPNTU4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f2f1ec390714d303cf84ba086e34e45b450dd8c4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1669833724,
         "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
@@ -495,43 +238,40 @@
         "type": "github"
       }
     },
-    "old-ghc-nix": {
-      "flake": false,
+    "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1631092763,
-        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
-        "owner": "angerman",
-        "repo": "old-ghc-nix",
-        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "lastModified": 1695318763,
+        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
         "type": "github"
       },
       "original": {
-        "owner": "angerman",
-        "ref": "master",
-        "repo": "old-ghc-nix",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "haskellNix": "haskellNix",
-        "nixpkgs": "nixpkgs_2"
+        "hs-nix-infra": "hs-nix-infra"
       }
     },
-    "stackage": {
-      "flake": false,
+    "systems": {
       "locked": {
-        "lastModified": 1690330226,
-        "narHash": "sha256-ApHKqIP/Ubi92lZ0fp8EwiVdM7cejhYA4Hd5Zf8b7d8=",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "22fbccd7b46469e9405a7c035b8f83682d9c68f1",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Kadena's Pact smart contract language";
 
   inputs = {
-    hs-nix-infra.url = "github:kadena-io/hs-nix-infra/enis/metadata-experiments";
+    hs-nix-infra.url = "github:kadena-io/hs-nix-infra";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,17 +2,16 @@
   description = "Kadena's Pact smart contract language";
 
   inputs = {
-    # nixpkgs.follows = "haskellNix/nixpkgs";
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=4d2b37a84fad1091b9de401eb450aae66f1a741e";
-    haskellNix.url = "github:input-output-hk/haskell.nix";
+    hs-nix-infra.url = "github:kadena-io/hs-nix-infra";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils, haskellNix }:
+  outputs = { self, hs-nix-infra, flake-utils }:
     flake-utils.lib.eachSystem
       [ "x86_64-linux" "x86_64-darwin"
         "aarch64-linux" "aarch64-darwin" ] (system:
     let
+      inherit (hs-nix-infra) nixpkgs haskellNix;
       pkgs = import nixpkgs {
         inherit system overlays;
         inherit (haskellNix) config;

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Kadena's Pact smart contract language";
 
   inputs = {
-    hs-nix-infra.url = "github:kadena-io/hs-nix-infra";
+    hs-nix-infra.url = "github:kadena-io/hs-nix-infra/enis/metadata-experiments";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -16,7 +16,8 @@
         inherit system overlays;
         inherit (haskellNix) config;
       };
-      flake = pkgs.pact.flake {
+      project = pkgs.pact;
+      flake = project.flake {
         # crossPlatforms = p: [ p.ghcjs ];
       };
       overlays = [ haskellNix.overlay
@@ -48,8 +49,10 @@
         echo ${name}: ${package}
         echo works > $out
       '';
-    in flake // rec {
+    in rec {
       packages.default = flake.packages."pact:exe:pact";
+      packages.recursive = with hs-nix-infra.lib.recursive system;
+        wrapRecursiveWithMeta "pact" "${wrapFlake self}.default";
       packages.docs = pkgs.stdenv.mkDerivation {
         name = "pact-docs";
         src = ./docs;
@@ -82,5 +85,8 @@
         echo works > $out
       '';
 
+      # Other flake outputs provided by haskellNix can be accessed through
+      # this project output
+      inherit project;
     });
 }


### PR DESCRIPTION
I'm skipping the PR checklist since this is a Nix-only infrastructure change.
<details>
  <summary>PR checklist:</summary>
  
  * [ ] Test coverage for the proposed changes
  * [ ] PR description contains example output from repl interaction or a snippet from unit test output
  * [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
  * [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
  * [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.
  
  Additionally, please justify why you should or should not do the following:
  
  * [ ] Confirm replay/back compat
  * [ ] Benchmark regressions
  * [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
  
</details>

This PR does the following:

## Unify the GHC derivation used across Kadena projects

Instead of depending on `nixpkgs` and `haskellNix` directly, this flake now depends on our new `hs-nix-infra` flake and uses the `nixpkgs` and `haskellNix` revisions provided by it. The hash of the `nixpkgs` and `haskellNix` flakes used for defining the `haskell.nix` `project` determines the hash of the GHC package that gets used to compile the Haskell modules.  

When multiple projects depend on `nixpkgs` and `haskellNix` independently, it's very hard (and not really well supported by nix CLI) to make sure that they don't deviate from each others' `nixpkgs` and `haskellNix` pins arbitrarily. I.e. updating two projects' `flake.lock` files at slightly different times is likely to cause one of the pins to be on a different revision, even though the difference doesn't matter functionally.

These unnecessarily different GHC packages put a lot of pressure on our CI infrastructure, taking hours to build functionally equivalent GHC packages and bloating the cache (with binaries from all the architectures we build and cache for). That also bloats the `/nix/store` of any `pact` user that wants to `nix build` an uncached `pact` version.

### The new workflow for updating Haskell-Nix toolchain

After this PR, the new workflow for managing our Haskell dependencies used by Nix will involve the following steps:
* If an update to the toolchain is needed in order to fix the build, the first thing to try is to bump the `hs-nix-infra` dependency of this flake to the latest version. If that's not enough, we need to open a PR to `hs-nix-infra` to bump its proper input:
    * If we need to update our hackage pin so that we can build with newly released Haskell packages, we can just `nix flake lock --update-input hackage` and get a newer hackage snapshot without needing to introduce a new GHC derivation.
    * If we need to use a new GHC version provided by a newer `nixpkgs` version or if we need to bump our `haskellNix` pin for any reason we need to bump `nixpkgs` and `haskellNix`. The PR would preferably bump both of them to the latest version.

Hopefully, this new workflow will reduce the number of `nixpkgs` + `haskellNix` versions we depend on across our Haskell projects.

## Add a `recursive` alternative to the `default` package

As part of the CI automation for this repo, we're building and caching the Nix binaries for `pact`, which makes it convenient for any user to `nix build` pact from any commit/branch since all the dependencies will come from our binary cache. However, even without building anything locally, *evaluating* the `default` package of this flake takes a significant amount of time and involves downloading ~2 GB of Nix dependencies. This is due to the complexity of what `haskellNix` does for us at Nix evaluation time.

This PR introduces a `recursive` package to this flake's output, which uses `recursive-nix` to push the Nix evaluation of the `default` package into the build of a derivation. This means, any user that tries to `nix build .#recursive` will fetch the `pact` binary from our cache without having to perform any complex Nix evaluation locally or downloading the Nix dependencies of any such evaluation as long as the `recursive` derivation they're building is already in our binary cache. If not, the `recursive-nix` derivation will be built locally (in which case make sure your local Nix setup has `recursive-nix` enabled), which is essentially as much work as building `default` itself. This might still be worthwhile however, since subsequent builds of the same `recursive` derivation will complete immediately, without having to evaluate the `default` derivation again.
