### PR TITLE
support ghc-9.10

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -18,14 +18,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.6', '9.8', '9.10']
+        ghc: ['9.6.6', '9.8.2', '9.10.1']
         cabal: ['3.12']
         os: ['ubuntu-20.04', 'ubuntu-22.04', 'macos-latest', 'macos-14']
         cabalcache: ['true']
         flags: ['+build-tool']
         include:
-        - os: 'ubuntu-20.04'
-          ghc: '9.8'
+        - os: 'ubuntu-22.04'
+          ghc: '9.8.2'
           cabal: '3.12'
           cabalcache: 'true'
           flags: '-build-tool'
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Non Haskell dependencies
 
@@ -143,11 +143,11 @@ jobs:
         cabal freeze
     - name: Sync from cabal cache
       if: matrix.cabalcache == 'true'
-      uses: larskuhtz/cabal-cache-action@018b7ae0c480ba3dc4fa0cfa3a0bc1f05b7724b3
+      uses: larskuhtz/cabal-cache-action@4b537195b33898fcd9adc62cee2a44986fd7b1b6
       with:
         bucket: "kadena-cabal-cache"
         region: "us-east-1"
-        folder: "${{ matrix.os }}"
+        folder: "packages/${{ matrix.os }}"
         aws_access_key_id: "${{ secrets.kadena_cabal_cache_aws_access_key_id }}"
         aws_secret_access_key: "${{ secrets.kadena_cabal_cache_aws_secret_access_key }}"
     - name: Build dependencies
@@ -219,8 +219,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - ghc: "9.6"
-          os: "ubuntu-20.04"
+        - ghc: "9.6.6"
+          os: "ubuntu-22.04"
     env:
       OS: ${{ matrix.os }}
     steps:
@@ -236,7 +236,7 @@ jobs:
         FROM ubuntu:${OS#ubuntu-}
         LABEL com.chainweb.docker.image.compiler="ghc-${{ matrix.ghc }}"
         LABEL com.chainweb.docker.image.os="${{ matrix.os }}"
-        RUN apt-get update && apt-get install -y ca-certificates libgmp10 libssl1.1 zlib1g locales && rm -rf /var/lib/apt/lists/* && locale-gen en_US.UTF-8 && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+        RUN apt-get update && apt-get install -y ca-certificates libgmp10 libssl3 zlib1g locales && rm -rf /var/lib/apt/lists/* && locale-gen en_US.UTF-8 && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
         ENV LANG=en_US.UTF-8
         WORKDIR /pact
         COPY pact/pact .

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -70,6 +70,11 @@ jobs:
     - name: Print Z3 version
       shell: bash
       run: z3 -version
+   
+    # Install libc6 for cabal-cache on ubuntu-20.04
+    - name: Install libc6 on ubuntu-20.04
+      if: matrix.os == 'ubuntu-20.04'
+      run: apt-get install libc6
 
     # Haskell Setup
     - name: Set permissions for .ghcup (ubuntu)

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -74,7 +74,7 @@ jobs:
     # Install libc6 for cabal-cache on ubuntu-20.04
     - name: Install libc6 on ubuntu-20.04
       if: matrix.os == 'ubuntu-20.04'
-      run: apt-get install libc6
+      run: sudo apt-get install libc6
 
     # Haskell Setup
     - name: Set permissions for .ghcup (ubuntu)

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -18,15 +18,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['9.6']
-        cabal: ['3.10']
+        ghc: ['9.6', '9.8', '9.10']
+        cabal: ['3.12']
         os: ['ubuntu-20.04', 'ubuntu-22.04', 'macos-latest', 'macos-14']
         cabalcache: ['true']
         flags: ['+build-tool']
         include:
         - os: 'ubuntu-20.04'
-          ghc: '9.6'
-          cabal: '3.10'
+          ghc: '9.8'
+          cabal: '3.12'
           cabalcache: 'true'
           flags: '-build-tool'
     env:

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         ghc: ['9.6.6', '9.8.2', '9.10.1']
         cabal: ['3.12']
-        os: ['ubuntu-20.04', 'ubuntu-22.04', 'macos-latest', 'macos-14']
+        os: ['ubuntu-20.04', 'ubuntu-22.04', 'macos-14']
         cabalcache: ['true']
         flags: ['+build-tool']
         include:
@@ -71,11 +71,6 @@ jobs:
       shell: bash
       run: z3 -version
    
-    # Install libc6 for cabal-cache on ubuntu-20.04
-    - name: Install libc6 on ubuntu-20.04
-      if: matrix.os == 'ubuntu-20.04'
-      run: sudo apt-get install libc6
-
     # Haskell Setup
     - name: Set permissions for .ghcup (ubuntu)
       if: startsWith(matrix.os, 'ubuntu-')

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-cache-on-bigubuntu:
-    runs-on: 
+    runs-on:
       group: bigrunner
     timeout-minutes: 740
     strategy:
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Nix with caching
-      uses: kadena-io/setup-nix-with-cache/by-root@v3.1
+      uses: kadena-io/setup-nix-with-cache/by-root@v3.2
       with:
         cache_url: s3://nixcache.chainweb.com?region=us-east-1
         signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
@@ -43,7 +43,7 @@ jobs:
 
         echo Build the recursive output
         nix build .#recursive.allDerivations --log-lines 500 --show-trace
-        
+
     - name: Verify pact binary
       run: |
         echo Validating pact version
@@ -89,4 +89,4 @@ jobs:
       run: |
         echo Validating pact version
         nix run pact --version
-        
+

--- a/cabal.project
+++ b/cabal.project
@@ -45,12 +45,13 @@ allow-newer: *:template-haskell
 allow-newer: *:base
 allow-newer: *:ghc-prim
 
--- Patch merged into master (upcoming verison 10.0). We are currently using 9.2
+-- Patch merged into master (upcoming verison 10.0). We are currently using 9.2.
+-- This fork contains additional fixes for using 9.2 with recent compilers. 
 source-repository-package
   type: git
-  tag: 3946a0e94470d7403a855dd60f8e54687ecc2b1d
+  tag: 1f2d042718fcf9a140398bd3dedac77c207cce27
   location: https://github.com/larskuhtz/sbv
-  --sha256: 1msbz6525nmsywpm910jh23siil4qgn3rpsm52m8j6877r7v5zw3
+  --sha256: sha256-Y2ZRU9lkrClYiNc8apwy4uO1TAvJ8JZEPKF73ZuGdlA=
 
 -- Servant is notoriously forcing outdated upper bounds onto its users.
 -- It is usually safe to just ignore those.

--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1707870123,
-        "narHash": "sha256-pOvz6uuPYw3CiPgi63QhNYumoKeyzDh9JOkLDngGWsE=",
+        "lastModified": 1719967069,
+        "narHash": "sha256-QQ+y+vW0TXPFhcMjOTUH+M19DuqE2KoEfp6R9SGCcqM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "75345eba5d4159e6f54cbdc38785d1e0d0e655e0",
+        "rev": "c4a407c5ed49b77ab65247dabd02477153f2292c",
         "type": "github"
       },
       "original": {
@@ -109,14 +109,6 @@
           "hs-nix-infra",
           "empty"
         ],
-        "ghc98X": [
-          "hs-nix-infra",
-          "empty"
-        ],
-        "ghc99": [
-          "hs-nix-infra",
-          "empty"
-        ],
         "hackage": [
           "hs-nix-infra",
           "hackage"
@@ -146,6 +138,8 @@
           "empty"
         ],
         "hls-2.6": "hls-2.6",
+        "hls-2.7": "hls-2.7",
+        "hls-2.8": "hls-2.8",
         "hpc-coveralls": [
           "hs-nix-infra",
           "empty"
@@ -158,7 +152,6 @@
           "hs-nix-infra",
           "empty"
         ],
-        "nix-tools-static": "nix-tools-static",
         "nixpkgs": [
           "hs-nix-infra",
           "haskellNix",
@@ -203,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707876653,
-        "narHash": "sha256-hsj9chw/cy9h8XuxQkxnfFR22Ek8xEm33aON2+TcUaI=",
+        "lastModified": 1719795037,
+        "narHash": "sha256-5xLJg7jOWqXuoYSDbNbF3dw1Rhs0D0SLFl9iTR+cp64=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "d1a608f84c9ed00ceca8571b253e79f67a1ae2d6",
+        "rev": "3234e94cd4eca7d2992a3938fb6200dfb8b86a84",
         "type": "github"
       },
       "original": {
@@ -233,43 +226,62 @@
         "type": "github"
       }
     },
+    "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hs-nix-infra": {
       "inputs": {
         "empty": "empty",
         "flake-compat": "flake-compat",
-        "hackage": "hackage",
+        "hackage": [
+          "hackage"
+        ],
         "haskellNix": "haskellNix",
         "nixpkgs": "nixpkgs",
         "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1708100161,
-        "narHash": "sha256-rWwE59SfmqXcVQL7GXovYvjbDPMsb4e1GgiNH+7tlrM=",
+        "lastModified": 1719864508,
+        "narHash": "sha256-T0nTbLSXYqDpLC8aHPrKtVjWa/dAPizEvP3eoUFAPKA=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "bcbf823a0851b41d64d4f9c87053abc3153c126e",
+        "rev": "211ce215a4befd746212fcd1166a6f10ab02b48e",
         "type": "github"
       },
       "original": {
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "type": "github"
-      }
-    },
-    "nix-tools-static": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1706266250,
-        "narHash": "sha256-9t+GRk3eO9muCtKdNAwBtNBZ5dH1xHcnS17WaQyftwA=",
-        "owner": "input-output-hk",
-        "repo": "haskell-nix-example",
-        "rev": "580cb6db546a7777dad3b9c0fa487a366c045c4e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "nix",
-        "repo": "haskell-nix-example",
         "type": "github"
       }
     },
@@ -324,6 +336,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "hackage": "hackage",
         "hs-nix-infra": "hs-nix-infra"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,18 @@
   description = "Kadena's Pact smart contract language";
 
   inputs = {
-    hs-nix-infra.url = "github:kadena-io/hs-nix-infra";
+    hackage = {
+      url = "github:input-output-hk/hackage.nix";
+      flake = false;
+    };
+    hs-nix-infra = {
+      url = "github:kadena-io/hs-nix-infra";
+      inputs.hackage.follows = "hackage";
+    };
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, hs-nix-infra, flake-utils }:
+  outputs = { self, hs-nix-infra, flake-utils, ... }:
     flake-utils.lib.eachSystem
       [ "x86_64-linux" "x86_64-darwin"
         "aarch64-linux" "aarch64-darwin" ] (system:

--- a/lib/unsafe/src/Data/Foldable/Unsafe.hs
+++ b/lib/unsafe/src/Data/Foldable/Unsafe.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE CPP #-}
+
+#if MIN_VERSION_base(4,20,0)
+{-# OPTIONS_GHC -Wno-x-partial #-}
+#endif
+
+
+-- |
+-- Module: unsafe.Data.Foldable.Unsafe
+-- Copyright: Copyright © 2024 Kadena LLC.
+-- License: MIT
+-- Maintainer: Pact Team
+-- Stability: experimental
+--
+-- This module provides unsafe versions for all functions in "Data.Foldable"
+-- that are either partial or return a 'Maybe' value.
+--
+module Data.Foldable.Unsafe
+(
+-- * Unsafe versions of partial functions
+  unsafeMaximum
+, unsafeMaximumBy
+, unsafeMinimum
+, unsafeMinimumBy
+
+-- * Unsafe versions of functions that return 'Maybe' values
+, unsafeFind
+) where
+
+import Data.Foldable
+
+import GHC.Stack
+
+-- -------------------------------------------------------------------------- --
+-- Unsafe versions of partial functions
+
+unsafeMaximum :: HasCallStack => Foldable t => Ord a => t a -> a
+unsafeMaximum = maximum
+
+unsafeMaximumBy :: HasCallStack => Foldable t => (a -> a -> Ordering) -> t a -> a
+unsafeMaximumBy = maximumBy
+
+unsafeMinimum :: HasCallStack => (Foldable t, Ord a) => t a -> a
+unsafeMinimum = minimum
+
+unsafeMinimumBy :: HasCallStack => Foldable t => (a -> a -> Ordering) -> t a -> a
+unsafeMinimumBy = minimumBy
+
+-- -------------------------------------------------------------------------- --
+-- Unsafe versions of functions that return Maybe
+
+unsafeFind :: HasCallStack => Foldable t => (a -> Bool) -> t a -> a
+unsafeFind a b = case find a b of
+    Nothing -> error "Data.List.Unsafe.unsafeFind: not found"
+    Just x -> x
+

--- a/lib/unsafe/src/Data/List/Unsafe.hs
+++ b/lib/unsafe/src/Data/List/Unsafe.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE CPP #-}
+
+#if MIN_VERSION_base(4,20,0)
+{-# OPTIONS_GHC -Wno-x-partial #-}
+#endif
+
+-- |
+-- Module: Data.List.Unsafe
+-- Copyright: Copyright © 2024 Kadena LLC.
+-- License: MIT
+-- Maintainer: Pact Team
+-- Stability: experimental
+--
+-- This module provides unsafe versions for all functions in "Data.List" that
+-- are either partial or return a 'Maybe' value.
+--
+module Data.List.Unsafe
+(
+-- * Unsafe versions of partial functions
+  unsafeHead
+, unsafeLast
+, unsafeTail
+, unsafeInit
+, unsafeIndex
+, unsafeGenericIndex
+
+-- * Unsafe versions of functions that return 'Maybe' values
+, unsafeUncons
+#if MIN_VERSION_base(4,19,0)
+, unsafeUnsnoc
+#endif
+, unsafeLookup
+, unsafeElemIndex
+, unsafeFindIndex
+, unsafeStripPrefix
+) where
+
+import Data.List
+
+import GHC.Stack
+
+-- -------------------------------------------------------------------------- --
+-- Unsafe versions of partial functions
+
+unsafeHead :: HasCallStack => [a] -> a
+unsafeHead = head
+
+unsafeLast :: HasCallStack => [a] -> a
+unsafeLast = last
+
+unsafeTail :: HasCallStack => [a] -> [a]
+unsafeTail = tail
+
+unsafeInit :: HasCallStack => [a] -> [a]
+unsafeInit = init
+
+unsafeIndex :: HasCallStack => [a] -> Int -> a
+unsafeIndex = (!!)
+
+unsafeGenericIndex :: Integral i => [a] -> i -> a
+unsafeGenericIndex = genericIndex
+
+-- -------------------------------------------------------------------------- --
+-- Unsafe versions of functions that return Maybe
+
+unsafeUncons :: HasCallStack => [a] -> (a, [a])
+unsafeUncons a = case uncons a of
+    Nothing -> error "Data.List.Unsafe.unsafeUncons: empty list"
+    Just x -> x
+
+#if MIN_VERSION_base(4,19,0)
+unsafeUnsnoc :: [a] -> ([a], a)
+unsafeUnsnoc a = case unsnoc a of
+    Nothing -> error "Data.List.Unsafe.unsafeUnsnoc: empty list"
+    Just x -> x
+#endif
+
+unsafeLookup :: HasCallStack => Eq a => a -> [(a,b)] -> b
+unsafeLookup a b = case lookup a b of
+    Nothing -> error "Data.List.Unsafe.unsafeLookup: not found"
+    Just x -> x
+
+unsafeElemIndex :: Eq a => a -> [a] -> Int
+unsafeElemIndex a b = case elemIndex a b of
+    Nothing -> error "Data.List.Unsafe.unsafeElemIndex: not found"
+    Just x -> x
+
+unsafeFindIndex :: (a -> Bool) -> [a] -> Int
+unsafeFindIndex a b = case findIndex a b of
+    Nothing -> error "Data.List.Unsafe.unsafeFindIndex: not found"
+    Just x -> x
+
+unsafeStripPrefix :: Eq a => [a] -> [a] -> [a]
+unsafeStripPrefix a b = case stripPrefix a b of
+    Nothing -> error "Data.List.Unsafe.unsafeStripPrefix: not found"
+    Just x -> x
+

--- a/pact.cabal
+++ b/pact.cabal
@@ -214,6 +214,7 @@ library
   build-depends:
     -- internal
     , pact-prettyprinter
+    , pact:unsafe
 
     -- external
     , Decimal >=0.4.2

--- a/pact.cabal
+++ b/pact.cabal
@@ -1,4 +1,4 @@
-cabal-version:       2.2
+cabal-version:       3.0
 name:                pact
 version:             4.12
 -- ^ 4 digit is prerelease, 3- or 2-digit for prod release
@@ -236,7 +236,7 @@ library
     , mod >=0.1.2
     , mtl >=2.3
     , pact-json >=0.1
-    , pact-time >=0.2
+    , pact-time >=0.3.0.1
     , parsers >=0.12.4
     , poly >=0.5.0
     , primitive >=0.8
@@ -260,7 +260,6 @@ library
     , utf8-string >=1.0.1.1
     , vector >=0.11.0.0
     , vector-algorithms >=0.7
-    , vector-space >=0.10.4
     , wide-word >= 0.1
     , yaml
 

--- a/pact.cabal
+++ b/pact.cabal
@@ -65,6 +65,22 @@ library pact-prettyprinter
     , prettyprinter >= 1.7
 
 -- -------------------------------------------------------------------------- --
+-- Internal: unsafe functions from base
+--
+-- This is to avoid cluttering production code with
+-- `{-# OPTIONS_GHC -Wno-x-partial #-}` pragmas with base >= 4.20
+
+library unsafe
+  visibility: public
+  hs-source-dirs: lib/unsafe/src
+  default-language: Haskell2010
+  exposed-modules:
+    Data.Foldable.Unsafe
+    Data.List.Unsafe
+  build-depends:
+    , base >= 4.5 && < 5
+
+-- -------------------------------------------------------------------------- --
 -- Pact library
 
 library

--- a/pact.cabal
+++ b/pact.cabal
@@ -439,7 +439,6 @@ test-suite hspec
     , attoparsec
     , base
     , base16-bytestring
-    , base64-bytestring
     , binary
     , bound
     , bytestring
@@ -460,7 +459,6 @@ test-suite hspec
     , trifecta
     , unordered-containers
     , vector
-    , wide-word >= 0.1
 
   other-modules:
     Blake2Spec

--- a/src-tool/Pact/Analyze/Feature.hs
+++ b/src-tool/Pact/Analyze/Feature.hs
@@ -12,7 +12,9 @@
 module Pact.Analyze.Feature where
 
 import           Control.Lens           (Prism', preview, prism', review)
+#if !MIN_VERSION_base(4,20,0)
 import           Data.Foldable          (foldl')
+#endif
 import qualified Data.Map               as Map
 import           Data.Map.Strict        (Map)
 import           Data.Set               (Set)

--- a/src-tool/Pact/Analyze/Translate.hs
+++ b/src-tool/Pact/Analyze/Translate.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GADTs                      #-}
@@ -32,8 +33,13 @@ import           Control.Monad.Reader       (MonadReader (local),
                                              ReaderT (runReaderT))
 import           Control.Monad.State.Strict (MonadState, StateT, evalStateT,
                                              modify', runStateT)
+#if MIN_VERSION_base(4,20,0)
+import           Data.Foldable              (for_, foldlM)
+#else
 import           Data.Foldable              (foldl', for_, foldlM)
+#endif
 import           Data.List                  (sort)
+import           Data.List.Unsafe           (unsafeTail)
 import qualified Data.Map                   as Map
 import           Data.Map.Strict            (Map)
 import           Data.Maybe                 (fromMaybe, isNothing)
@@ -754,7 +760,7 @@ translatePact nodes = do
     -- The proper fix is recognizing the nested defpact dyn invoke and replacing it with
     -- the default value of what the invocation would return.
     -- For now, this unblocks the problem.
-    (if null protoSteps then [] else tail $ reverse protoSteps)
+    (if null protoSteps then [] else unsafeTail $ reverse protoSteps)
 
   let steps = zipWith3
         (\(Step exec p e _ _) mCancel mRb -> Step exec p e mCancel mRb)

--- a/src-tool/Pact/Analyze/Types/Shared.hs
+++ b/src-tool/Pact/Analyze/Types/Shared.hs
@@ -35,7 +35,6 @@ import           Control.Lens                 (At (at), Index, Iso, IxValue,
                                                makePrisms, over, (%~), (&),
                                                (<&>))
 import           Data.Aeson                   (FromJSON)
-import           Data.AffineSpace             ((.+^), (.-.))
 import           Data.Coerce                  (Coercible, coerce)
 import           Data.Constraint              (Dict (Dict), withDict)
 import           Data.Data                    (Data, Proxy, Typeable)
@@ -69,6 +68,7 @@ import           Data.Type.Equality           ((:~:) (Refl))
 import           GHC.TypeLits                 (KnownSymbol, SomeSymbol(..), Symbol, symbolVal, someSymbolVal)
 import           Prelude                      hiding (Float)
 
+import           Pact.Time                    ((.-.), (.+^))
 import           Pact.Types.Pretty            hiding (list)
 import qualified Pact.Types.Pretty            as Pretty
 import qualified Pact.Types.Lang              as Pact

--- a/src/Crypto/Hash/PoseidonNative.hs
+++ b/src/Crypto/Hash/PoseidonNative.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Crypto.Hash.PoseidonNative (poseidon) where
 
+#if !MIN_VERSION_base(4,20,0)
 import Data.List(foldl')
+#endif
 import qualified Data.Primitive.Array as Array
 import qualified Data.Primitive.SmallArray as SmallArray
 

--- a/src/Pact/ApiReq.hs
+++ b/src/Pact/ApiReq.hs
@@ -55,6 +55,7 @@ import qualified Data.ByteString.Short as SBS
 import Data.Default (def)
 import Data.Foldable
 import Data.List
+import Data.List.Unsafe
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Set as S
 import qualified Data.Map.Strict as Map
@@ -280,7 +281,7 @@ combineSigDatas sds outputLocal = do
   when (S.size hashes /= 1 || S.size cmds /= 1) $ do
     error "SigData files must contain exactly one unique hash and command.  Aborting..."
   let sigs = foldl1 f $ map _sigDataSigs sds
-  returnCommandIfDone outputLocal $ SigData (head $ S.toList hashes) sigs (Just $ head $ S.toList cmds)
+  returnCommandIfDone outputLocal $ SigData (unsafeHead $ S.toList hashes) sigs (Just $ unsafeHead $ S.toList cmds)
   where
     f accum sigs
       | length accum /= length sigs = error "Sig lists have different lengths"

--- a/src/Pact/Eval.hs
+++ b/src/Pact/Eval.hs
@@ -65,6 +65,7 @@ import Data.Functor.Classes
 import Data.Graph
 import qualified Data.HashMap.Strict as HM
 import Data.IORef
+import Data.List.Unsafe
 import qualified Data.Map.Strict as M
 import Data.Maybe
 import qualified Data.Vector as V
@@ -661,7 +662,7 @@ enforceAcyclic
 enforceAcyclic info cs = forM cs $ \c -> case c of
   AcyclicSCC v -> return v
   CyclicSCC vs -> do
-    let i = if null vs then info else _tInfo $ view _1 $ head vs
+    let i = if null vs then info else _tInfo $ view _1 $ unsafeHead vs
         pl = over (traverse . _3) (SomeDoc . prettyList)
           $ over (traverse . _1) (fmap mkSomeDoc)
           $ vs

--- a/src/Pact/Native/Pairing.hs
+++ b/src/Pact/Native/Pairing.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -55,7 +56,11 @@ import Data.Group(Group(..))
 import Data.Euclidean (Euclidean, GcdDomain)
 import Data.Semiring (Semiring, Ring)
 import Data.Field (Field)
+#if MIN_VERSION_base(4,20,0)
+import Data.Foldable (forM_, traverse_)
+#else
 import Data.Foldable (forM_, foldl', traverse_)
+#endif
 import qualified Data.Vector as G
 import qualified Data.Vector.Mutable as MG
 import qualified Data.Semiring as SR

--- a/src/Pact/Native/Time.hs
+++ b/src/Pact/Native/Time.hs
@@ -23,10 +23,8 @@ module Pact.Native.Time
 import Control.Monad
 import Prelude
 import Data.Decimal
-import Data.AffineSpace
 import Data.Text (Text, pack, unpack)
 import Pact.Time
-
 import Pact.Types.Pretty
 import Pact.Types.Runtime
 import Pact.Native.Internal

--- a/src/Pact/Repl/Lib.hs
+++ b/src/Pact/Repl/Lib.hs
@@ -32,7 +32,9 @@ import Control.Monad.State.Strict (get,put)
 import Data.Aeson (eitherDecode)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Default
+#if !MIN_VERSION_base(4,20,0)
 import Data.Foldable
+#endif
 import Data.IORef
 import qualified Data.Map.Strict as M
 import qualified Data.HashMap.Strict as HM

--- a/src/Pact/Typechecker.hs
+++ b/src/Pact/Typechecker.hs
@@ -44,6 +44,7 @@ import Data.Default
 import Data.Foldable
 import qualified Data.HashMap.Strict as HM
 import Data.List
+import Data.List.Unsafe (unsafeHead)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
@@ -1006,7 +1007,7 @@ toAST (TApp Term.App{..} _) = do
               return app'
             Resume -> do
               app' <- specialBind
-              case head args' of -- 'specialBind' ensures non-empty args
+              case unsafeHead args' of -- 'specialBind' ensures non-empty args
                 (Binding _ _ _ (AstBindSchema sty)) ->
                   setOrAssocYR yrResume sty
                 a -> die'' a "Expected binding"
@@ -1205,7 +1206,7 @@ showFails = do
 
 -- | unsafe lens for using `typecheckBody` with const
 singLens :: Iso' a [a]
-singLens = iso pure head
+singLens = iso pure unsafeHead
 
 -- | Typecheck a top-level production.
 typecheck :: TopLevel Node -> TC (TopLevel Node)


### PR DESCRIPTION
Build system and CI:
* [x] remove redundant dependencies from cabal file
* [x] update cabal CI workflow to use cabal 3.12 and include build with GHC-9.10 

Maintenance of dependencies:
* [x] remove vector-space dependency
* [x] upgrade to pact-time-0.3
* [x] upgrade to sbv-9.2 fork that supports GHC-9.10

Compiler warnings and deprecations:
* [x] add internal "unsafe" library for partial "base" functions. Avoids cluttering production code with `{-# OPTIONS_GHC -fno-warn-x-partial #-}` pragmas with GHC >=9.10.
* [x] Fix compiler warnings with GHC >=9.10 (`foldl'` is now in `Prelude` and uses of `head` and `tail` cause `x-partial` warning)

