### PR TITLE
small cleanups

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# --- Jump into Nix Shell --- #
-nix-shell --pure -p 'python38.withPackages (ps: [ps.sphinx ps.sphinx_rtd_theme])' -p pandoc -p perl --run "./work.sh"

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
           pact =
             final.haskell-nix.project' {
               src = ./.;
-              compiler-nix-name = "ghc962";
+              compiler-nix-name = "ghc963";
               shell.tools = {
                 cabal = {};
                 haskell-language-server = {};


### PR DESCRIPTION
- delete `docs/build.sh` (people should use `nix build .#docs` instead)
- default to ghc963 in flake.nix