### PR TITLE
fix enforce-pact-version decimal parser

### DIFF
--- a/tests/pact/versions.repl
+++ b/tests/pact/versions.repl
@@ -15,6 +15,7 @@
   "pact version bounds fail for current version if wrong bounds"
   (enforce-pact-version "6.0.0" "100.0.0"))
 
+;; regression #1327 
 (expect
   "enforce-pact-version succeeds for current version if lower bound set"
   true

--- a/tests/pact/versions.repl
+++ b/tests/pact/versions.repl
@@ -1,0 +1,26 @@
+(begin-tx)
+
+
+(expect
+  "pact version bounds work for current pact version"
+  true
+  (enforce-pact-version "3.0.0" "6.0.0"))
+
+(expect
+  "enforce-pact-version works for current pact version"
+  true
+  (enforce-pact-version (pact-version)))
+
+(expect-failure
+  "pact version bounds fail for current version if wrong bounds"
+  (enforce-pact-version "6.0.0" "100.0.0"))
+
+(expect
+  "enforce-pact-version succeeds for current version if lower bound set"
+  true
+  (enforce-pact-version "1.0.0"))
+
+(expect
+  "enforce-pact-version succeeds (double digit regression)"
+  true
+  (enforce-pact-version "3.0000.0" "88.420.0"))

--- a/tests/pact/versions.repl
+++ b/tests/pact/versions.repl
@@ -1,4 +1,3 @@
-(begin-tx)
 
 
 (expect


### PR DESCRIPTION
`enforce-pact-version` was actually using lexicographic comparison due to the fact that the digit-parser is a stringy parser: 


The problem: 

```haskell
П> AP.parseOnly (AP.many1 AP.digit) "10"
Right "10"
```

Which leads to the following case for the first time in Pact's history, now that it has a double-digit version part: 

```pact
pact> (enforce-pact-version "4.3.1" "4.10.1")
<interactive>:0:0:Error: Invalid pact version 4.10, minimum allowed: 4.3.1
 at <interactive>:0:0: (enforce-pact-version "4.3.1" "4.10.1")
 ```

:tada: 

This PR uses integer parsing on the version segments: 

```pact
pact> (enforce-pact-version "4.3.1" "4.10.1")
true
```

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
~~* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.~~
~~* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)~~
~~* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.~~

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
