### PR TITLE
Fix the Z3 referenced in the flake to 4.11

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
               };
               shell.buildInputs = with pkgs; [
                 zlib
-                z3
+                z3_4_11
                 pkgconfig
                 (python3.withPackages (ps: [ps.sphinx ps.sphinx_rtd_theme]))
                 pandoc perl


### PR DESCRIPTION
Without this change, `nix develop` pulls in z3-4.8.5, which is not recent enough for Pact. Even with this change, right now, it will pull in 4.11.0, while the docs say that 4.11.2 is required. This version will become available once `hs-nix-infra` updates `nixpkgs`.