### PR TITLE
fixes #1346, parsing of diff-time as property

### DIFF
--- a/src-tool/Pact/Analyze/Parse/Prop.hs
+++ b/src-tool/Pact/Analyze/Parse/Prop.hs
@@ -458,6 +458,12 @@ inferPreProp preProp = case preProp of
       _                 -> throwErrorIn b $
         "expected integer or decimal, found " <> pretty (existentialType b')
 
+  PreApp s [a,b]
+    | s == STemporalDiff -> do
+        a' <- checkPreProp STime a
+        b' <- checkPreProp STime b
+        pure $ Some SDecimal $ CoreProp $ DiffTime a' b'
+
   PreApp op'@(toOp comparisonOpP -> Just op) [a, b] -> do
     a''@(Some aTy a') <- inferPreProp a
     b''@(Some bTy b') <- inferPreProp b

--- a/tests/AnalyzeSpec.hs
+++ b/tests/AnalyzeSpec.hs
@@ -2360,6 +2360,15 @@ spec = describe "analyze" $ do
               (diff-time (time "2021-01-01T00:00:01Z") (time "2021-01-01T00:00:00Z")))
           |]
     in expectVerified code
+  describe "diff-time implementation as property (#1346)" $
+    let code =
+          [text|
+            (defun test:decimal (a: time b: time)
+              @model[(property (> (diff-time a b) 0.0))]
+              (enforce (> (diff-time a b) 0.0) "a-b > 0")
+             1.0)
+          |]
+    in expectVerified code
 
   describe "regression time representation (int64/integer)" $
     let code =


### PR DESCRIPTION
This PR adds parsing of the property `diff-time`.

closes #1346 

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] Documentation has been updated if new natives or FV properties have been added. To generate new documentation, issue `cabal run tests`. If they pass locally, docs are generated.
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
