### PR TITLE
fix tc step types

### DIFF
--- a/tests/pact/caps.repl
+++ b/tests/pact/caps.repl
@@ -60,7 +60,7 @@
 
   (defpact test-pact-guards (id:string)
     (step (step1 id))
-    (step (step2 (read-msg "id"))))
+    (step (let ((s2 (step2 (read-msg "id")))) "step2")))
 
   (defun step1 (id:string)
     (insert guard-table id { "g": (create-pact-guard "test")}))
@@ -207,7 +207,7 @@
 
 (env-data { "id": "a"})
 
-(expect "pact enforce succeeds" 1 (at 'result (continue-pact 1 false (hash "pact-guards-a-id"))))
+(expect "pact enforce succeeds" "step2"  (continue-pact 1 false (hash "pact-guards-a-id")))
 
 (pact-state true)
 (env-hash (hash "pact-guards-b-id"))

--- a/tests/pact/tc.repl
+++ b/tests/pact/tc.repl
@@ -329,6 +329,16 @@
     "test anon lambdas"
     (map (lambda (i) (> i 1)) [1 2 3]))
 
+  (defpact fail-steps-type-missmatch: integer ()
+    "test type missmatch of steps"
+    (step "missmatch")
+    (step 1))
+
+  (defpact tc-steps-type-pass: integer ()
+    "test type match of steps"
+    (step 1)
+    (step 1))
+
 )
 
 (create-table persons)


### PR DESCRIPTION
This PR enhances the typechecking for defpacts by ensuring consistency in return types across all steps. Previously, varying return types were permissible for each step. This update mandates that the return type for all steps aligns with the defpact's defined result type.

PR checklist:

* [x] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
