### PR TITLE
Fix missing quotes around $usage in release.sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -77,7 +77,7 @@ if [ -z "$ghtoken" ]; then echo "Missing Github auth token"; echo "$usage"; exit
 
 if [ -z "$version" ]; then echo "Missing version"; echo "$usage"; exit 1; fi
 
-if [ ! -d "$brewdir" ]; then echo "Missing/invalid homebrew-pact dir"; echo $usage; exit 1; fi
+if [ ! -d "$brewdir" ]; then echo "Missing/invalid homebrew-pact dir"; echo "$usage"; exit 1; fi
 
 cd $brewdir
 brewdir="$PWD"


### PR DESCRIPTION
**Description:**

This pull request addresses an issue in the `release.sh` script where the `echo $usage` command is not enclosed in quotes:

```bash
if [ ! -d "$brewdir" ]; then echo "Missing/invalid homebrew-pact dir"; echo $usage; exit 1; fi
```

### The Issue:
When `$usage` is expanded without quotes, it can lead to unexpected behavior if the variable contains special characters, spaces, or line breaks. For example:
- Spaces can cause `echo` to break the text into unintended multiple arguments.
- Special characters can trigger unexpected shell behavior, making the output unreliable.

### The Fix:
The corrected line ensures `$usage` is properly quoted to handle any content safely:

```bash
if [ ! -d "$brewdir" ]; then echo "Missing/invalid homebrew-pact dir"; echo "$usage"; exit 1; fi
```

### Importance:
This fix ensures:
1. **Robustness**: The script will behave as expected regardless of the content in `$usage`.
2. **Readability**: Consistent use of quoting for variables in shell scripts improves maintainability and prevents subtle bugs.
3. **Preventive Maintenance**: While `$usage` may currently contain simple text, future updates to the script could inadvertently introduce complex or multi-line content. This fix preemptively avoids potential issues.

PR checklist:

* [x] Test coverage for the proposed changes
* [x] PR description contains example output from repl interaction or a snippet from unit test output
* [x] New builtins have a FV translation
* [x] Documentation has been (manually) updated at https://docs.kadena.io/pact
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/kadena-io/pact/blob/master/CHANGELOG.md)
* [x] In case of  changes to the Pact trace output (`pact -t`), make sure [pact-lsp](https://github.com/kadena-io/pact-lsp) is in sync.

Additionally, please justify why you should or should not do the following:

* [x] Confirm replay/back compat
* [x] Benchmark regressions
* [x] (For Kadena engineers) Run integration-tests against a Chainweb built with this version of Pact
