### PR TITLE
Error message fix

### DIFF
--- a/src/Pact/Native/Capabilities.hs
+++ b/src/Pact/Native/Capabilities.hs
@@ -169,12 +169,15 @@ capFuns :: (ApplyMgrFun e,InstallMgd e)
 capFuns = (applyMgrFun,installSigCap)
 
 installSigCap :: InstallMgd e
-installSigCap cap@SigCapability{..} cdef = do
-  ty <- traverse reduce (_dFunType cdef)
-  r <- evalCap (getInfo cdef) CapManaged True (cap,cdef,(fromPactValue <$> _scArgs,ty),getInfo cdef)
+installSigCap SigCapability{..} cdef = do
+  (cap,d,prep) <- appToCap $
+    App (TVar (Ref (TDef cdef (getInfo cdef))) (getInfo cdef))
+        (map (liftTerm . fromPactValue) _scArgs) (getInfo cdef)
+  r <- evalCap (getInfo cdef) CapManaged True (cap,d,prep,getInfo cdef)
   case r of
     NewlyInstalled mc -> return mc
     _ -> evalError' cdef "Unexpected result from managed sig cap install"
+
 
 
 enforceNotWithinDefcap :: HasInfo i => i -> Doc -> Eval e ()


### PR DESCRIPTION
This fixes replay. We check in `evalCap` if a cap's arguments have the right type.
We used to check in `installSigCap` too, which would be called before `evalCap`.
I recognized while implementing verifiers that this check was unnecessary and
deleted it, but we need it to remain, because otherwise the call stack from
the typechecking error changes and breaks replay.

PR checklist:

* [ ] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [x] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
