### PR TITLE
feature: support for reflecting db contents into another db

### DIFF
--- a/docs/en/pact-functions.md
+++ b/docs/en/pact-functions.md
@@ -461,7 +461,7 @@ Return ID if called during current pact execution, failing if not.
 Obtain current pact build version.
 ```lisp
 pact> (pact-version)
-"4.11"
+"4.12"
 ```
 
 Top level only: this function will fail if used in module code.

--- a/pact.cabal
+++ b/pact.cabal
@@ -128,6 +128,7 @@ library
     Pact.Persist.MockPersist
     Pact.Persist.Pure
     Pact.Persist.SQLite
+    Pact.Persist.Taped
     Pact.PersistPactDb
     Pact.PersistPactDb.Regression
     Pact.Repl

--- a/src/Pact/MockDb.hs
+++ b/src/Pact/MockDb.hs
@@ -25,8 +25,8 @@ newtype MockTxIds =
 instance Default MockTxIds where def = MockTxIds (\_t _i -> rc [])
 
 newtype MockGetUserTableInfo =
-  MockGetUserTableInfo (TableName -> Method () ModuleName)
-instance Default MockGetUserTableInfo where def = MockGetUserTableInfo (\_t -> rc "")
+  MockGetUserTableInfo (TableName -> Method () (Maybe ModuleName))
+instance Default MockGetUserTableInfo where def = MockGetUserTableInfo (\_t -> rc (Just ""))
 
 newtype MockCommitTx =
   MockCommitTx (Method () [TxLogJson])

--- a/src/Pact/Persist/Taped.hs
+++ b/src/Pact/Persist/Taped.hs
@@ -1,0 +1,222 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE InstanceSigs #-}
+
+-- |
+-- Module      :  Pact.Persist.Taped
+-- Copyright   :  (C) 2024 Kadena
+-- License     :  BSD-style (see the file LICENSE)
+-- Maintainer  :  Edmund Noble <edmund@kadena.io>
+--
+-- Tapes for recording and playing back database access.
+--
+module Pact.Persist.Taped
+  ( WriteSet(..)
+  , reflectingDb
+  , ReflectingDbEnv(..)
+  , reflectingInputMirror
+  , reflectingOutputMirror
+  , reflectingSource
+  , reflectingWriteSet
+  ) where
+
+import Control.Concurrent.MVar
+import Control.Lens
+
+import Data.Default
+import Data.Map (Map)
+import Data.Set (Set)
+import qualified Data.Set as Set
+
+import Pact.Types.Term
+import Pact.Types.Persistence
+import Control.Monad.State
+import Control.Monad
+import qualified Data.Map as Map
+import Pact.Types.RowData
+import Pact.Types.Lang (Code(..))
+import Pact.Types.Namespace
+import Data.Maybe (isNothing)
+
+data WriteSet
+  = WriteSet
+    { _userTableWrites :: Map TableName (Set RowKey)
+    , _keySetWrites :: Set KeySetName
+    , _moduleWrites :: Set ModuleName
+    , _namespaceWrites :: Set NamespaceName
+    , _defPactWrites :: Set PactId
+    }
+
+instance Semigroup WriteSet where
+  ws <> ws' = WriteSet
+    { _userTableWrites = Map.unionWith Set.union (_userTableWrites ws) (_userTableWrites ws')
+    , _keySetWrites = Set.union (_keySetWrites ws) (_keySetWrites ws')
+    , _moduleWrites = Set.union (_moduleWrites ws) (_moduleWrites ws')
+    , _namespaceWrites = Set.union (_namespaceWrites ws) (_namespaceWrites ws')
+    , _defPactWrites = Set.union (_defPactWrites ws) (_defPactWrites ws')
+    }
+instance Monoid WriteSet where
+  mempty = WriteSet mempty mempty mempty mempty mempty
+
+data ReflectingDbEnv mi mo s = ReflectingDbEnv
+  { _reflectingWriteSet :: !WriteSet
+  , _reflectingInputMirror :: !mi
+  , _reflectingOutputMirror :: !mo
+  , _reflectingSource :: !s
+  }
+
+makeLenses ''ReflectingDbEnv
+
+-- Given inputMirrorDb, outputMirrorDb, and sourceDb, this function creates a PactDb which forwards its read and
+-- write requests to sourceDb, and simultaneously populates inputMirrorDb with enough data to allow re-running
+-- the same requests without the entire source db. It also populates outputMirrorDb with all of the writes made.
+-- Together these allow making small, self-contained tests by:
+-- 1. running Pact transactions on reflectingDb with larger source databases
+-- 2. extracting the mirror databases in JSON format
+-- 3. running the same Pact transactions on reflectingDb with the source set to the original input mirror database
+-- 4. asserting that the final output mirror is equal to the original output mirror
+--
+-- Note: createSchema operates on Persister, which is a layer lower than PactDb;
+-- one must have valid schemas in all database values before using them with reflectingDb.
+reflectingDb :: PactDb mi -> PactDb mo -> PactDb s -> PactDb (ReflectingDbEnv mi mo s)
+reflectingDb inputMirrorDb outputMirrorDb sourceDb = PactDb
+  { _readRow = \d k -> modifyMVarStateT $ do
+      -- when read from, the reflecting db reflects the write from the source to the mirror
+      -- and returns the read value
+      mv <- wrapMethod reflectingSource (_readRow sourceDb d k)
+      createTableForDomainIfMissing reflectingInputMirror inputMirrorDb d
+      WriteSet{..} <- use reflectingWriteSet
+      wrapMethod reflectingInputMirror $ \var -> do
+        -- write to the mirror db only if this row wasn't already written to the source during this transaction
+        () <- case d of
+          UserTables tn
+            | Just tableWrites <- Map.lookup tn _userTableWrites
+            , Set.member k tableWrites -> return ()
+            | otherwise -> forM_ mv $ \v ->
+              _writeRow inputMirrorDb Write d k v var
+          KeySets
+            | Set.member k _keySetWrites -> return ()
+            | otherwise -> forM_ mv $ \v ->
+              _writeRow inputMirrorDb Write d k v var
+          Modules
+            | Set.member k _moduleWrites -> return ()
+            | otherwise -> forM_ mv $ \v ->
+              _writeRow inputMirrorDb Write d k v var
+          Namespaces
+            | Set.member k _namespaceWrites -> return ()
+            | otherwise -> forM_ mv $ \v ->
+              _writeRow inputMirrorDb Write d k v var
+          Pacts
+            | Set.member k _defPactWrites -> return ()
+            | otherwise -> forM_ mv $ \v ->
+              _writeRow inputMirrorDb Write d k v var
+        return ()
+      return mv
+
+  , _writeRow = \wt d k v -> modifyMVarStateT $ do
+      wrapMethod reflectingSource (_writeRow sourceDb wt d k v)
+      createTableForDomainIfMissing reflectingOutputMirror outputMirrorDb d
+      -- we always use Write mode here, because the above write must have succeeded
+      wrapMethod reflectingOutputMirror (_writeRow outputMirrorDb Write d k v)
+      reflectingWriteSet <>= case d of
+        UserTables tn -> mempty { _userTableWrites = Map.singleton tn (Set.singleton k) }
+        KeySets -> mempty { _keySetWrites = Set.singleton k }
+        Modules -> mempty { _moduleWrites = Set.singleton k }
+        Namespaces -> mempty { _namespaceWrites = Set.singleton k }
+        Pacts -> mempty { _defPactWrites = Set.singleton k }
+  , _keys = \d -> modifyMVarStateT $ do
+      ks <- wrapMethod reflectingSource (_keys sourceDb d)
+      createTableForDomainIfMissing reflectingInputMirror inputMirrorDb d
+      -- we have no way of knowing the values at these keys, so we write fake values
+      () <- case d of
+        UserTables tn -> do
+          forM_ ks $ \k -> wrapMethod reflectingInputMirror (_writeRow inputMirrorDb Write (UserTables tn) k
+            RowData { _rdVersion = RDV1, _rdData = ObjectMap mempty })
+        KeySets -> do
+          forM_ ks $ \k -> wrapMethod reflectingInputMirror (_writeRow inputMirrorDb Write KeySets k
+            KeySet { _ksKeys = mempty, _ksPredFun = Name $ BareName "fake" def })
+        Modules -> do
+          forM_ ks $ \k ->
+            wrapMethod reflectingInputMirror
+              (_writeRow inputMirrorDb Write Modules k
+                (ModuleData (MDInterface (Interface "fake" (Code "") (Meta Nothing []) []) ) mempty mempty))
+        Namespaces -> do
+          forM_ ks $ \k ->
+            wrapMethod reflectingInputMirror
+              (_writeRow inputMirrorDb Write Namespaces k
+                (Namespace (NamespaceName "fake") (GKeySetRef "fake") (GKeySetRef "fake")))
+        Pacts -> do
+          forM_ ks $ \k ->
+            wrapMethod reflectingInputMirror (_writeRow inputMirrorDb Write Pacts k Nothing)
+
+      return ks
+
+  , _txids = \tn txid -> modifyMVarStateT $ wrapMethod reflectingSource (_txids sourceDb tn txid)
+  , _createUserTable = \tn mn -> modifyMVarStateT $ do
+      wrapMethod reflectingSource (_createUserTable sourceDb tn mn)
+      wrapMethod reflectingOutputMirror (_createUserTable outputMirrorDb tn mn)
+
+  , _getUserTableInfo = \tn -> modifyMVarStateT $ wrapMethod reflectingSource (_getUserTableInfo sourceDb tn)
+  , _beginTx = \em -> modifyMVarStateT $ do
+    txid <- wrapMethod reflectingSource (_beginTx sourceDb em)
+    _ <- wrapMethod reflectingInputMirror (_beginTx inputMirrorDb em)
+    _ <- wrapMethod reflectingOutputMirror (_beginTx outputMirrorDb em)
+    return txid
+  , _commitTx = modifyMVarStateT $ do
+    logs <- wrapMethod reflectingSource (_commitTx sourceDb)
+    _ <- wrapMethod reflectingInputMirror (_commitTx inputMirrorDb)
+    _ <- wrapMethod reflectingOutputMirror (_commitTx outputMirrorDb)
+    -- reset write set outside of transaction
+    reflectingWriteSet .= mempty
+    return logs
+  , _rollbackTx = modifyMVarStateT $ do
+    wrapMethod reflectingSource (_rollbackTx sourceDb)
+    -- we commit to the mirror databases even on a rollback, to allow observing even failed txs
+    _ <- wrapMethod reflectingInputMirror (_commitTx inputMirrorDb)
+    _ <- wrapMethod reflectingOutputMirror (_commitTx outputMirrorDb)
+    -- reset write set outside of transaction
+    reflectingWriteSet .= mempty
+  , _getTxLog = \d txid -> modifyMVarStateT $ do
+    wrapMethod reflectingSource (_getTxLog sourceDb d txid)
+  }
+  where
+  wrapMethod :: Lens' s a -> (MVar a -> IO r) -> StateT s IO r
+  wrapMethod l m = do
+    v <- get
+    var <- liftIO $ newMVar (v ^. l)
+    r <- liftIO $ m var
+    v' <- liftIO $ takeMVar var
+    put (v & l .~ v')
+    return r
+
+  modifyMVarStateT act var = do
+    modifyMVar var $ \v -> do
+      (a, v') <- runStateT act v
+      return (v', a)
+
+  createTableForDomainIfMissing :: Lens' s a -> PactDb a -> Domain k v -> StateT s IO ()
+  createTableForDomainIfMissing l db d = wrapMethod l $ \var ->
+    -- create a user table for this write if missing, do this even if the value
+    -- itself is Nothing, to avoid missing table errors
+    case d of
+      UserTables tn -> do
+        tableModule <- _getUserTableInfo db tn var
+        when (isNothing tableModule) $
+          _createUserTable db tn "fake module name" var
+      _ -> return ()

--- a/src/Pact/PersistPactDb.hs
+++ b/src/Pact/PersistPactDb.hs
@@ -319,12 +319,12 @@ record tt k v = modify'
     append (h:t) b = let !x = append t b in h : x
 {-# INLINE record #-}
 
-getUserTableInfo' :: MVar (DbEnv p) -> TableName -> IO ModuleName
+getUserTableInfo' :: MVar (DbEnv p) -> TableName -> IO (Maybe ModuleName)
 getUserTableInfo' e tn = runMVState e $ do
   r <- doPersist $ \p -> readValue p (DataTable userTableInfo) (DataKey $ asString tn)
   case r of
-    (Just (UserTableInfo mn)) -> return mn
-    Nothing -> throwDbError $ "getUserTableInfo: no such table: " <> pretty tn
+    (Just (UserTableInfo mn)) -> return (Just mn)
+    Nothing -> return Nothing
 {-# INLINE getUserTableInfo' #-}
 
 

--- a/src/Pact/Types/Persistence.hs
+++ b/src/Pact/Types/Persistence.hs
@@ -384,7 +384,7 @@ data PactDb e = PactDb {
     -- | Create a user table.
   , _createUserTable :: !(TableName -> ModuleName -> Method e ())
     -- | Get module, keyset for user table.
-  , _getUserTableInfo :: !(TableName -> Method e ModuleName)
+  , _getUserTableInfo :: !(TableName -> Method e (Maybe ModuleName))
     -- | Initiate transactional state. Returns txid for 'Transactional' mode
     -- or Nothing for 'Local' mode. If state already initiated, rollback and throw error.
   , _beginTx :: !(ExecutionMode -> Method e (Maybe TxId))

--- a/src/Pact/Types/Runtime.hs
+++ b/src/Pact/Types/Runtime.hs
@@ -462,7 +462,7 @@ createUserTable :: Info -> TableName -> ModuleName -> Eval e ()
 createUserTable i t m = method i $ \db -> _createUserTable db t m
 
 -- | Invoke _getUserTableInfo
-getUserTableInfo :: Info -> TableName -> Eval e ModuleName
+getUserTableInfo :: Info -> TableName -> Eval e (Maybe ModuleName)
 getUserTableInfo i t = method i $ \db -> _getUserTableInfo db t
 
 -- | Invoke _beginTx

--- a/tests/PersistSpec.hs
+++ b/tests/PersistSpec.hs
@@ -3,26 +3,118 @@
 module PersistSpec (spec) where
 
 import Test.Hspec
+import Pact.PersistPactDb(createSchema, pactdb)
 import Pact.PersistPactDb.Regression
 import qualified Pact.Persist.SQLite as SQLite
 import System.Directory
+import Control.Lens
 import Control.Monad
 import Pact.Types.Logger
+import Pact.Types.Persistence
+import Pact.Persist.Taped
+import qualified Pact.Persist.Pure as Pure
 import Control.Concurrent
+import qualified Data.Map as Map
+import Pact.Types.RowData
+import Pact.Types.Term(ObjectMap(..))
+import Pact.Types.Exp(Literal(..))
 
 spec :: Spec
 spec = do
   it "regress Pure" (void $ regressPure neverLog)
   describe "regress SQLite" regressSQLite
+  describe "reflected pure db" reflectedTests
 
 
 regressSQLite :: Spec
 regressSQLite = it "SQLite successfully closes" $ do
-  let f = "deleteme.sqllite"
+  let f = "deleteme.sqlite"
   db <- do
     doesFileExist f >>= \b -> when b (removeFile f)
-    sl <- SQLite.initSQLite (SQLite.SQLiteConfig "deleteme.sqllite" []) neverLog
-    mv <- runRegression (initDbEnv neverLog SQLite.persister sl)
+    sl <- SQLite.initSQLite (SQLite.SQLiteConfig "deleteme.sqlite" []) neverLog
+    mv <- newMVar $ initDbEnv neverLog SQLite.persister sl
+    createSchema mv
+    runRegression pactdb mv
     _db <$> readMVar mv
   SQLite.closeSQLite db `shouldReturn` Right ()
   removeFile f
+
+regressReflected :: IO ()
+regressReflected = do
+  -- create an empty reflecting db
+  reflectedV <- do
+    pureDbEnv <- initPureDbEnv
+    newMVar ReflectingDbEnv
+      { _reflectingWriteSet = mempty
+      , _reflectingInputMirror = pureDbEnv
+      , _reflectingOutputMirror = pureDbEnv
+      , _reflectingSource = pureDbEnv
+      }
+  -- do a bunch of things with the reflecting db, grab the resulting db state
+  reflectedOut <- do
+    runRegression (reflectingDb pactdb pactdb pactdb) reflectedV
+    readMVar reflectedV
+  -- do the same things with just a pure db, grab the resulting db state
+  pureOut <- do
+    v <- newMVar =<< initPureDbEnv
+    runRegression pactdb v
+    readMVar v
+  -- reflected source should have the same contents afterward as pure db
+  _db (_reflectingSource reflectedOut) `shouldBe` _db pureOut
+
+reflectedTests :: Spec
+reflectedTests = do
+   it "should reflect reads to the mirrordb" reflectionTest
+   it "should regress the same as the read db" regressReflected
+
+initPureDbEnv :: IO (DbEnv Pure.PureDb)
+initPureDbEnv = do
+  v <- newMVar (initDbEnv neverLog Pure.persister Pure.initPureDb)
+  createSchema v
+  readMVar v
+
+reflectionTest :: IO ()
+reflectionTest = do
+  sourceDb <- do
+    mv <- newMVar $ initDbEnv neverLog Pure.persister Pure.initPureDb
+    createSchema mv
+    -- prepare initial database
+    _ <- _beginTx pactdb Transactional mv
+    _createUserTable pactdb "mod.tbl" "mod" mv
+    _writeRow pactdb Insert (UserTables "mod.tbl") "key" (RowData RDV1 (ObjectMap $ Map.singleton "vkey" (RDLiteral $ LString "value"))) mv
+    _ <- _commitTx pactdb mv
+    readMVar mv
+  -- initialize, read and write reflecting database
+  (inputValue, reflectedOut) <- do
+    inputMirrorDb <- initPureDbEnv
+    outputMirrorDb <- initPureDbEnv
+    reflectedV <- newMVar ReflectingDbEnv
+      { _reflectingWriteSet = mempty
+      , _reflectingInputMirror = inputMirrorDb
+      , _reflectingOutputMirror = outputMirrorDb
+      , _reflectingSource = sourceDb
+      }
+    let rdb = reflectingDb pactdb pactdb pactdb
+    -- read a value from the source database, reflecting it into the input mirror database
+    inputValue <- _readRow rdb (UserTables "mod.tbl") "key" reflectedV
+    -- write a new value to the read database, which should not be reflected by further reads into the input mirror,
+    -- but into the output mirror instead
+    _writeRow rdb Write (UserTables "mod.tbl") "key2"
+      (RowData RDV1 (ObjectMap $ Map.singleton "vkey" (RDLiteral $ LString "new value")))
+      reflectedV
+    _ <- _readRow rdb (UserTables "mod.tbl") "key2" reflectedV
+    reflectedOut <- readMVar reflectedV
+    return (inputValue, reflectedOut)
+  do
+    -- check that the input mirror has the read value
+    inputMirrorV <- newMVar $ view reflectingInputMirror reflectedOut
+    reflectedValue <- _readRow pactdb (UserTables "mod.tbl") "key" inputMirrorV
+    reflectedValue `shouldBe` inputValue
+    -- check that the input mirror does not have the written value
+    unreflectedValue <- _readRow pactdb (UserTables "mod.tbl") "key2" inputMirrorV
+    unreflectedValue `shouldBe` Nothing
+  do
+    -- check that the output mirror has the written value
+    outputMirrorV <- newMVar $ view reflectingOutputMirror reflectedOut
+    reflectedOutputValue <- _readRow pactdb (UserTables "mod.tbl") "key2" outputMirrorV
+    reflectedOutputValue `shouldBe` Just (RowData RDV1 (ObjectMap $ Map.singleton "vkey" $ RDLiteral (LString "new value")))


### PR DESCRIPTION
This lets us for example reflect all of the things we read from one PactDb (like chainweb's) into another (like a pure one) for later use (for example in a unit test).

Change-Id: I476b90b2074ad2b6cd4de0b376931108181e638d

PR checklist:

* [x] Test coverage for the proposed changes
* [ ] PR description contains example output from repl interaction or a snippet from unit test output
* [ ] New builtins have a FV translation
* [ ] Documentation has been (manually) updated at https://docs.kadena.io/pact
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [ ] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [ ] Confirm replay/back compat
* [ ] Benchmark regressions
* [ ] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
