### PR TITLE
use corresponding package set

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,18 +70,11 @@
         '';
       };
 
-      devShell = pkgs.haskellPackages.shellFor {
-        buildInputs = with pkgs.haskellPackages; [
-          cabal-install
-          haskell-language-server
-          # hlint
-        ];
+      inherit (flake) devShell;
 
-        withHoogle = true;
-      };
       packages.check = pkgs.runCommand "check" {} ''
         echo ${mkCheck "pact" packages.default}
-        echo ${mkCheck "devShell" flake.devShell}
+        echo ${mkCheck "devShell" devShell}
         echo works > $out
       '';
 


### PR DESCRIPTION
Prior to this PR, the `nix develop` shell did not rely on the package set we use for building pact. 
A nixpkgs update broke the current shell, which we resolved in this PR.

@enobayram thank you for the support :+1: 
PR checklist:
