### PR TITLE
Update bug report issue template to refer to docs site

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,8 +9,7 @@ assignees: ''
 ## Issue description
 
 <!--
-Before opening a bug, please take a look at the [Pact ReadtheDocs](https://pact-language.readthedocs.io/en/stable/).
-This explains Pact's semantics and some common issues and will also help you to find the information that the issue template asks for.
+Before opening a bug, please take a look at the [Pact documentation](https://docs.kadena.io/pact). This explains Pact's semantics and some common issues and will also help you to find the information that the issue template asks for.
 -->
 
 ### Steps to reproduce


### PR DESCRIPTION
The issue template still refers to the read the docs website, but visiting that site shows a large, all-caps deprecation notice. This PR adjusts the link in the template to point to docs.kadena.io/pact.