### PR TITLE
Update Pact Server HS

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ console> pact --serve --help
 Config file is YAML format with the following properties:
 port       - HTTP server port
 persistDir - Directory for database files.
-             If ommitted, runs in-memory only.
+             If omitted, runs in-memory only.
 logDir     - Directory for HTTP logs
 pragmas    - SQLite pragmas to use with persistence DBs
 verbose    - [True|False] Provide extra logging information

--- a/docs/en/pact-reference.md
+++ b/docs/en/pact-reference.md
@@ -624,7 +624,7 @@ Modules may be imported at a namespace, and interfaces my be implemented in a si
 
 #### Example: appending code to a namespace
 
-If one is simply appending code to an existing namespace, then the namespace prefix in the fully qualified name may be ommitted, as using a namespace works in a similar way to importing a module: all toplevel definitions within a namespace are brought into scope when `(namespace 'my-namespace)` is declared. Continuing from the previous example:
+If one is simply appending code to an existing namespace, then the namespace prefix in the fully qualified name may be omitted, as using a namespace works in a similar way to importing a module: all toplevel definitions within a namespace are brought into scope when `(namespace 'my-namespace)` is declared. Continuing from the previous example:
 
 ```lisp
 pact> (my-other-namespace.my-other-module.more-hello 3)

--- a/docs/en/pact-reference.rst
+++ b/docs/en/pact-reference.rst
@@ -806,7 +806,7 @@ Example: appending code to a namespace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If one is simply appending code to an existing namespace, then the
-namespace prefix in the fully qualified name may be ommitted, as using a
+namespace prefix in the fully qualified name may be omitted, as using a
 namespace works in a similar way to importing a module: all toplevel
 definitions within a namespace are brought into scope when
 ``(namespace 'my-namespace)`` is declared. Continuing from the previous

--- a/src/Pact/Server/Server.hs
+++ b/src/Pact/Server/Server.hs
@@ -84,7 +84,7 @@ usage = unlines
   [ "Config file is YAML format with the following properties:"
   , "port       - HTTP server port"
   , "persistDir - Directory for database files."
-  , "             If ommitted, runs in-memory only."
+  , "             If omitted, runs in-memory only."
   , "logDir     - Directory for HTTP logs"
   , "pragmas    - SQLite pragmas to use with persistence DBs"
   , "entity     - Entity name for simulating privacy, defaults to \"entity\""


### PR DESCRIPTION
Hey Team,

I noticed a small mistake when using the Server script. Namely, the server usage guidelines in Server.hs printed "ommitted" rather than "omitted". Obviously a minor error, but I noticed it had propagated through some other documentation as well, including the README. I went ahead and fixed the server along with the documentation to help the team clean up.
