### PR TITLE
Fix GHC 9.2.8 builds due to Prelude.liftA2

### DIFF
--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -53,7 +53,6 @@ module Pact.Eval
     ) where
 
 import Bound
-import qualified Control.Applicative
 import Control.Lens hiding (DefName)
 import Control.DeepSeq
 import Control.Monad
@@ -756,7 +755,7 @@ fullyQualifyDefs info mdef defs = do
           && mn == _mnName (_mName mdef)
           && isNsMatch -> resolveBareName memo (BareName fn i)
           where
-            isNsMatch = fromMaybe True (Control.Applicative.liftA2 (==) modNs mNs)
+            isNsMatch = fromMaybe True ((==) <$> modNs <*> mNs)
             modNs = _mnNamespace (_mName mdef)
       f  -> do
         dm <- lift (resolveRefFQN f f) -- lookup ref, don't try modules for barenames

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -53,7 +53,7 @@ module Pact.Eval
     ) where
 
 import Bound
-import Control.Applicative (liftA2)
+import qualified Control.Applicative
 import Control.Lens hiding (DefName)
 import Control.DeepSeq
 import Control.Monad
@@ -756,7 +756,7 @@ fullyQualifyDefs info mdef defs = do
           && mn == _mnName (_mName mdef)
           && isNsMatch -> resolveBareName memo (BareName fn i)
           where
-            isNsMatch = fromMaybe True (liftA2 (==) modNs mNs)
+            isNsMatch = fromMaybe True (Control.Applicative.liftA2 (==) modNs mNs)
             modNs = _mnNamespace (_mName mdef)
       f  -> do
         dm <- lift (resolveRefFQN f f) -- lookup ref, don't try modules for barenames

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -53,6 +53,7 @@ module Pact.Eval
     ) where
 
 import Bound
+import Control.Applicative (liftA2)
 import Control.Lens hiding (DefName)
 import Control.DeepSeq
 import Control.Monad


### PR DESCRIPTION
`liftA2` has been reexported from `Prelude` only since `base-4.18` (GHC 9.6.X), so references to `liftA2` without the accompanying `Control.Applicative` import causes build failures in earlier GHC versions. Simply adding `import Control.Applicative (liftA2)` to this repo fixes the issue for earlier GHC versions, but that causes an "unused import" warning in GHC 9.6, which becomes a build failure due to the `-Werror` flag.

This PR allows us to build `pact` with GHC 9.2.8 as well as GHC 9.6.3 without any issues, by importing `Control.Applicative` `qualified` and referring to `liftA2` with the `Control.Applicative.` prefix, avoiding the warning in GHC 9.6.3 and fixing the missing reference in 9.2.8.

I'm not sure how important that is for the `pact` project, but `chainweb-data` currently can't be upgraded to GHC 9.6.X due its transitive dependencies (see https://github.com/kadena-io/chainweb-data/pull/172) and it also can't stay with an earlier `pact` version, since `pact` made a sudden jump from 8.10 to 9.6 skipping all the intermediate GHC releases, so it may, in general, be desirable to allow it to build with earlier versions.

Note that the fully qualified `Control.Applicative.liftA2` reference is ugly, but I'm not sure what would've been a less ugly solution... Using CPP would be even uglier, or I could replace `liftA2` with `... <$> ... <*> ...`, but that could in (far-fetched) theory affect the performance, so opted for a fix that's obviously equivalent.

Feel free to close this PR if GHC 9.2.8 is considered irrelevant for `pact`.

-----------------------------------

_I'm skipping the PR checklist since it's hard to imagine how this change can have any effect on the program behavior._

<details>
  <summary> _Skipped PR checklist_ </summary>
  PR checklist:
  
  * [ ] Test coverage for the proposed changes
  * [ ] PR description contains example output from repl interaction or a snippet from unit test output
  * [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
  * [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
  * [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.
  
  Additionally, please justify why you should or should not do the following:
  
  * [ ] Confirm replay/back compat
  * [ ] Benchmark regressions
  * [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact

</details>