### PR TITLE
Make verifiers take only one argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ commands.sqlite
 cabal.project.local*
 /golden/lcov/actual
 .DS_Store
+.ghci_history

--- a/src/Pact/ApiReq.hs
+++ b/src/Pact/ApiReq.hs
@@ -197,7 +197,7 @@ data ApiReq = ApiReq {
   _ylCodeFile :: Maybe FilePath,
   _ylKeyPairs :: Maybe [ApiKeyPair],
   _ylSigners :: Maybe [ApiSigner],
-  _ylVerifiers :: Maybe [Verifier ParsedVerifierArgs],
+  _ylVerifiers :: Maybe [Verifier ParsedVerifierProof],
   _ylNonce :: Maybe Text,
   _ylPublicMeta :: Maybe ApiPublicMeta,
   _ylNetworkId :: Maybe NetworkId
@@ -548,7 +548,7 @@ mkExec
     -- ^ public metadata
   -> [(DynKeyPair, [SigCapability])]
     -- ^ signing keypairs + caplists
-  -> [Verifier ParsedVerifierArgs]
+  -> [Verifier ParsedVerifierProof]
     -- ^ verifiers
   -> Maybe NetworkId
     -- ^ optional 'NetworkId'
@@ -577,7 +577,7 @@ mkUnsignedExec
     -- ^ public metadata
   -> [Signer]
     -- ^ payload signers
-  -> [Verifier ParsedVerifierArgs]
+  -> [Verifier ParsedVerifierProof]
     -- ^ payload verifiers
   -> Maybe NetworkId
     -- ^ optional 'NetworkId'
@@ -641,7 +641,7 @@ mkCont
     -- ^ command public metadata
   -> [(DynKeyPair, [SigCapability])]
     -- ^ signing keypairs
-  -> [Verifier ParsedVerifierArgs]
+  -> [Verifier ParsedVerifierProof]
     -- ^ verifiers
   -> Maybe Text
     -- ^ optional nonce
@@ -677,7 +677,7 @@ mkUnsignedCont
     -- ^ command public metadata
   -> [Signer]
     -- ^ payload signers
-  -> [Verifier ParsedVerifierArgs]
+  -> [Verifier ParsedVerifierProof]
     -- ^ verifiers
   -> Maybe Text
     -- ^ optional nonce

--- a/src/Pact/Types/Command.hs
+++ b/src/Pact/Types/Command.hs
@@ -148,7 +148,7 @@ mkCommand
   :: J.Encode c
   => J.Encode m
   => [(Ed25519KeyPair, [SigCapability])]
-  -> [Verifier ParsedVerifierArgs]
+  -> [Verifier ParsedVerifierProof]
   -> m
   -> Text
   -> Maybe NetworkId
@@ -172,7 +172,7 @@ mkCommandWithDynKeys
   :: J.Encode c
   => J.Encode m
   => [(DynKeyPair, [UserCapability])]
-  -> [Verifier ParsedVerifierArgs]
+  -> [Verifier ParsedVerifierProof]
   -> m
   -> Text
   -> Maybe NetworkId
@@ -245,7 +245,7 @@ mkUnsignedCommand
   :: J.Encode m
   => J.Encode c
   => [Signer]
-  -> [Verifier ParsedVerifierArgs]
+  -> [Verifier ParsedVerifierProof]
   -> m
   -> Text
   -> Maybe NetworkId
@@ -369,7 +369,7 @@ data Payload m c = Payload
   , _pNonce :: !Text
   , _pMeta :: !m
   , _pSigners :: ![Signer]
-  , _pVerifiers :: !(Maybe [Verifier ParsedVerifierArgs])
+  , _pVerifiers :: !(Maybe [Verifier ParsedVerifierProof])
   , _pNetworkId :: !(Maybe NetworkId)
   } deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 instance (NFData a,NFData m) => NFData (Payload m a)

--- a/src/Pact/Types/Verifier.hs
+++ b/src/Pact/Types/Verifier.hs
@@ -12,9 +12,9 @@ module Pact.Types.Verifier
   ( VerifierName(..)
   , Verifier(..)
   , verifierName
-  , verifierArgs
+  , verifierProof
   , verifierCaps
-  , ParsedVerifierArgs(..)
+  , ParsedVerifierProof(..)
   ) where
 
 import Control.DeepSeq
@@ -34,9 +34,9 @@ newtype VerifierName = VerifierName Text
   deriving newtype (J.Encode, Arbitrary, NFData, Eq, Show, Ord, FromJSON)
   deriving stock Generic
 
-data Verifier args = Verifier
+data Verifier prf = Verifier
   { _verifierName :: VerifierName
-  , _verifierArgs :: args
+  , _verifierProof :: prf
   , _verifierCaps :: [UserCapability]
   }
   deriving (Eq, Show, Generic, Ord, Functor, Foldable, Traversable)
@@ -53,22 +53,22 @@ instance Arbitrary a => Arbitrary (Verifier a) where
 instance J.Encode a => J.Encode (Verifier a) where
   build va = J.object
     [ "name" J..= _verifierName va
-    , "args" J..= _verifierArgs va
-    , "caps" J..= J.Array (_verifierCaps va)
+    , "proof" J..= _verifierProof va
+    , "clist" J..= J.Array (_verifierCaps va)
     ]
 instance FromJSON a => FromJSON (Verifier a) where
   parseJSON = withObject "Verifier" $ \o -> do
     name <- o .: "name"
-    args <- o .: "args"
-    caps <- o .: "caps"
-    return $ Verifier name args caps
+    proof <- o .: "proof"
+    caps <- o .: "clist"
+    return $ Verifier name proof caps
 
-newtype ParsedVerifierArgs = ParsedVerifierArgs [PactValue]
+newtype ParsedVerifierProof = ParsedVerifierProof PactValue
   deriving newtype (NFData, Eq, Show, Ord, FromJSON)
   deriving stock Generic
 
-instance J.Encode ParsedVerifierArgs where
-  build (ParsedVerifierArgs as) = J.build (J.Array as)
+instance J.Encode ParsedVerifierProof where
+  build (ParsedVerifierProof as) = J.build as
 
-instance Arbitrary ParsedVerifierArgs where
-  arbitrary = ParsedVerifierArgs <$> scale (min 10) arbitrary
+instance Arbitrary ParsedVerifierProof where
+  arbitrary = ParsedVerifierProof <$> arbitrary

--- a/tests/PactContinuationSpec.hs
+++ b/tests/PactContinuationSpec.hs
@@ -1315,7 +1315,7 @@ testVerifiers = context "using a verifier" $ it "should parse and run" $ do
       [(simpleKeys,[])]
       [Verifier
         (VerifierName "TESTING-VERIFIER")
-        (ParsedVerifierArgs [PLiteral $ LDecimal 3])
+        (ParsedVerifierProof $ PLiteral (LDecimal 3))
         [SigCapability (QualifiedName (ModuleName "coin" Nothing) "TRANSFER" def) [PLiteral (LString "jeff"), PLiteral (LDecimal 10)]]]
       Nothing (Just "test1")
     allResults <- runAll [cmd]

--- a/tests/Test/Pact/Utils/LegacyValue.hs
+++ b/tests/Test/Pact/Utils/LegacyValue.hs
@@ -1040,7 +1040,7 @@ spec_pact_types_command =
       , Case checkAesonCompat
       , Case checkLegacyValueCompat
       ]
-   spec_case @(Verifier ParsedVerifierArgs)
+   spec_case @(Verifier ParsedVerifierProof)
       [ Case checkRoundtrip
       , Case checkRoundtrip2
       , Case checkAesonCompat


### PR DESCRIPTION
PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
