### PR TITLE
Pin github actions external workflow

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.0.0
 
     # Non Haskell dependencies
 


### PR DESCRIPTION
Removed description since this simply pins one of the github actions workflow tag/version